### PR TITLE
OCPBUGS-4147: Enforce single Cluster in openshift-cluster-api namespace

### DIFF
--- a/pkg/webhook/cluster.go
+++ b/pkg/webhook/cluster.go
@@ -6,15 +6,26 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+const (
+	openshiftCAPINamespace = "openshift-cluster-api"
 )
 
 type ClusterWebhook struct {
+	client client.Client
 }
 
 func (r *ClusterWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	r.client = mgr.GetClient()
 	return ctrl.NewWebhookManagedBy(mgr).
 		WithValidator(r).
 		For(&v1beta1.Cluster{}).
@@ -23,16 +34,60 @@ func (r *ClusterWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 var _ webhook.CustomValidator = &ClusterWebhook{}
 
+// fetchInfrastructureObject fetches the Infrastructure object from the cluster.
+func (r *ClusterWebhook) fetchInfrastructureObject(ctx context.Context) (*configv1.Infrastructure, error) {
+	infrastructureObjectKey := client.ObjectKey{Name: "cluster", Namespace: "default"}
+
+	infrastructureObject := configv1.Infrastructure{}
+	err := r.client.Get(ctx, infrastructureObjectKey, &infrastructureObject)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch Infrastructure object: %w", err)
+	}
+
+	return &infrastructureObject, nil
+}
+
+// In openshift-cluster-api allow only one Cluster object to be created. This Cluster manages the cluster we are running on.
+func (r *ClusterWebhook) validateClusterName(ctx context.Context, cluster *v1beta1.Cluster) error {
+	if cluster.Namespace != openshiftCAPINamespace {
+		return nil
+	}
+
+	infrastructureObject, err := r.fetchInfrastructureObject(ctx)
+	if err != nil {
+		return fmt.Errorf("cluster in %s namespace must be named <infrastructure_id>. Failed to obtain name from Infrastructure object for validation: %w", openshiftCAPINamespace, err)
+	}
+
+	infrastructureName := infrastructureObject.Status.InfrastructureName
+	if cluster.ObjectMeta.Name != infrastructureName {
+		return fmt.Errorf("cluster name must be %s in %s namespace", infrastructureName, openshiftCAPINamespace)
+	}
+
+	return nil
+}
+
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *ClusterWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) error {
 	cluster, ok := obj.(*v1beta1.Cluster)
 	if !ok {
 		panic("expected to get an of object of type v1beta1.Cluster")
 	}
-	switch cluster.Spec.InfrastructureRef.Kind {
-	case "AWSCluster", "AzureCluster", "GCPCluster", "IBMPowerVSCluster":
-	default:
-		return fmt.Errorf("unsupported cluster infra provider kind: %s", cluster.Spec.InfrastructureRef.Kind)
+
+	errs := []error{}
+	infrastructureRefPath := field.NewPath("spec", "infrastructureRef")
+	if cluster.Spec.InfrastructureRef != nil {
+		switch cluster.Spec.InfrastructureRef.Kind {
+		case "AWSCluster", "AzureCluster", "GCPCluster", "IBMPowerVSCluster":
+		default:
+			errs = append(errs, field.NotSupported(infrastructureRefPath.Child("kind"),
+				cluster.Spec.InfrastructureRef.Kind, []string{"AWSCluster", "AzureCluster", "GCPCluster", "IBMPowerVSCluster"}))
+		}
+	}
+
+	errs = append(errs, r.validateClusterName(ctx, cluster))
+
+	if len(errs) > 0 {
+		return utilerrors.NewAggregate(errs)
 	}
 
 	return nil
@@ -49,10 +104,12 @@ func (r *ClusterWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runt
 		panic("expected to get an of object of type v1beta1.Cluster")
 	}
 
-	switch newCluster.Spec.InfrastructureRef.Kind {
-	case "AWSCluster", "AzureCluster", "GCPCluster", "IBMPowerVSCluster":
-	default:
-		return fmt.Errorf("unsupported cluster infra provider kind: %s", newCluster.Spec.InfrastructureRef.Kind)
+	if newCluster.Spec.InfrastructureRef != nil {
+		switch newCluster.Spec.InfrastructureRef.Kind {
+		case "AWSCluster", "AzureCluster", "GCPCluster", "IBMPowerVSCluster":
+		default:
+			return field.NotSupported(field.NewPath("spec", "infrastructureRef", "kind"), newCluster.Spec.InfrastructureRef.Kind, []string{"AWSCluster", "AzureCluster", "GCPCluster", "IBMPowerVSCluster"})
+		}
 	}
 
 	return nil


### PR DESCRIPTION
We want only one Cluster in the openshift-cluster-api namespace that creates machines for the cluster we are running on. To prevent creation of multiple clusters, this PR adds webhook that allows only clusters named <InfrastructureName> that is obtained from the InfrastructureObject.