### PR TITLE
Add kubeconfig controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/onsi/gomega v1.18.1
 	github.com/openshift/api v0.0.0-20220222102030-354aa98a475c
 	github.com/openshift/library-go v0.0.0-20220221165938-535fc9bdb13b
+	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.5
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.23.0
@@ -44,7 +45,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.12.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect

--- a/pkg/controllers/cluster/aws_test.go
+++ b/pkg/controllers/cluster/aws_test.go
@@ -3,7 +3,6 @@ package cluster
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	awsv1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -12,6 +11,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-capi-operator/pkg/controllers"
 	"github.com/openshift/cluster-capi-operator/pkg/operatorstatus"
+	"github.com/openshift/cluster-capi-operator/pkg/test"
 )
 
 var _ = Describe("Reconcile AWS cluster", func() {
@@ -51,10 +51,7 @@ var _ = Describe("Reconcile AWS cluster", func() {
 		Expect(awsCluster.Spec.Region).To(Equal(awsPlatformStatus.Region))
 		Expect(awsCluster.Status.Ready).To(BeTrue())
 
-		Expect(cl.Delete(ctx, awsCluster)).To(Succeed())
-		Eventually(func() bool {
-			return apierrors.IsNotFound(cl.Get(ctx, client.ObjectKeyFromObject(awsCluster.DeepCopy()), &awsv1.AWSCluster{}))
-		}, timeout).Should(BeTrue())
+		Expect(test.CleanupAndWait(ctx, cl, awsCluster)).To(Succeed())
 	})
 
 	It("should create a cluster with expected spec and status", func() {

--- a/pkg/controllers/cluster/cluster_test.go
+++ b/pkg/controllers/cluster/cluster_test.go
@@ -3,13 +3,13 @@ package cluster
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/cluster-capi-operator/pkg/controllers"
 	"github.com/openshift/cluster-capi-operator/pkg/operatorstatus"
+	"github.com/openshift/cluster-capi-operator/pkg/test"
 )
 
 var _ = Describe("Reconcile CAPI cluster", func() {
@@ -45,10 +45,7 @@ var _ = Describe("Reconcile CAPI cluster", func() {
 		Expect(cluster.Spec.InfrastructureRef.Name).To(Equal(r.clusterName))
 		Expect(cluster.Spec.InfrastructureRef.Namespace).To(Equal(controllers.DefaultManagedNamespace))
 
-		Expect(cl.Delete(ctx, cluster)).To(Succeed())
-		Eventually(func() bool {
-			return apierrors.IsNotFound(cl.Get(ctx, client.ObjectKeyFromObject(cluster.DeepCopy()), &clusterv1.Cluster{}))
-		}, timeout).Should(BeTrue())
+		Expect(test.CleanupAndWait(ctx, cl, cluster)).To(Succeed())
 	})
 
 	It("should create a cluster with expected spec and status", func() {

--- a/pkg/controllers/cluster/suite_test.go
+++ b/pkg/controllers/cluster/suite_test.go
@@ -3,7 +3,6 @@ package cluster
 import (
 	"context"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -23,7 +22,6 @@ var (
 	testEnv *envtest.Environment
 	cfg     *rest.Config
 	cl      client.Client
-	timeout = time.Second * 10
 	ctx     = context.Background()
 )
 

--- a/pkg/controllers/clusteroperator/clusteroperator_controller.go
+++ b/pkg/controllers/clusteroperator/clusteroperator_controller.go
@@ -5,10 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	configv1 "github.com/openshift/api/config/v1"
-	"github.com/openshift/cluster-capi-operator/assets"
-	"github.com/openshift/cluster-capi-operator/pkg/controllers"
-	"github.com/openshift/cluster-capi-operator/pkg/operatorstatus"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -18,6 +14,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-capi-operator/assets"
+	"github.com/openshift/cluster-capi-operator/pkg/controllers"
+	"github.com/openshift/cluster-capi-operator/pkg/operatorstatus"
 )
 
 // ClusterOperatorReconciler reconciles a ClusterOperator object

--- a/pkg/controllers/kubeconfig/generate.go
+++ b/pkg/controllers/kubeconfig/generate.go
@@ -1,0 +1,59 @@
+package kubeconfig
+
+import (
+	"errors"
+
+	"k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/openshift/cluster-capi-operator/pkg/controllers"
+)
+
+type kubeconfigOptions struct {
+	token            []byte
+	caCert           []byte
+	apiServerEnpoint string
+	clusterName      string
+}
+
+func generateKubeconfig(options kubeconfigOptions) (*api.Config, error) {
+	if len(options.token) == 0 {
+		return nil, errors.New("token can't be empty")
+	}
+
+	if len(options.caCert) == 0 {
+		return nil, errors.New("ca cert can't be empty")
+	}
+
+	if options.apiServerEnpoint == "" {
+		return nil, errors.New("api server endpoint can't be empty")
+	}
+
+	if options.clusterName == "" {
+		return nil, errors.New("cluster name can't be empty")
+	}
+
+	userName := "cluster-capi-operator"
+	kubeconfig := &api.Config{
+		Clusters: map[string]*api.Cluster{
+			options.clusterName: {
+				Server:                   options.apiServerEnpoint,
+				CertificateAuthorityData: options.caCert,
+			},
+		},
+		Contexts: map[string]*api.Context{
+			options.clusterName: {
+				Cluster:   options.clusterName,
+				AuthInfo:  userName,
+				Namespace: controllers.DefaultManagedNamespace,
+			},
+		},
+		AuthInfos: map[string]*api.AuthInfo{
+			userName: {
+				Token: string(options.token),
+			},
+		},
+		CurrentContext: options.clusterName,
+	}
+
+	return kubeconfig, nil
+}

--- a/pkg/controllers/kubeconfig/generate_test.go
+++ b/pkg/controllers/kubeconfig/generate_test.go
@@ -1,0 +1,68 @@
+package kubeconfig
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/cluster-capi-operator/pkg/controllers"
+)
+
+var _ = Describe("Generate kubeconfig", func() {
+	var options *kubeconfigOptions
+	testBase64Text := "dGVzdA=="
+
+	BeforeEach(func() {
+		options = &kubeconfigOptions{
+			token:            []byte(testBase64Text),
+			caCert:           []byte(testBase64Text),
+			apiServerEnpoint: "https://example.com",
+			clusterName:      "test",
+		}
+	})
+
+	It("should generate kubeconfig", func() {
+		kubeconfig, err := generateKubeconfig(*options)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kubeconfig).NotTo(BeNil())
+
+		Expect(kubeconfig.Clusters).To(HaveKey(options.clusterName))
+		Expect(kubeconfig.Clusters[options.clusterName].Server).To(Equal(options.apiServerEnpoint))
+		Expect(kubeconfig.Clusters[options.clusterName].CertificateAuthorityData).To(Equal(options.caCert))
+
+		Expect(kubeconfig.Contexts).To(HaveKey(options.clusterName))
+		Expect(kubeconfig.Contexts[options.clusterName].Cluster).To(Equal(options.clusterName))
+		Expect(kubeconfig.Contexts[options.clusterName].AuthInfo).To(Equal("cluster-capi-operator"))
+		Expect(kubeconfig.Contexts[options.clusterName].Namespace).To(Equal(controllers.DefaultManagedNamespace))
+
+		Expect(kubeconfig.AuthInfos).To(HaveKey("cluster-capi-operator"))
+		Expect(kubeconfig.AuthInfos["cluster-capi-operator"].Token).To(Equal(testBase64Text))
+	})
+
+	It("should fail with empty token", func() {
+		options.token = nil
+		kubeconfig, err := generateKubeconfig(*options)
+		Expect(err).To((HaveOccurred()))
+		Expect(kubeconfig).To(BeNil())
+	})
+
+	It("should fail with empty ca cert", func() {
+		options.caCert = nil
+		kubeconfig, err := generateKubeconfig(*options)
+		Expect(err).To((HaveOccurred()))
+		Expect(kubeconfig).To(BeNil())
+	})
+
+	It("should fail with empty api server endpoint", func() {
+		options.apiServerEnpoint = ""
+		kubeconfig, err := generateKubeconfig(*options)
+		Expect(err).To((HaveOccurred()))
+		Expect(kubeconfig).To(BeNil())
+	})
+
+	It("should fail with empty cluster name", func() {
+		options.clusterName = ""
+		kubeconfig, err := generateKubeconfig(*options)
+		Expect(err).To((HaveOccurred()))
+		Expect(kubeconfig).To(BeNil())
+	})
+})

--- a/pkg/controllers/kubeconfig/kubeconfig.go
+++ b/pkg/controllers/kubeconfig/kubeconfig.go
@@ -1,0 +1,163 @@
+package kubeconfig
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-capi-operator/pkg/controllers"
+	"github.com/openshift/cluster-capi-operator/pkg/operatorstatus"
+)
+
+const (
+	serviceAccountName = "cluster-capi-operator"
+)
+
+// ClusterReconciler reconciles a ClusterOperator object
+type KubeconfigReconciler struct {
+	operatorstatus.ClusterOperatorStatusClient
+	Scheme             *runtime.Scheme
+	RestCfg            *rest.Config
+	SupportedPlatforms map[string]bool
+	clusterName        string
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *KubeconfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&clusterv1.Cluster{}).
+		Complete(r)
+}
+
+func (r *KubeconfigReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx).WithName("KubeconfigController")
+
+	infra := &configv1.Infrastructure{}
+	if err := r.Get(ctx, client.ObjectKey{Name: controllers.InfrastructureResourceName}, infra); err != nil {
+		log.Error(err, "Unable to retrive Infrastructure object")
+		if err := r.SetStatusDegraded(ctx, err); err != nil {
+			return ctrl.Result{}, fmt.Errorf("error syncing ClusterOperatorStatus: %v", err)
+		}
+		return ctrl.Result{}, err
+	}
+
+	if infra.Status.PlatformStatus == nil {
+		log.Info("No platform status exists in infrastructure object. Skipping kubeconfig reconciliation...")
+		if err := r.SetStatusAvailable(ctx); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
+
+	r.clusterName = infra.Status.InfrastructureName
+
+	// If the platform type is not supported, we should skip cluster reconciliation.
+	if _, ok := r.SupportedPlatforms[strings.ToLower(string(infra.Status.PlatformStatus.Type))]; !ok {
+		log.Info("Platform type is not supported. Skipping kubeconfig reconciliation...", "platformType", infra.Status.PlatformStatus.Type)
+		if err := r.SetStatusAvailable(ctx); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
+
+	log.Info("Reconciling kubeconfig secret")
+	if err := r.reconcileKubeconfig(ctx); err != nil {
+		log.Error(err, "Error reconciling kubeconfig")
+		if err := r.SetStatusDegraded(ctx, err); err != nil {
+			return ctrl.Result{}, fmt.Errorf("error syncing ClusterOperatorStatus: %v", err)
+		}
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, r.SetStatusAvailable(ctx)
+}
+
+func (r *KubeconfigReconciler) reconcileKubeconfig(ctx context.Context) error {
+	// Get service account for cluster-capi-operator
+	serviceAccount := &corev1.ServiceAccount{}
+	saKey := client.ObjectKey{
+		Name:      serviceAccountName,
+		Namespace: controllers.DefaultManagedNamespace,
+	}
+	if err := r.Get(ctx, saKey, serviceAccount); err != nil {
+		return fmt.Errorf("error retrieving ServiceAccount %s: %v", serviceAccountName, err)
+	}
+
+	// Get secret that contains token and ca data
+	var tokenSecretRef *corev1.ObjectReference
+	prefix := fmt.Sprintf("%s-token", serviceAccountName)
+	for i, secretRef := range serviceAccount.Secrets {
+		if strings.HasPrefix(secretRef.Name, prefix) {
+			tokenSecretRef = &serviceAccount.Secrets[i]
+		}
+	}
+
+	if tokenSecretRef == nil {
+		return fmt.Errorf("unable to find token secret for service account %s", serviceAccountName)
+	}
+
+	// Get the token secret
+	tokenSecret := &corev1.Secret{}
+	tokenSecretKey := client.ObjectKey{
+		Name:      tokenSecretRef.Name,
+		Namespace: controllers.DefaultManagedNamespace,
+	}
+	if err := r.Get(ctx, tokenSecretKey, tokenSecret); err != nil {
+		return fmt.Errorf("unable to retrieve Secret object: %v", err)
+	}
+
+	// Generate kubeconfig
+	kubeconfig, err := generateKubeconfig(kubeconfigOptions{
+		token:            tokenSecret.Data["token"],
+		caCert:           tokenSecret.Data["ca.crt"],
+		apiServerEnpoint: r.RestCfg.Host,
+		clusterName:      r.clusterName,
+	})
+
+	if err != nil {
+		return fmt.Errorf("error generating kubeconfig: %v", err)
+	}
+
+	// Create a secret with generated kubeconfig
+	out, err := clientcmd.Write(*kubeconfig)
+	if err != nil {
+		return fmt.Errorf("error writing kubeconfig: %v", err)
+	}
+
+	kubeconfigSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-kubeconfig", r.clusterName),
+			Namespace: controllers.DefaultManagedNamespace,
+			Labels: map[string]string{
+				clusterv1.ClusterLabelName: r.clusterName,
+			},
+		},
+		Data: map[string][]byte{
+			"value": out,
+		},
+		Type: clusterv1.ClusterSecretType,
+	}
+
+	kubeconfigSecretCopy := kubeconfigSecret.DeepCopy()
+	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, kubeconfigSecret, func() error {
+		kubeconfigSecret.ObjectMeta = kubeconfigSecretCopy.ObjectMeta
+		kubeconfigSecret.Data = kubeconfigSecretCopy.Data
+		kubeconfigSecret.Type = kubeconfigSecretCopy.Type
+		return nil
+	}); err != nil {
+		return fmt.Errorf("error reconciling kubeconfig secret: %v", err)
+	}
+
+	return nil
+}

--- a/pkg/controllers/kubeconfig/kubeconfig_test.go
+++ b/pkg/controllers/kubeconfig/kubeconfig_test.go
@@ -1,0 +1,111 @@
+package kubeconfig
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/cluster-capi-operator/pkg/controllers"
+	"github.com/openshift/cluster-capi-operator/pkg/operatorstatus"
+	"github.com/openshift/cluster-capi-operator/pkg/test"
+)
+
+var _ = Describe("Reconcile kubeconfig secret", func() {
+	Context("create or update kubeconfig secret", func() {
+		var r *KubeconfigReconciler
+		var serviceAccount *corev1.ServiceAccount
+		var serviceAccountSecret *corev1.Secret
+
+		secretName := fmt.Sprintf("%s-token", serviceAccountName)
+
+		BeforeEach(func() {
+			r = &KubeconfigReconciler{
+				ClusterOperatorStatusClient: operatorstatus.ClusterOperatorStatusClient{
+					Client: cl,
+				},
+				clusterName: "test-cluster",
+				RestCfg:     cfg,
+			}
+
+			serviceAccount = &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceAccountName,
+					Namespace: controllers.DefaultManagedNamespace,
+				},
+				Secrets: []corev1.ObjectReference{
+					{
+						Name: secretName,
+					},
+				},
+			}
+
+			serviceAccountSecret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: controllers.DefaultManagedNamespace,
+				},
+				Data: map[string][]byte{
+					"token":  []byte("dGVzdA=="),
+					"ca.crt": []byte("dGVzdA=="),
+				},
+			}
+
+			Expect(cl.Create(ctx, serviceAccount)).To(Succeed())
+			Expect(cl.Create(ctx, serviceAccountSecret)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			kubeconfigSecret := &corev1.Secret{}
+			Expect(cl.Get(ctx, client.ObjectKey{
+				Name:      fmt.Sprintf("%s-kubeconfig", r.clusterName),
+				Namespace: controllers.DefaultManagedNamespace,
+			}, kubeconfigSecret)).To(Succeed())
+			Expect(kubeconfigSecret.Data).To(HaveKey("value")) // kubeconfig content is tested separately
+
+			Expect(test.CleanupAndWait(ctx, cl, serviceAccount, serviceAccountSecret, kubeconfigSecret)).To(Succeed())
+		})
+
+		It("should create a kubeconfig secret when it doesn't exist", func() {
+			Expect(r.reconcileKubeconfig(ctx)).To(Succeed())
+		})
+
+		It("should reconcile existing kubeconfig secret when it doesn't exist", func() {
+			Expect(r.reconcileKubeconfig(ctx)).To(Succeed())
+			Expect(r.reconcileKubeconfig(ctx)).To(Succeed())
+		})
+	})
+
+	Context("catch possible errors", func() {
+		var r *KubeconfigReconciler
+
+		BeforeEach(func() {
+			r = &KubeconfigReconciler{
+				ClusterOperatorStatusClient: operatorstatus.ClusterOperatorStatusClient{
+					Client: cl,
+				},
+				clusterName: "test-cluster",
+				RestCfg:     cfg,
+			}
+		})
+
+		It("error when service account is missing", func() {
+			Expect(r.reconcileKubeconfig(ctx)).To(MatchError(ContainSubstring("error retrieving ServiceAccount")))
+		})
+
+		It("error when token secret reference is missing", func() {
+			serviceAccount := &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceAccountName,
+					Namespace: controllers.DefaultManagedNamespace,
+				},
+			}
+			Expect(cl.Create(ctx, serviceAccount)).To(Succeed())
+			Expect(r.reconcileKubeconfig(ctx)).To(MatchError(ContainSubstring("unable to find token secret for service accoun")))
+			Expect(test.CleanupAndWait(ctx, cl, serviceAccount)).To(Succeed())
+		})
+	})
+})

