### PR TITLE
Update manifests to use release.openshift.io/feature-set

### DIFF
--- a/hack/assets/customizations.go
+++ b/hack/assets/customizations.go
@@ -34,7 +34,7 @@ var (
 		"include.release.openshift.io/self-managed-high-availability": "true",
 		"include.release.openshift.io/single-node-developer":          "true",
 	}
-	techPreviewAnnotation      = "release.openshift.io/feature-gate"
+	techPreviewAnnotation      = "release.openshift.io/feature-set"
 	techPreviewAnnotationValue = "TechPreviewNoUpgrade"
 )
 

--- a/manifests/0000_30_cluster-api_00_credentials-request.yaml
+++ b/manifests/0000_30_cluster-api_00_credentials-request.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+    release.openshift.io/feature-set: "TechPreviewNoUpgrade"
 spec:
   serviceAccountNames:
     - cluster-capi-operator
@@ -68,7 +68,7 @@ metadata:
   annotations:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+    release.openshift.io/feature-set: "TechPreviewNoUpgrade"
 spec:
   secretRef:
     name: capz-manager-bootstrap-credentials
@@ -87,7 +87,7 @@ metadata:
   annotations:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+    release.openshift.io/feature-set: "TechPreviewNoUpgrade"
 spec:
   serviceAccountNames:
     - cluster-capi-operator

--- a/manifests/0000_30_cluster-api_00_namespace.yaml
+++ b/manifests/0000_30_cluster-api_00_namespace.yaml
@@ -5,7 +5,7 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"    
+    release.openshift.io/feature-set: "TechPreviewNoUpgrade"    
     openshift.io/node-selector: ""
     workload.openshift.io/allowed: "management"
   labels:

