### PR TITLE
Bug 2037061: Add service account names to aws and gcp credentials request manifest

### DIFF
--- a/manifests/0000_30_capi-operator_00_credentials-request.yaml
+++ b/manifests/0000_30_capi-operator_00_credentials-request.yaml
@@ -8,6 +8,8 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
 spec:
+  serviceAccountNames:
+    - cluster-capi-operator
   secretRef:
     name: aws-cloud-credentials
     namespace: openshift-cluster-api
@@ -84,6 +86,8 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
 spec:
+  serviceAccountNames:
+    - cluster-capi-operator
   secretRef:
     name: gcp-cloud-credentials
     namespace: openshift-cluster-api


### PR DESCRIPTION
 For enabling short-lived credentials in aws and gcp clusters using workload
 identity, we need ccoctl tool to know the kubernetes service account
 names from the credentials request manifest so that it can create
 aws and gcp service accounts that can be impersonated only by specific
 kubernetes service accounts.

ref:
https://github.com/openshift/machine-api-operator/commit/1f3a083fe50c0e80106ca336878725f142173aba