### PR TITLE
SPLAT-1084: Remove IPAM CRD installation filter

### DIFF
--- a/hack/assets/customizations.go
+++ b/hack/assets/customizations.go
@@ -80,10 +80,6 @@ func processObjects(objs []unstructured.Unstructured, providerName string) map[r
 			replaceCertManagerAnnotations(&obj)
 			finalObjs = append(finalObjs, obj)
 		case "CustomResourceDefinition":
-			// Filter out IPAM for metal3
-			if strings.Contains(strings.ToLower(obj.GetName()), "ipam") {
-				break
-			}
 			replaceCertManagerAnnotations(&obj)
 			removeConversionWebhook(&obj)
 			setOpenShiftAnnotations(obj, true)

--- a/manifests/0000_30_cluster-api_02_crd.core-cluster-api.yaml
+++ b/manifests/0000_30_cluster-api_02_crd.core-cluster-api.yaml
@@ -10176,3 +10176,269 @@ status:
     plural: ""
   conditions: null
   storedVersions: null
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: ipaddresses.ipam.cluster.x-k8s.io
+spec:
+  group: ipam.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: IPAddress
+    listKind: IPAddressList
+    plural: ipaddresses
+    singular: ipaddress
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Address
+      jsonPath: .spec.address
+      name: Address
+      type: string
+    - description: Name of the pool the address is from
+      jsonPath: .spec.poolRef.name
+      name: Pool Name
+      type: string
+    - description: Kind of the pool the address is from
+      jsonPath: .spec.poolRef.kind
+      name: Pool Kind
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: IPAddress is the Schema for the ipaddress API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPAddressSpec is the desired state of an IPAddress.
+            properties:
+              address:
+                description: Address is the IP address.
+                type: string
+              claimRef:
+                description: ClaimRef is a reference to the claim this IPAddress was
+                  created for.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+              gateway:
+                description: Gateway is the network gateway of the network the address
+                  is from.
+                type: string
+              poolRef:
+                description: PoolRef is a reference to the pool that this IPAddress
+                  was created from.
+                properties:
+                  apiGroup:
+                    description: APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in
+                      the core API group. For any other third-party types, APIGroup
+                      is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - apiGroup
+                - kind
+                - name
+                type: object
+              prefix:
+                description: Prefix is the prefix of the address.
+                type: integer
+            required:
+            - address
+            - claimRef
+            - gateway
+            - poolRef
+            - prefix
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: ipaddressclaims.ipam.cluster.x-k8s.io
+spec:
+  group: ipam.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: IPAddressClaim
+    listKind: IPAddressClaimList
+    plural: ipaddressclaims
+    singular: ipaddressclaim
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Name of the pool to allocate an address from
+      jsonPath: .spec.poolRef.name
+      name: Pool Name
+      type: string
+    - description: Kind of the pool to allocate an address from
+      jsonPath: .spec.poolRef.kind
+      name: Pool Kind
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: IPAddressClaim is the Schema for the ipaddressclaim API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPAddressClaimSpec is the desired state of an IPAddressClaim.
+            properties:
+              poolRef:
+                description: PoolRef is a reference to the pool from which an IP address
+                  should be created.
+                properties:
+                  apiGroup:
+                    description: APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in
+                      the core API group. For any other third-party types, APIGroup
+                      is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - apiGroup
+                - kind
+                - name
+                type: object
+            required:
+            - poolRef
+            type: object
+          status:
+            description: IPAddressClaimStatus is the observed status of a IPAddressClaim.
+            properties:
+              addressRef:
+                description: AddressRef is a reference to the address that was created
+                  for this claim.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+              conditions:
+                description: Conditions summarises the current state of the IPAddressClaim
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+            required:
+            - addressRef
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null


### PR DESCRIPTION
Removing a filter which was introduced in cluster-capi-operator#8 and refactored in cluster-capi-operator#34 to filter out the metal3 ipam types.  The metal 3 IPAM types were dropped in cluster-capi-operator#23.  As a result, removing the check so the current CAPI IPAM CRDs can be installed in support of [vSphere static IP efforts](https://issues.redhat.com/browse/SPLAT-827).  
