### PR TITLE
Fix panics in e2e tests

### DIFF
--- a/e2e/aws_test.go
+++ b/e2e/aws_test.go
@@ -47,6 +47,11 @@ var _ = Describe("Cluster API AWS MachineSet", Ordered, func() {
 	})
 
 	AfterEach(func() {
+		if platform != configv1.AWSPlatformType {
+			// Because AfterEach always runs, even when tests are skipped, we have to
+			// explicitly skip it here for other platforms.
+			Skip("Skipping AWS E2E tests")
+		}
 		framework.DeleteMachineSets(cl, machineSet)
 		framework.WaitForMachineSetsDeleted(cl, machineSet)
 		framework.DeleteObjects(cl, awsMachineTemplate)

--- a/e2e/gcp_test.go
+++ b/e2e/gcp_test.go
@@ -37,6 +37,11 @@ var _ = Describe("Cluster API GCP MachineSet", Ordered, func() {
 	})
 
 	AfterEach(func() {
+		if platform != configv1.GCPPlatformType {
+			// Because AfterEach always runs, even when tests are skipped, we have to
+			// explicitly skip it here for other platforms.
+			Skip("Skipping GCP E2E tests")
+		}
 		framework.DeleteMachineSets(cl, machineSet)
 		framework.WaitForMachineSetsDeleted(cl, machineSet)
 		framework.DeleteObjects(cl, gcpMachineTemplate)

--- a/e2e/powervs_test.go
+++ b/e2e/powervs_test.go
@@ -40,6 +40,11 @@ var _ = Describe("Cluster API IBMPowerVS MachineSet", Ordered, func() {
 	})
 
 	AfterEach(func() {
+		if platform != configv1.PowerVSPlatformType {
+			// Because AfterEach always runs, even when tests are skipped, we have to
+			// explicitly skip it here for other platforms.
+			Skip("Skipping PowerVS E2E tests")
+		}
 		framework.DeleteMachineSets(cl, machineSet)
 		framework.WaitForMachineSetsDeleted(cl, machineSet)
 		framework.DeleteObjects(cl, powerVSMachineTemplate)


### PR DESCRIPTION
Currently we skip only BeforeAll part of our tests, but AfterEach is executed on each platform which leads to panics.

```
  Skipping AWS E2E tests
  In [BeforeAll] at: /home/mfedosin/projects/cluster-capi-operator/e2e/aws_test.go:41

  Full Stack Trace
    github.com/openshift/cluster-capi-operator/e2e.glob..func1.1()
    	/home/mfedosin/projects/cluster-capi-operator/e2e/aws_test.go:41 +0x10c

  There were additional failures detected after the initial failure:
    [PANICKED]
    Test Panicked
    In [AfterEach] at: /usr/local/go/src/runtime/panic.go:260

    runtime error: invalid memory address or nil pointer dereference

    Full Stack Trace
      github.com/openshift/cluster-capi-operator/e2e/framework.DeleteMachineSets({0x3df5318, 0xc000812540}, {0xc000943ec8, 0x1, 0x0?})
      	/home/mfedosin/projects/cluster-capi-operator/e2e/framework/machineset.go:116 +0xbb
      github.com/openshift/cluster-capi-operator/e2e.glob..func1.2()
      	/home/mfedosin/projects/cluster-capi-operator/e2e/aws_test.go:50 +0x85
```

This commit fixes it by adding Skip in AfterEach blocks as well.