### PR TITLE
Set privileged pod security for openshift-cluster-api namespace

### DIFF
--- a/manifests/0000_30_cluster-api_00_namespace.yaml
+++ b/manifests/0000_30_cluster-api_00_namespace.yaml
@@ -11,4 +11,7 @@ metadata:
   labels:
     openshift.io/run-level: "0"
     openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
   name: openshift-cluster-api


### PR DESCRIPTION
Currently the operator can't run because pod security admission is enforced and we don't have the correct configuration.

For now, we run this as privileged (xref https://github.com/openshift/machine-api-operator/pull/924) but over time will restrict this down as per the requirements of the workloads in this project.