### PR TITLE
Fix some CI issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ TOOLS_BIN_DIR := $(TOOLS_DIR)/bin
 BIN_DIR := bin
 GOLANGCI_LINT = $(PROJECT_DIR)/$(TOOLS_BIN_DIR)/golangci-lint
 KUSTOMIZE = $(PROJECT_DIR)/$(TOOLS_BIN_DIR)/kustomize
+GOLANGCI_LINT_VERSION  = v1.44.1
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.23
@@ -40,20 +41,22 @@ run: verify
 
 # Run go fmt against code
 .PHONY: fmt
-fmt: $(GOLANGCI_LINT)
+fmt: golangci-lint
 	( GOLANGCI_LINT_CACHE=$(PROJECT_DIR)/.cache $(GOLANGCI_LINT) run --fix )
 
 # Run go vet against code
 .PHONY: vet
 vet: lint
 
-.PHONY: lint
-lint: $(GOLANGCI_LINT)
+.PHONY: golangci-lint lint
+lint: golangci-lint
 	( GOLANGCI_LINT_CACHE=$(PROJECT_DIR)/.cache $(GOLANGCI_LINT) run )
 
 # Download golangci-lint locally if necessary
-$(GOLANGCI_LINT): $(TOOLS_DIR)/go.mod # Build golangci-lint from tools folder.
-	cd $(TOOLS_DIR); go build -tags=tools -mod=readonly -o $(BIN_DIR)/golangci-lint github.com/golangci/golangci-lint/cmd/golangci-lint
+.PHONY: golangci-lint
+GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
+golangci-lint: # Download golangci-lint locally if necessary
+	GOBIN=$(PROJECT_DIR)/bin go install -mod=readonly github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 .PHONY: envtest
 ENVTEST = $(shell pwd)/bin/setup-envtest


### PR DESCRIPTION
This PR contains two fixes for Cluster CAPI operator CI:

1. It bumps envtest version.
2. It starts using `go install` to fetch testing binaries.