### PR TITLE
Bug 2084545: Create cluster-capi-operator-secret in right namespace

### DIFF
--- a/manifests/0000_30_cluster-api_capi-operator_02_service_account.yaml
+++ b/manifests/0000_30_cluster-api_capi-operator_02_service_account.yaml
@@ -14,6 +14,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cluster-capi-operator-secret
+  namespace: openshift-cluster-api
   annotations:
     kubernetes.io/service-account.name: cluster-capi-operator
 type: kubernetes.io/service-account-token


### PR DESCRIPTION
The secret should be created in `openshift-cluster-api` namespace.