### PR TITLE
Bug 2084545: Add missing annotations for cluster-capi-operator-secret

### DIFF
--- a/manifests/0000_30_cluster-api_capi-operator_02_service_account.yaml
+++ b/manifests/0000_30_cluster-api_capi-operator_02_service_account.yaml
@@ -17,4 +17,8 @@ metadata:
   namespace: openshift-cluster-api
   annotations:
     kubernetes.io/service-account.name: cluster-capi-operator
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
 type: kubernetes.io/service-account-token


### PR DESCRIPTION
Currently CVO doesn't create the secret, because it doesn't contain required annotations. This PR adds them.