### PR TITLE
fix indentation for webhook manifests

### DIFF
--- a/manifests/0000_30_cluster-api_10_webhooks.yaml
+++ b/manifests/0000_30_cluster-api_10_webhooks.yaml
@@ -68,16 +68,16 @@ webhooks:
     failurePolicy: Fail
     name: validation.cluster.cluster.x-k8s.io
     rules:
-    - apiGroups:
-      - cluster.x-k8s.io
-      apiVersions:
-      - v1beta1
-      operations:
-      - CREATE
-      - UPDATE
-      - DELETE
-      resources:
-      - clusters
+      - apiGroups:
+          - cluster.x-k8s.io
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - clusters
     sideEffects: None
   - admissionReviewVersions:
       - v1


### PR DESCRIPTION
Despite the fact the indentation is correct, these manifests are not correctly parsed by CVO, and some fields are missing.

To fix it we update the indentation to bring it to a more standard variant.