### PR TITLE
Don't patch objects if there are no changes

### DIFF
--- a/pkg/util/patch.go
+++ b/pkg/util/patch.go
@@ -1,0 +1,16 @@
+package util
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func IsPatchRequired(origObj client.Object, patch client.Patch) (bool, error) {
+	data, err := patch.Data(origObj)
+	if err != nil {
+		return false, fmt.Errorf("failed to calculate patch: %w", err)
+	}
+
+	return string(data) != "{}", nil
+}


### PR DESCRIPTION
Currently we send a request to update some objects on each reconciliation, even if these objects were not modified.

To prevent this we introduce checks to ensure that changes were made before sending patch requests.