### PR TITLE
Disable operator reconciliation

### DIFF
--- a/pkg/controllers/clusteroperator_controller.go
+++ b/pkg/controllers/clusteroperator_controller.go
@@ -86,7 +86,7 @@ func (r *ClusterOperatorReconciler) Reconcile(ctx context.Context, _ ctrl.Reques
 }
 
 // https://github.com/kubernetes-sigs/cluster-api/blob/main/cmd/clusterctl/client/config/providers_client.go#L36-L47
-func (r *ClusterOperatorReconciler) currentProviderName() string {
+func (r *ClusterOperatorReconciler) currentProviderName() string { //nolint TODO:remove during refatoring
 	switch r.PlatformType {
 	case configv1.LibvirtPlatformType, configv1.NonePlatformType, configv1.OvirtPlatformType, configv1.EquinixMetalPlatformType:
 		return "" // no equivilent in capi
@@ -97,7 +97,7 @@ func (r *ClusterOperatorReconciler) currentProviderName() string {
 	}
 }
 
-func (r *ClusterOperatorReconciler) reconcile(ctx context.Context) (ctrl.Result, error) {
+func (r *ClusterOperatorReconciler) reconcile(ctx context.Context) (ctrl.Result, error) { //nolint TODO:remove during refatoring
 	objs, err := assets.FromDir("capi-operator", r.Scheme)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -203,7 +203,7 @@ func newImageMeta(imageURL string) *operatorv1.ImageMeta {
 	return im
 }
 
-func (r *ClusterOperatorReconciler) customizeDeployment(dep *appsv1.Deployment) error {
+func (r *ClusterOperatorReconciler) customizeDeployment(dep *appsv1.Deployment) error { //nolint TODO:remove during refatoring
 	containerToImageRef := map[string]string{
 		"manager":         "cluster-api:operator",
 		"kube-rbac-proxy": "kube-rbac-proxy",
@@ -229,7 +229,7 @@ func (r *ClusterOperatorReconciler) customizeDeployment(dep *appsv1.Deployment) 
 	return setSpecHashAnnotation(&dep.ObjectMeta, dep.Spec)
 }
 
-func setSpecHashAnnotation(objMeta *metav1.ObjectMeta, spec interface{}) error {
+func setSpecHashAnnotation(objMeta *metav1.ObjectMeta, spec interface{}) error { //nolint TODO:remove during refatoring
 	jsonBytes, err := json.Marshal(spec)
 	if err != nil {
 		return err

--- a/pkg/controllers/operator_status.go
+++ b/pkg/controllers/operator_status.go
@@ -49,7 +49,7 @@ func (r *ClusterOperatorReconciler) setStatusAvailable(ctx context.Context) erro
 // setStatusDegraded sets the Degraded condition to True, with the given reason and
 // message, and sets the upgradeable condition.  It does not modify any existing
 // Available or Progressing conditions.
-func (r *ClusterOperatorReconciler) setStatusDegraded(ctx context.Context, reconcileErr error) error {
+func (r *ClusterOperatorReconciler) setStatusDegraded(ctx context.Context, reconcileErr error) error { //nolint TODO:remove during refatoring
 	co, err := r.getOrCreateClusterOperator(ctx)
 	if err != nil {
 		klog.Errorf("Unable to set cluster operator status degraded: %v", err)
@@ -138,7 +138,7 @@ func newClusterOperatorStatusCondition(conditionType configv1.ClusterStatusCondi
 	}
 }
 
-func printOperandVersions(versions []configv1.OperandVersion) string {
+func printOperandVersions(versions []configv1.OperandVersion) string { //nolint TODO:remove during refatoring
 	versionsOutput := []string{}
 	for _, operand := range versions {
 		versionsOutput = append(versionsOutput, fmt.Sprintf("%s: %s", operand.Name, operand.Version))


### PR DESCRIPTION
This PR temporarily disables operator reconciliation. After CVO started managing all manifests, we need to refactor the operator. With the current implementation, it tries to install AWS provider and some CRDs are missing, this causes tests to fail.