### PR TITLE
Add cluster machine approver manifests

### DIFF
--- a/manifests/0000_90_cluster-api_cluster-machine-approver_01_prometheus.yaml
+++ b/manifests/0000_90_cluster-api_cluster-machine-approver_01_prometheus.yaml
@@ -1,0 +1,106 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-cluster-api
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespace/metrics
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-cluster-api
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: capi-machine-approver
+  name: cluster-machine-approver
+  namespace: openshift-cluster-api
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      interval: 30s
+      port: https
+      scheme: https
+      tlsConfig:
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+        serverName: capi-machine-approver.openshift-cluster-api.svc
+  namespaceSelector:
+    matchNames:
+      - openshift-cluster-api
+  selector:
+    matchLabels:
+      app: capi-machine-approver
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: machineapprover-rules
+  namespace: openshift-cluster-api
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+spec:
+  groups:
+    - name: cluster-capi-machine-approver.rules
+      rules:
+        - alert: MachineApproverMaxPendingCSRsReached
+          expr: |
+             mapi_current_pending_csr > mapi_max_pending_csr
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "max pending CSRs threshold reached."
+            description: |
+              The number of pending CertificateSigningRequests has exceeded the
+              maximum threshold (current number of machine + 100). Check the
+              pending CSRs to determine which machines need approval, also check
+              that the nodelink controller is running in the openshift-machine-api
+              namespace.

--- a/manifests/0000_90_cluster-api_cluster-machine-approver_02_rbac.yaml
+++ b/manifests/0000_90_cluster-api_cluster-machine-approver_02_rbac.yaml
@@ -1,0 +1,227 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: openshift-cluster-api
+  name: capi-machine-approver-sa
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: capi-machine-approver
+  namespace: openshift-cluster-api
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+rules:
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: capi-machine-approver
+  namespace: openshift-cluster-api
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: capi-machine-approver
+subjects:
+- kind: ServiceAccount
+  namespace: openshift-cluster-api
+  name: capi-machine-approver-sa
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: capi-machine-approver
+  namespace: openshift-config-managed
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - csr-controller-ca
+  verbs:
+  - get
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: capi-machine-approver
+  namespace: openshift-config-managed
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: capi-machine-approver
+subjects:
+- kind: ServiceAccount
+  namespace: openshift-cluster-api
+  name: capi-machine-approver-sa
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:openshift:controller:capi-machine-approver
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+rules:
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests/approval
+  verbs:
+  - update
+- apiGroups:
+  - certificates.k8s.io
+  resourceNames:
+  - kubernetes.io/kube-apiserver-client-kubelet
+  - kubernetes.io/kubelet-serving
+  resources:
+  - signers
+  verbs:
+  - approve
+- apiGroups:
+  - machine.openshift.io
+  resources:
+  - machines
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusteroperators
+  verbs:
+  - get
+  - create
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusteroperators/status
+  resourceNames:
+  - capi-machine-approver
+  verbs:
+  - update
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - networks
+  verbs:
+  - get
+- apiGroups:
+  - network.openshift.io
+  resources:
+  - hostsubnets
+  verbs:
+  - get
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machines
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:openshift:controller:capi-machine-approver
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:controller:capi-machine-approver
+subjects:
+- kind: ServiceAccount
+  namespace: openshift-cluster-api
+  name: capi-machine-approver-sa

--- a/manifests/0000_90_cluster-api_cluster-machine-approver_03_kube-rbac-proxy-config.yaml
+++ b/manifests/0000_90_cluster-api_cluster-machine-approver_03_kube-rbac-proxy-config.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-rbac-proxy
+  namespace: openshift-cluster-api
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+data:
+  config-file.yaml: |+
+    authorization:
+      resourceAttributes:
+        apiVersion: v1
+        resource: namespace
+        subresource: metrics
+        namespace: openshift-cluster-api

