### PR TITLE
Bug 2116686: OCPBUGS-1493: Add provider webhook

### DIFF
--- a/cmd/cluster-capi-operator/main.go
+++ b/cmd/cluster-capi-operator/main.go
@@ -21,6 +21,7 @@ import (
 	gcpv1 "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
 	ibmpowervsv1 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -100,6 +101,7 @@ func init() {
 	utilruntime.Must(azurev1.AddToScheme(scheme))
 	utilruntime.Must(gcpv1.AddToScheme(scheme))
 	utilruntime.Must(clusterv1.AddToScheme(scheme))
+	utilruntime.Must(clusterctlv1.AddToScheme(scheme))
 	utilruntime.Must(ibmpowervsv1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 }
@@ -283,6 +285,11 @@ func setupWebhooks(mgr ctrl.Manager, platform configv1.PlatformType) {
 
 	if err := (&webhook.ClusterWebhook{}).SetupWebhookWithManager(mgr); err != nil {
 		klog.Error(err, "unable to create webhook", "webhook", "Cluster")
+		os.Exit(1)
+	}
+
+	if err := (&webhook.ProviderWebhook{}).SetupWebhookWithManager(mgr); err != nil {
+		klog.Error(err, "unable to create webhook", "webhook", "Provider")
 		os.Exit(1)
 	}
 }

--- a/manifests/0000_30_cluster-api_10_webhooks.yaml
+++ b/manifests/0000_30_cluster-api_10_webhooks.yaml
@@ -27,6 +27,8 @@ webhooks:
         apiVersions:
           - v1alpha1
         operations:
+          - CREATE
+          - UPDATE
           - DELETE
         resources:
           - coreproviders
@@ -48,6 +50,8 @@ webhooks:
         apiVersions:
           - v1alpha1
         operations:
+          - CREATE
+          - UPDATE
           - DELETE
         resources:
           - infrastructureproviders
@@ -71,6 +75,28 @@ webhooks:
       operations:
       - CREATE
       - UPDATE
+      - DELETE
       resources:
       - clusters
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1alpha1
+    clientConfig:
+      service:
+        name: cluster-capi-operator-webhook-service
+        namespace: openshift-cluster-api
+        path: /validate-clusterctl-cluster-x-k8s-io-v1alpha3-provider
+        port: 9443
+    failurePolicy: Fail
+    name: validation.clusterctl.cluster.x-k8s.io
+    rules:
+      - apiGroups:
+          - clusterctl.cluster.x-k8s.io
+        apiVersions:
+          - v1alpha3
+        operations:
+          - DELETE
+        resources:
+          - providers
     sideEffects: None

--- a/pkg/webhook/provider.go
+++ b/pkg/webhook/provider.go
@@ -1,0 +1,52 @@
+package webhook
+
+import (
+	"context"
+	"errors"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	clusterv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+type ProviderWebhook struct {
+}
+
+func (r *ProviderWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		WithValidator(r).
+		For(&clusterv1.Provider{}).
+		Complete()
+}
+
+var _ webhook.CustomValidator = &ProviderWebhook{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *ProviderWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) error {
+	_, ok := obj.(*clusterv1.Provider)
+	if !ok {
+		panic("expected to get an of object of type v1alpha3.Provider")
+	}
+
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *ProviderWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) error {
+	_, ok := oldObj.(*clusterv1.Provider)
+	if !ok {
+		panic("expected to get an of object of type v1alpha3.Provider")
+	}
+	_, ok = newObj.(*clusterv1.Provider)
+	if !ok {
+		panic("expected to get an of object of type v1alpha3.Provider")
+	}
+
+	return nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *ProviderWebhook) ValidateDelete(_ context.Context, obj runtime.Object) error {
+	return errors.New("deletion of cluster API providers is not allowed")
+}


### PR DESCRIPTION
To prevent deletion of created Cluster API providers we add a webhook to check this operation.

Also this commit enables missing operations for other webhooks.