### PR TITLE
Add network interfaces permissions for aws

### DIFF
--- a/manifests/0000_30_cluster-api_00_credentials-request.yaml
+++ b/manifests/0000_30_cluster-api_00_credentials-request.yaml
@@ -28,6 +28,9 @@ spec:
       - ec2:DescribeSecurityGroups
       - ec2:DescribeSubnets
       - ec2:DescribeVpcs
+      - ec2:DescribeNetworkInterfaces
+      - ec2:DescribeNetworkInterfaceAttribute
+      - ec2:ModifyNetworkInterfaceAttribute
       - ec2:RunInstances
       - ec2:TerminateInstances
       - elasticloadbalancing:DescribeLoadBalancers


### PR DESCRIPTION
CAPA attaches security groups to network interfaces after instance creation, this requires new permissions. In MAPI we specify security groups on instance creation that's we don't have these permissions for MAPI.
