### PR TITLE
Set a release branch for manifests

### DIFF
--- a/cluster-api-operator.yaml
+++ b/cluster-api-operator.yaml
@@ -1,1 +1,1 @@
-branch: "main"
+branch: release-4.11

--- a/manifests/0000_30_cluster-api_capi-operator_02_providers.configmap.yaml
+++ b/manifests/0000_30_cluster-api_capi-operator_02_providers.configmap.yaml
@@ -3,11 +3,11 @@ data:
   providers-list.yaml: |
     - name: cluster-api
       type: CoreProvider
-      branch: master
+      branch: release-4.11
       version: v1.1.2
     - name: aws
       type: InfrastructureProvider
-      branch: master
+      branch: release-4.11
       version: v1.3.0
     # - name: "azure"
     #   type: "InfrastructureProvider"

--- a/providers-list.yaml
+++ b/providers-list.yaml
@@ -1,10 +1,10 @@
 - name: cluster-api
   type: CoreProvider
-  branch: master
+  branch: release-4.11
   version: v1.1.2
 - name: aws
   type: InfrastructureProvider
-  branch: master
+  branch: release-4.11
   version: v1.3.0
 # - name: "azure"
 #   type: "InfrastructureProvider"


### PR DESCRIPTION
Set a release branch for manifests, this should help with backports later and we can always see where manifests are coming from.