### PR TITLE
Update annotations

### DIFF
--- a/assets/core-capi/core-cluster-api.yaml
+++ b/assets/core-capi/core-cluster-api.yaml
@@ -341,6 +341,10 @@ data:
     kind: Service
     metadata:
       annotations:
+        exclude.release.openshift.io/internal-openshift-hosted: "true"
+        include.release.openshift.io/self-managed-high-availability: "true"
+        include.release.openshift.io/single-node-developer: "true"
+        release.openshift.io/feature-set: TechPreviewNoUpgrade
         service.beta.openshift.io/serving-cert-secret-name: capi-webhook-service-cert
       labels:
         cluster.x-k8s.io/provider: cluster-api

--- a/assets/infrastructure-providers/infrastructure-aws.yaml
+++ b/assets/infrastructure-providers/infrastructure-aws.yaml
@@ -439,6 +439,10 @@ data:
     kind: Service
     metadata:
       annotations:
+        exclude.release.openshift.io/internal-openshift-hosted: "true"
+        include.release.openshift.io/self-managed-high-availability: "true"
+        include.release.openshift.io/single-node-developer: "true"
+        release.openshift.io/feature-set: TechPreviewNoUpgrade
         service.beta.openshift.io/serving-cert-secret-name: capa-webhook-service-cert
       labels:
         cluster.x-k8s.io/provider: infrastructure-aws

--- a/assets/infrastructure-providers/infrastructure-azure.yaml
+++ b/assets/infrastructure-providers/infrastructure-azure.yaml
@@ -372,6 +372,10 @@ data:
     kind: Service
     metadata:
       annotations:
+        exclude.release.openshift.io/internal-openshift-hosted: "true"
+        include.release.openshift.io/self-managed-high-availability: "true"
+        include.release.openshift.io/single-node-developer: "true"
+        release.openshift.io/feature-set: TechPreviewNoUpgrade
         service.beta.openshift.io/serving-cert-secret-name: capz-webhook-service-cert
       labels:
         cluster.x-k8s.io/provider: infrastructure-azure

--- a/assets/infrastructure-providers/infrastructure-gcp.yaml
+++ b/assets/infrastructure-providers/infrastructure-gcp.yaml
@@ -208,6 +208,10 @@ data:
     kind: Service
     metadata:
       annotations:
+        exclude.release.openshift.io/internal-openshift-hosted: "true"
+        include.release.openshift.io/self-managed-high-availability: "true"
+        include.release.openshift.io/single-node-developer: "true"
+        release.openshift.io/feature-set: TechPreviewNoUpgrade
         service.beta.openshift.io/serving-cert-secret-name: capg-webhook-service-cert
       labels:
         cluster.x-k8s.io/provider: infrastructure-gcp

--- a/assets/infrastructure-providers/infrastructure-ibmcloud.yaml
+++ b/assets/infrastructure-providers/infrastructure-ibmcloud.yaml
@@ -5,9 +5,13 @@ data:
     kind: Service
     metadata:
       annotations:
+        exclude.release.openshift.io/internal-openshift-hosted: "true"
+        include.release.openshift.io/self-managed-high-availability: "true"
+        include.release.openshift.io/single-node-developer: "true"
         prometheus.io/port: "8443"
         prometheus.io/scheme: https
         prometheus.io/scrape: "true"
+        release.openshift.io/feature-set: TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-ibmcloud
         clusterctl.cluster.x-k8s.io: ""
@@ -436,6 +440,10 @@ data:
     kind: Service
     metadata:
       annotations:
+        exclude.release.openshift.io/internal-openshift-hosted: "true"
+        include.release.openshift.io/self-managed-high-availability: "true"
+        include.release.openshift.io/single-node-developer: "true"
+        release.openshift.io/feature-set: TechPreviewNoUpgrade
         service.beta.openshift.io/serving-cert-secret-name: webhook-server-cert
       labels:
         cluster.x-k8s.io/provider: infrastructure-ibmcloud

--- a/manifests/0000_30_cluster-api_02_service.upstream.yaml
+++ b/manifests/0000_30_cluster-api_02_service.upstream.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotation:
+  annotations:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"


### PR DESCRIPTION
Generated by:
./hack/assets.sh

Fixes a typo in a service manifest: `annotation` -> `annotations`. It forces the service to be deployed only when `TechPreviewNoUpgrade` is enabled.