--- a/manifests/0000_90_cluster-api_cluster-machine-approver_04_metrics-service.yaml
+++ b/manifests/0000_90_cluster-api_cluster-machine-approver_04_metrics-service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: capi-machine-approver
+  namespace: openshift-cluster-api
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+    service.alpha.openshift.io/serving-cert-secret-name: capi-machine-approver-tls
+  labels:
+    app: capi-machine-approver
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: https
+    port: 9192
+    targetPort: https
+  selector:
+    app: capi-machine-approver
+  sessionAffinity: None

--- a/manifests/0000_90_cluster-api_cluster-machine-approver_05_deployment.yaml
+++ b/manifests/0000_90_cluster-api_cluster-machine-approver_05_deployment.yaml
@@ -1,0 +1,112 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capi-machine-approver
+  namespace: openshift-cluster-api
+  labels:
+    app: capi-machine-approver
+    capi-machine-approver: "true"
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: capi-machine-approver
+  template:
+    metadata:
+      name: capi-machine-approver
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      labels:
+        app: capi-machine-approver
+    spec:
+      hostNetwork: true
+      serviceAccountName: capi-machine-approver-sa
+      containers:
+      - args:
+        - --secure-listen-address=0.0.0.0:9192
+        - --upstream=http://127.0.0.1:9191/
+        - --tls-cert-file=/etc/tls/private/tls.crt
+        - --tls-private-key-file=/etc/tls/private/tls.key
+        - --config-file=/etc/kube-rbac-proxy/config-file.yaml
+        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+        - --logtostderr=true
+        - --v=3
+        image: quay.io/openshift/origin-kube-rbac-proxy:4.2.0
+        imagePullPolicy: IfNotPresent
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9192
+          name: https
+          protocol: TCP
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        resources:
+          requests:
+            memory: 20Mi
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/kube-rbac-proxy
+          name: auth-proxy-config
+        - mountPath: /etc/tls/private
+          name: capi-machine-approver-tls
+      - name: capi-machine-approver-controller
+        image: registry.ci.openshift.org/openshift:cluster-machine-approver
+        imagePullPolicy: IfNotPresent
+        command: ["/usr/bin/machine-approver"]
+        args:
+        - "--config=/var/run/configmaps/config/config.yaml"
+        - "-v=2"
+        - "--logtostderr"
+        - "--leader-elect=true"
+        - "--leader-elect-lease-duration=137s"
+        - "--leader-elect-renew-deadline=107s"
+        - "--leader-elect-retry-period=26s"
+        - "--leader-elect-resource-namespace=openshift-cluster-api"
+        - "--apigroup=cluster.x-k8s.io"
+        - "--disable-status-controller=true"
+        resources:
+          requests:
+            memory: 50Mi
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /var/run/configmaps/config
+          name: config
+        env:
+        - name: RELEASE_VERSION
+          value: "0.0.1-snapshot"
+        - name: METRICS_PORT
+          value: "9191"
+        terminationMessagePolicy: FallbackToLogsOnError
+      volumes:
+      - configMap:
+          name: kube-rbac-proxy
+        name: auth-proxy-config
+      - name: capi-machine-approver-tls
+        secret:
+          secretName: capi-machine-approver-tls
+      - name: config
+        configMap:
+          defaultMode: 440
+          name: capi-machine-approver-config
+          optional: true
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
+      tolerations:
+      - key: node-role.kubernetes.io/master  # Just tolerate NoSchedule taint on master node. If there are other conditions like disk-pressure etc, let's not schedule the control-plane pods onto that node.
+        operator: Exists
+        effect: "NoSchedule"
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120 # Evict pods within 2 mins.
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120 # Evict pods within 2 mins.

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -10,3 +10,7 @@ spec:
     from:
       kind: DockerImage
       name: registry.ci.openshift.org/openshift:kube-rbac-proxy
+  - name: cluster-machine-approver
+    from:
+      kind: DockerImage
+      name: registry.ci.openshift.org/openshift:cluster-machine-approver


### PR DESCRIPTION
Add cluster machine approver manifests, all manifests are annotated with `release.openshift.io/feature-gate: "TechPreviewNoUpgrade"` and cluster-machine-approver flags are set to work with CAPI machines.

/hold 
depends on https://github.com/openshift/cluster-version-operator/pull/694