--- a/pkg/controllers/kubeconfig/suite_test.go
+++ b/pkg/controllers/kubeconfig/suite_test.go
@@ -1,0 +1,55 @@
+package kubeconfig
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2/klogr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/openshift/cluster-capi-operator/pkg/controllers"
+	"github.com/openshift/cluster-capi-operator/pkg/test"
+)
+
+var (
+	testEnv *envtest.Environment
+	cfg     *rest.Config
+	cl      client.Client
+	ctx     = context.Background()
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Kubeconfig Controller Suite",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(klogr.New())
+
+	By("bootstrapping test environment")
+	var err error
+	testEnv = &envtest.Environment{}
+	cfg, cl, err = test.StartEnvTest(testEnv)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+	Expect(cl).NotTo(BeNil())
+
+	managedNamespace := &corev1.Namespace{}
+	managedNamespace.SetName(controllers.DefaultManagedNamespace)
+	Expect(cl.Create(context.Background(), managedNamespace)).To(Succeed())
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	Expect(test.StopEnvTest(testEnv)).To(Succeed())
+})

--- a/pkg/controllers/secretsync/secret_sync_controller.go
+++ b/pkg/controllers/secretsync/secret_sync_controller.go
@@ -39,14 +39,14 @@ type UserDataSecretController struct {
 func (r *UserDataSecretController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx).WithName("SecretSyncController")
 
-	log.Info("emitted event, syncing user data secret", "request", req)
+	log.Info("reconciling worker user data secret")
 
 	defaultSourceSecretObjectKey := client.ObjectKey{
 		Name: managedUserDataSecretName, Namespace: SecretSourceNamespace,
 	}
 	sourceSecret := &corev1.Secret{}
 	if err := r.Get(ctx, defaultSourceSecretObjectKey, sourceSecret); err != nil {
-		log.Error(err, "unable to get secret for sync")
+		log.Error(err, "unable to get source secret for sync")
 		if err := r.setDegradedCondition(ctx); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to set conditions for secret sync controller: %v", err)
 		}

--- a/pkg/test/cleanup.go
+++ b/pkg/test/cleanup.go
@@ -1,0 +1,67 @@
+package test
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	cacheSyncBackoff = wait.Backoff{
+		Duration: 100 * time.Millisecond,
+		Factor:   1.5,
+		Steps:    8,
+		Jitter:   0.4,
+	}
+)
+
+// CleanupAndWait deletes all the given objects and waits for the cache to be updated accordingly.
+func CleanupAndWait(ctx context.Context, cl client.Client, objs ...client.Object) error {
+	if err := cleanup(ctx, cl, objs...); err != nil {
+		return err
+	}
+
+	// Makes sure the cache is updated with the deleted object
+	errs := []error{}
+	for _, o := range objs {
+		// Ignoring namespaces because in testenv the namespace cleaner is not running.
+		if o.GetObjectKind().GroupVersionKind().GroupKind() == corev1.SchemeGroupVersion.WithKind("Namespace").GroupKind() {
+			continue
+		}
+
+		oCopy := o.DeepCopyObject().(client.Object)
+		key := client.ObjectKeyFromObject(o)
+		err := wait.ExponentialBackoff(
+			cacheSyncBackoff,
+			func() (done bool, err error) {
+				if err := cl.Get(ctx, key, oCopy); err != nil {
+					if apierrors.IsNotFound(err) {
+						return true, nil
+					}
+					return false, err
+				}
+				return false, nil
+			})
+		errs = append(errs, errors.Wrapf(err, "key %s, %s is not being deleted from the testenv client cache", o.GetObjectKind().GroupVersionKind().String(), key))
+	}
+	return kerrors.NewAggregate(errs)
+}
+
+// cleanup deletes all the given objects.
+func cleanup(ctx context.Context, cl client.Client, objs ...client.Object) error {
+	errs := []error{}
+	for _, o := range objs {
+		err := cl.Delete(ctx, o)
+		if apierrors.IsNotFound(err) {
+			continue
+		}
+		errs = append(errs, err)
+	}
+	return kerrors.NewAggregate(errs)
+}


### PR DESCRIPTION
Add controller that creates a kubeconfig from operators service account. This kubeconfig is tied to cluster object will be used by CAPI to link nodes and machines.