### PR TITLE
Extract provider versions from json file in import-assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,5 +29,5 @@ This command does 2 main things:
    b. place provider rbac resources in /manifests
    c. place all other resources in /assets/providers as configmaps (to be consumed by capi-operator)
 
-To update the version of a provider, edit hack/import-assets/providers.go and bump
+To update the version of a provider, edit hack/import-assets/provider-versions.json and bump
 the versions as required.

--- a/hack/import-assets/provider-versions.json
+++ b/hack/import-assets/provider-versions.json
@@ -1,0 +1,8 @@
+{
+  "cluster-api": "v1.0.0",
+  "aws": "v0.7.0",
+  "azure": "v0.5.2",
+  "metal3": "v0.5.2",
+  "gcp": "v0.4.0",
+  "openstack": "v0.4.0"
+}


### PR DESCRIPTION
This PR extract provider versions from file instead hardcoded in import-assets utility. It would be better to manage resources in json file. In addition to that, although it is not being used, providerFilter can be used if import-assets is executed directly by user to filter.