### PR TITLE
Add option to choose a provider to update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ ginkgo: # Download envtest-setup locally if necessary.
 
 .PHONY: assets
 assets:
-	./hack/assets.sh
+	./hack/assets.sh $(PROVIDER)
 
 # Run go mod
 .PHONY: vendor

--- a/hack/assets.sh
+++ b/hack/assets.sh
@@ -7,4 +7,4 @@ REPO_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 mkdir -p $REPO_ROOT/assets/core-capi
 mkdir -p $REPO_ROOT/assets/infrastructure-providers
-cd $REPO_ROOT/hack/assets; go run .; cd -
+cd $REPO_ROOT/hack/assets; go run . $1; cd -

--- a/hack/assets/main.go
+++ b/hack/assets/main.go
@@ -33,12 +33,25 @@ func init() {
 }
 
 func main() {
-	if err := importCAPIOperator(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+	providerName := getProviderFromArgs()
+	if providerName == "" || providerName == "operator" {
+		if err := importCAPIOperator(); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
 	}
-	if err := importProviders(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+
+	if providerName != "operator" {
+		if err := importProviders(providerName); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
 	}
+}
+
+func getProviderFromArgs() string {
+	if len(os.Args) == 2 {
+		return os.Args[1]
+	}
+	return ""
 }


### PR DESCRIPTION
Currently when we run `make assets`  all providers get updated. With a growing provider list, it takes a long time. This PR adds an option to choose a provider to update. For example: `PROVIDER=operator make assets`