### PR TITLE
Revert "Merge pull request #20 from alexander-demichev/annotations"

### DIFF
--- a/hack/import-assets/providers.go
+++ b/hack/import-assets/providers.go
@@ -153,7 +153,7 @@ func (p *provider) writeRBACComponentsToManifests(objs []unstructured.Unstructur
 		return err
 	}
 
-	fName := strings.ToLower("0000_30_cluster-api_" + p.providerTypeName() + "-" + p.name + "_03_rbac.yaml")
+	fName := strings.ToLower("0000_30_cluster-api-" + p.providerTypeName() + "-" + p.name + "_03_rbac.yaml")
 	return os.WriteFile(path.Join(manifestsPath, fName), ensureNewLine(combined), 0600)
 }
 

--- a/hack/import-assets/rbac_manifests.go
+++ b/hack/import-assets/rbac_manifests.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	assetsDir   = path.Join(projDir, "assets", "capi-operator")
-	outFile     = path.Join(projDir, "manifests", "0000_30_cluster-api_operator_03_rbac_roles.yaml")
+	outFile     = path.Join(projDir, "manifests", "0000_30_cluster-api-operator_03_rbac_roles.yaml")
 	annotations = map[string]string{
 		"exclude.release.openshift.io/internal-openshift-hosted":      "true",
 		"include.release.openshift.io/self-managed-high-availability": "true",

--- a/manifests/0000_30_capi-operator_00_namespace.yaml
+++ b/manifests/0000_30_capi-operator_00_namespace.yaml
@@ -5,7 +5,6 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"    
     openshift.io/node-selector: ""
     workload.openshift.io/allowed: "management"
   labels:

--- a/manifests/0000_30_capi-operator_01_images.configmap.yaml
+++ b/manifests/0000_30_capi-operator_01_images.configmap.yaml
@@ -7,11 +7,10 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
 data:
   images.json: >
     {
-      "cluster-capi-operator": "registry.ci.openshift.org/openshift:cluster-capi-operator",
+      "cluster-capi-operator": "quay.io/openshift/origin-cluster-capi-operator",
       "cluster-api:operator": "quay.io/asalkeld/cluster-api-operator-amd64:dev",
       "bootstrap-kubeadm:manager": "k8s.gcr.io/cluster-api/kubeadm-bootstrap-controller:v0.4.3",
       "controlplane-kubeadm:manager": "k8s.gcr.io/cluster-api/kubeadm-control-plane-controller:v0.4.3",
@@ -20,5 +19,5 @@ data:
       "infrastructure-azure:manager": "us.gcr.io/k8s-artifacts-prod/cluster-api-azure/cluster-api-azure-controller:v0.5.2",
       "infrastructure-metal3:ip-address-manager": "quay.io/metal3-io/ip-address-manager:v0.1.0",
       "infrastructure-metal3:manager": "quay.io/metal3-io/cluster-api-provider-metal3:v0.5.0",
-      "kube-rbac-proxy": "registry.ci.openshift.org/openshift:kube-rbac-proxy"
+      "kube-rbac-proxy": "gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0"
     }

--- a/manifests/0000_30_capi-operator_02_service_account.yaml
+++ b/manifests/0000_30_capi-operator_02_service_account.yaml
@@ -8,4 +8,3 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"

--- a/manifests/0000_30_capi-operator_03_rbac_roles.yaml
+++ b/manifests/0000_30_capi-operator_03_rbac_roles.yaml
@@ -1,37 +1,33 @@
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: ClusterRole
 metadata:
-  name: cluster-capi-operator
   annotations:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
-roleRef:
-  kind: ClusterRole
   name: cluster-capi-operator
-  apiGroup: rbac.authorization.k8s.io
-subjects:
-- kind: ServiceAccount
-  namespace: openshift-cluster-api
-  name: cluster-capi-operator
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: Role
 metadata:
-  name: cluster-capi-operator
-  namespace: openshift-cluster-api
   annotations:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
-roleRef:
-  kind: Role
   name: cluster-capi-operator
-  apiGroup: rbac.authorization.k8s.io
-subjects:
-- kind: ServiceAccount
   namespace: openshift-cluster-api
-  name: cluster-capi-operator
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/manifests/0000_30_capi-operator_04_rbac_bindings.yaml
+++ b/manifests/0000_30_capi-operator_04_rbac_bindings.yaml
@@ -1,35 +1,35 @@
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: ClusterRoleBinding
 metadata:
+  name: cluster-capi-operator
   annotations:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+roleRef:
+  kind: ClusterRole
   name: cluster-capi-operator
-rules:
-- apiGroups:
-  - '*'
-  resources:
-  - '*'
-  verbs:
-  - '*'
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  namespace: openshift-cluster-api
+  name: cluster-capi-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: RoleBinding
 metadata:
+  name: cluster-capi-operator
+  namespace: openshift-cluster-api
   annotations:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+roleRef:
+  kind: Role
   name: cluster-capi-operator
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
   namespace: openshift-cluster-api
-rules:
-- apiGroups:
-  - '*'
-  resources:
-  - '*'
-  verbs:
-  - '*'
+  name: cluster-capi-operator

--- a/manifests/0000_30_capi-operator_11_deployment.yaml
+++ b/manifests/0000_30_capi-operator_11_deployment.yaml
@@ -8,7 +8,6 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   labels:
     k8s-app: cluster-capi-operator
 spec:

--- a/manifests/0000_30_capi-operator_12_clusteroperator.yaml
+++ b/manifests/0000_30_capi-operator_12_clusteroperator.yaml
@@ -6,7 +6,6 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
 spec: {}
 status:
   versions:

--- a/manifests/0000_30_cluster-api-core-cluster-api_03_rbac.yaml
+++ b/manifests/0000_30_cluster-api-core-cluster-api_03_rbac.yaml
@@ -5,7 +5,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   labels:
     cluster.x-k8s.io/provider: cluster-api
     clusterctl.cluster.x-k8s.io: ""
@@ -19,7 +18,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   labels:
     cluster.x-k8s.io/provider: cluster-api
     clusterctl.cluster.x-k8s.io: ""
@@ -56,7 +54,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   labels:
     cluster.x-k8s.io/provider: cluster-api
     clusterctl.cluster.x-k8s.io: ""
@@ -70,7 +67,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   labels:
     cluster.x-k8s.io/aggregate-to-manager: "true"
     cluster.x-k8s.io/provider: cluster-api
@@ -349,7 +345,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: cluster-api
@@ -372,7 +367,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: cluster-api

--- a/manifests/0000_30_cluster-api-infrastructure-aws_03_rbac.yaml
+++ b/manifests/0000_30_cluster-api-infrastructure-aws_03_rbac.yaml
@@ -5,7 +5,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
     clusterctl.cluster.x-k8s.io: ""
@@ -20,7 +19,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
     clusterctl.cluster.x-k8s.io: ""
@@ -73,7 +71,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
@@ -378,7 +375,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
     clusterctl.cluster.x-k8s.io: ""
@@ -404,7 +400,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
@@ -427,7 +422,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
@@ -449,7 +443,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws

--- a/manifests/0000_30_cluster-api-infrastructure-azure_03_rbac.yaml
+++ b/manifests/0000_30_cluster-api-infrastructure-azure_03_rbac.yaml
@@ -5,7 +5,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   labels:
     cluster.x-k8s.io/provider: infrastructure-azure
     clusterctl.cluster.x-k8s.io: ""
@@ -19,7 +18,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   labels:
     cluster.x-k8s.io/provider: infrastructure-azure
     clusterctl.cluster.x-k8s.io: ""
@@ -72,7 +70,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   labels:
     cluster.x-k8s.io/provider: infrastructure-azure
     clusterctl.cluster.x-k8s.io: ""
@@ -115,7 +112,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-azure
@@ -369,7 +365,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   labels:
     cluster.x-k8s.io/provider: infrastructure-azure
     clusterctl.cluster.x-k8s.io: ""
@@ -387,7 +382,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   labels:
     cluster.x-k8s.io/provider: infrastructure-azure
     clusterctl.cluster.x-k8s.io: ""
@@ -413,7 +407,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-azure
@@ -436,7 +429,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-azure
@@ -459,7 +451,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-azure
@@ -481,7 +472,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-azure

--- a/manifests/0000_30_cluster-api-infrastructure-gcp_03_rbac.yaml
+++ b/manifests/0000_30_cluster-api-infrastructure-gcp_03_rbac.yaml
@@ -5,7 +5,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   labels:
     cluster.x-k8s.io/provider: infrastructure-gcp
     clusterctl.cluster.x-k8s.io: ""
@@ -58,7 +57,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-gcp
@@ -150,7 +148,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   labels:
     cluster.x-k8s.io/provider: infrastructure-gcp
     clusterctl.cluster.x-k8s.io: ""
@@ -176,7 +173,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-gcp
@@ -199,7 +195,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-gcp
@@ -221,7 +216,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-gcp

--- a/manifests/0000_30_cluster-api-infrastructure-metal3_03_rbac.yaml
+++ b/manifests/0000_30_cluster-api-infrastructure-metal3_03_rbac.yaml
@@ -5,7 +5,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   labels:
     cluster.x-k8s.io/provider: infrastructure-metal3
     clusterctl.cluster.x-k8s.io: ""
@@ -19,7 +18,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   labels:
     cluster.x-k8s.io/provider: infrastructure-metal3
     clusterctl.cluster.x-k8s.io: ""
@@ -33,7 +31,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   labels:
     cluster.x-k8s.io/provider: infrastructure-metal3
     clusterctl.cluster.x-k8s.io: ""
@@ -86,7 +83,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   labels:
     cluster.x-k8s.io/provider: infrastructure-metal3
     clusterctl.cluster.x-k8s.io: ""
@@ -127,7 +123,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-metal3
@@ -418,7 +413,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-metal3
@@ -530,7 +524,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-metal3
@@ -553,7 +546,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-metal3
@@ -576,7 +568,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-metal3
@@ -598,7 +589,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-metal3

--- a/manifests/0000_30_cluster-api-infrastructure-openstack_03_rbac.yaml
+++ b/manifests/0000_30_cluster-api-infrastructure-openstack_03_rbac.yaml
@@ -5,7 +5,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   labels:
     cluster.x-k8s.io/provider: infrastructure-openstack
     clusterctl.cluster.x-k8s.io: ""
@@ -19,7 +18,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   labels:
     cluster.x-k8s.io/provider: infrastructure-openstack
     clusterctl.cluster.x-k8s.io: ""
@@ -72,7 +70,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-openstack
@@ -164,7 +161,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-openstack
@@ -187,7 +183,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-openstack

--- a/manifests/0000_30_cluster-api-operator_03_rbac_roles.yaml
+++ b/manifests/0000_30_cluster-api-operator_03_rbac_roles.yaml
@@ -5,7 +5,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   labels:
     clusterctl.cluster.x-k8s.io/core: capi-operator
   name: capi-operator-metrics-reader
@@ -22,7 +21,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   labels:
     clusterctl.cluster.x-k8s.io/core: capi-operator
   name: capi-operator-proxy-role
@@ -47,7 +45,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   labels:
     clusterctl.cluster.x-k8s.io/core: capi-operator
   name: capi-operator-manager-rolebinding
@@ -67,7 +64,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   labels:
     clusterctl.cluster.x-k8s.io/core: capi-operator
   name: capi-operator-proxy-rolebinding
@@ -87,7 +83,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   labels:
     clusterctl.cluster.x-k8s.io/core: capi-operator
   name: capi-operator-leader-election-role
@@ -139,7 +134,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   labels:
     clusterctl.cluster.x-k8s.io/core: capi-operator
   name: capi-operator-leader-election-rolebinding
@@ -160,7 +154,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
   creationTimestamp: null
   labels:
     clusterctl.cluster.x-k8s.io/core: capi-operator

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -10,3 +10,4 @@ spec:
     from:
       kind: DockerImage
       name: registry.ci.openshift.org/openshift:kube-rbac-proxy
+


### PR DESCRIPTION
This reverts commit 3d1c8939f88b4cbbf0d6f7abf638dc6f2f7a682f, reversing
changes made to d4e3c4fcbbb7bcf216d2a6b2269a3bc109a1ae8f.

The original pr in #20 looks to have broken payload delivery for the org, so per policy we need to revert as quickly as possible. Ideally you can then revert the revert, and layer in the fixed commits. However in this case the fix might be to the tests in the origin repo.

You can see whats taking down payloads here: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.10-e2e-aws-ovn-upgrade/1470831487283630080

```
fail [github.com/openshift/origin/test/extended/operators/operators.go:151]: unexpected operator status versions cluster-api:
[]v1.OperandVersion{v1.OperandVersion{Name:"operator", Version:"4.10.0-0.ci-2021-12-14-120025"}}
Expected
    <string>: 4.10.0-0.ci-2021-12-14-120025
to equal
    <string>: 4.10.0-0.ci-2021-12-14-185120
```

Essentially we have tests that assert all operators hanging on the ClusterVersion must reach the correct upgrade level, and I suspect that annotation you added is to explicitly not do that, so presumably the test needs an update.

I notice you don't have any upgrade e2e jobs on this repo so that is likely how it slipped in. You may not want upgrade support so that is reasonable, but it might be good to add one just to catch this kind of thing as you are part of the payload, and that does tie you into upgrades even if your desired behavior is a little different.
