### PR TITLE
Add cloud credentials requests to manifests

### DIFF
--- a/manifests/0000_30_capi-operator_00_credentials-request.yaml
+++ b/manifests/0000_30_capi-operator_00_credentials-request.yaml
@@ -1,0 +1,99 @@
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: openshift-cluster-api-aws
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+spec:
+  secretRef:
+    name: aws-cloud-credentials
+    namespace: openshift-cluster-api
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: AWSProviderSpec
+    statementEntries:
+    - effect: Allow
+      action:
+      - ec2:CreateTags
+      - ec2:DescribeAvailabilityZones
+      - ec2:DescribeDhcpOptions
+      - ec2:DescribeImages
+      - ec2:DescribeInstances
+      - ec2:DescribeInternetGateways
+      - ec2:DescribeSecurityGroups
+      - ec2:DescribeSubnets
+      - ec2:DescribeVpcs
+      - ec2:RunInstances
+      - ec2:TerminateInstances
+      - elasticloadbalancing:DescribeLoadBalancers
+      - elasticloadbalancing:DescribeTargetGroups
+      - elasticloadbalancing:DescribeTargetHealth
+      - elasticloadbalancing:RegisterInstancesWithLoadBalancer
+      - elasticloadbalancing:RegisterTargets
+      - elasticloadbalancing:DeregisterTargets
+      - iam:PassRole
+      - iam:CreateServiceLinkedRole
+      resource: "*"
+    - effect: Allow
+      action:
+      - kms:Decrypt
+      - kms:Encrypt
+      - kms:GenerateDataKey
+      - kms:GenerateDataKeyWithoutPlainText
+      - kms:DescribeKey
+      resource: '*'
+    - effect: Allow
+      action:
+      - kms:RevokeGrant
+      - kms:CreateGrant
+      - kms:ListGrants
+      resource: '*'
+      policyCondition:
+        "Bool":
+          "kms:GrantIsForAWSResource": true
+---
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: openshift-cluster-api-azure
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+spec:
+  secretRef:
+    name: azure-cloud-credentials
+    namespace: openshift-cluster-api
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: AzureProviderSpec
+    roleBindings:
+    - role: Contributor
+---
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: openshift-cluster-api-gcp
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+spec:
+  secretRef:
+    name: gcp-cloud-credentials
+    namespace: openshift-cluster-api
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: GCPProviderSpec
+    skipServiceCheck: true
+    predefinedRoles:
+    - "roles/compute.instanceAdmin.v1"
+    - "roles/iam.serviceAccountUser"
+    - "roles/compute.loadBalancerAdmin"
+# includes compute.targetPools.* currently used to add masters to LB in DR scenarios.
+# https://cloud.google.com/compute/docs/access/iam#compute.loadBalancerAdmin


### PR DESCRIPTION
Add cloud credentials requests to manifests, for now, it's limited to AWS, GCP and Azure.