--- a/manifests/0000_30_cluster-api_01_images.configmap.yaml
+++ b/manifests/0000_30_cluster-api_01_images.configmap.yaml
@@ -7,7 +7,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+    release.openshift.io/feature-set: "TechPreviewNoUpgrade"
 data:
   images.json: >
     {

--- a/manifests/0000_30_cluster-api_02_crd.core-cluster-api.yaml
+++ b/manifests/0000_30_cluster-api_02_crd.core-cluster-api.yaml
@@ -6,7 +6,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:
@@ -1237,7 +1237,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:
@@ -2365,7 +2365,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:
@@ -3511,7 +3511,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:
@@ -4765,7 +4765,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:
@@ -6205,7 +6205,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:
@@ -7595,7 +7595,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:
@@ -8112,7 +8112,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:
@@ -8404,7 +8404,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:

--- a/manifests/0000_30_cluster-api_02_crd.infrastructure-aws.yaml
+++ b/manifests/0000_30_cluster-api_02_crd.infrastructure-aws.yaml
@@ -6,7 +6,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:
@@ -1418,7 +1418,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:
@@ -3744,7 +3744,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
@@ -4298,7 +4298,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:
@@ -5419,7 +5419,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
@@ -6853,7 +6853,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
@@ -7630,7 +7630,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:
@@ -8113,7 +8113,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
@@ -8454,7 +8454,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:
@@ -8763,7 +8763,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:
@@ -9478,7 +9478,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:
@@ -12735,7 +12735,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:
@@ -13134,7 +13134,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:

--- a/manifests/0000_30_cluster-api_02_crd.infrastructure-azure.yaml
+++ b/manifests/0000_30_cluster-api_02_crd.infrastructure-azure.yaml
@@ -7,7 +7,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-azure
@@ -114,7 +114,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-azure
@@ -191,7 +191,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-azure
@@ -263,7 +263,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:
@@ -1789,7 +1789,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:
@@ -3931,7 +3931,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:
@@ -5103,7 +5103,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:
@@ -5611,7 +5611,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:
@@ -7678,7 +7678,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-azure
@@ -7968,7 +7968,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-azure
@@ -8150,7 +8150,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-azure
@@ -8956,7 +8956,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:

--- a/manifests/0000_30_cluster-api_02_crd.infrastructure-gcp.yaml
+++ b/manifests/0000_30_cluster-api_02_crd.infrastructure-gcp.yaml
@@ -6,7 +6,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:
@@ -701,7 +701,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:
@@ -1401,7 +1401,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:
@@ -1934,7 +1934,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:

--- a/manifests/0000_30_cluster-api_02_crd.upstream.yaml
+++ b/manifests/0000_30_cluster-api_02_crd.upstream.yaml
@@ -6,7 +6,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: cluster-api
@@ -1494,7 +1494,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: cluster-api
@@ -2982,7 +2982,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: cluster-api
@@ -4472,7 +4472,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: cluster-api

--- a/manifests/0000_30_cluster-api_02_providers.configmap.yaml
+++ b/manifests/0000_30_cluster-api_02_providers.configmap.yaml
@@ -24,7 +24,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
   name: cluster-capi-operator-providers
   namespace: openshift-cluster-api

--- a/manifests/0000_30_cluster-api_02_service.upstream.yaml
+++ b/manifests/0000_30_cluster-api_02_service.upstream.yaml
@@ -5,7 +5,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   labels:
     cluster.x-k8s.io/provider: cluster-api
     clusterctl.cluster.x-k8s.io: ""

--- a/manifests/0000_30_cluster-api_02_service_account.yaml
+++ b/manifests/0000_30_cluster-api_02_service_account.yaml
@@ -8,7 +8,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+    release.openshift.io/feature-set: "TechPreviewNoUpgrade"
 ---
 apiVersion: v1
 kind: Secret
@@ -20,5 +20,5 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+    release.openshift.io/feature-set: "TechPreviewNoUpgrade"
 type: kubernetes.io/service-account-token

--- a/manifests/0000_30_cluster-api_02_webhook-service.yaml
+++ b/manifests/0000_30_cluster-api_02_webhook-service.yaml
@@ -5,7 +5,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.beta.openshift.io/serving-cert-secret-name: cluster-capi-operator-webhook-service-cert
   name: cluster-capi-operator-webhook-service
   namespace: openshift-cluster-api

--- a/manifests/0000_30_cluster-api_03_rbac-roles.core-cluster-api.yaml
+++ b/manifests/0000_30_cluster-api_03_rbac-roles.core-cluster-api.yaml
@@ -5,7 +5,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: cluster-api
@@ -27,7 +27,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   labels:
     cluster.x-k8s.io/aggregate-to-manager: "true"
     cluster.x-k8s.io/provider: cluster-api
@@ -319,7 +319,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   labels:
     cluster.x-k8s.io/provider: cluster-api
     clusterctl.cluster.x-k8s.io: ""
@@ -333,7 +333,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   labels:
     cluster.x-k8s.io/provider: cluster-api
     clusterctl.cluster.x-k8s.io: ""
@@ -366,7 +366,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: cluster-api
@@ -393,7 +393,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   labels:
     cluster.x-k8s.io/provider: cluster-api
     clusterctl.cluster.x-k8s.io: ""

--- a/manifests/0000_30_cluster-api_03_rbac-roles.infrastructure-aws.yaml
+++ b/manifests/0000_30_cluster-api_03_rbac-roles.infrastructure-aws.yaml
@@ -5,7 +5,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
@@ -310,7 +310,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
@@ -332,7 +332,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
     clusterctl.cluster.x-k8s.io: ""
@@ -347,7 +347,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
     clusterctl.cluster.x-k8s.io: ""
@@ -400,7 +400,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws

--- a/manifests/0000_30_cluster-api_03_rbac-roles.infrastructure-azure.yaml
+++ b/manifests/0000_30_cluster-api_03_rbac-roles.infrastructure-azure.yaml
@@ -5,7 +5,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   labels:
     cluster.x-k8s.io/provider: infrastructure-azure
     clusterctl.cluster.x-k8s.io: ""
@@ -48,7 +48,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-azure
@@ -71,7 +71,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-azure
@@ -325,7 +325,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-azure
@@ -347,7 +347,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   labels:
     cluster.x-k8s.io/provider: infrastructure-azure
     clusterctl.cluster.x-k8s.io: ""
@@ -361,7 +361,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   labels:
     cluster.x-k8s.io/provider: infrastructure-azure
     clusterctl.cluster.x-k8s.io: ""
@@ -394,7 +394,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-azure

--- a/manifests/0000_30_cluster-api_03_rbac-roles.infrastructure-gcp.yaml
+++ b/manifests/0000_30_cluster-api_03_rbac-roles.infrastructure-gcp.yaml
@@ -5,7 +5,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-gcp
@@ -97,7 +97,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-gcp
@@ -119,7 +119,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   labels:
     cluster.x-k8s.io/provider: infrastructure-gcp
     clusterctl.cluster.x-k8s.io: ""
@@ -133,7 +133,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   labels:
     cluster.x-k8s.io/provider: infrastructure-gcp
     clusterctl.cluster.x-k8s.io: ""
@@ -186,7 +186,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-gcp

--- a/manifests/0000_30_cluster-api_03_rbac-roles.upstream.yaml
+++ b/manifests/0000_30_cluster-api_03_rbac-roles.upstream.yaml
@@ -5,7 +5,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: cluster-api
@@ -27,7 +27,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: cluster-api
@@ -50,7 +50,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   labels:
     cluster.x-k8s.io/provider: cluster-api
     clusterctl.cluster.x-k8s.io: ""
@@ -104,7 +104,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: cluster-api
@@ -128,7 +128,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   labels:
     cluster.x-k8s.io/provider: cluster-api
     clusterctl.cluster.x-k8s.io: ""
@@ -155,7 +155,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: cluster-api
@@ -178,7 +178,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   labels:
     cluster.x-k8s.io/provider: cluster-api
     clusterctl.cluster.x-k8s.io: ""

--- a/manifests/0000_30_cluster-api_03_rbac_roles.yaml
+++ b/manifests/0000_30_cluster-api_03_rbac_roles.yaml
@@ -6,7 +6,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+    release.openshift.io/feature-set: "TechPreviewNoUpgrade"
   name: cluster-capi-operator
 rules:
 - apiGroups:
@@ -23,7 +23,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+    release.openshift.io/feature-set: "TechPreviewNoUpgrade"
   name: cluster-capi-operator
   namespace: openshift-cluster-api
 rules:

--- a/manifests/0000_30_cluster-api_04_rbac_bindings.yaml
+++ b/manifests/0000_30_cluster-api_04_rbac_bindings.yaml
@@ -7,7 +7,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+    release.openshift.io/feature-set: "TechPreviewNoUpgrade"
 roleRef:
   kind: ClusterRole
   name: cluster-capi-operator
@@ -26,7 +26,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+    release.openshift.io/feature-set: "TechPreviewNoUpgrade"
 roleRef:
   kind: Role
   name: cluster-capi-operator

--- a/manifests/0000_30_cluster-api_10_webhooks.yaml
+++ b/manifests/0000_30_cluster-api_10_webhooks.yaml
@@ -6,7 +6,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: validating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/manifests/0000_30_cluster-api_11_deployment.upstream.yaml
+++ b/manifests/0000_30_cluster-api_11_deployment.upstream.yaml
@@ -5,7 +5,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: cluster-api

--- a/manifests/0000_30_cluster-api_11_deployment.yaml
+++ b/manifests/0000_30_cluster-api_11_deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+    release.openshift.io/feature-set: "TechPreviewNoUpgrade"
   labels:
     k8s-app: cluster-capi-operator
 spec:

--- a/manifests/0000_30_cluster-api_12_clusteroperator.yaml
+++ b/manifests/0000_30_cluster-api_12_clusteroperator.yaml
@@ -6,7 +6,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+    release.openshift.io/feature-set: "TechPreviewNoUpgrade"
 spec: {}
 status:
   versions:


### PR DESCRIPTION
This was added in
https://github.com/openshift/cluster-version-operator/pull/821 to allow
more featuresets and allow for a future migration to include actual gates

/assign @JoelSpeed 
/cc @wking 