### PR TITLE
Bump CAPZ to v1.9.5

### DIFF
--- a/assets/infrastructure-providers/infrastructure-azure-provider.yaml
+++ b/assets/infrastructure-providers/infrastructure-azure-provider.yaml
@@ -15,5 +15,5 @@ spec:
       matchLabels:
         provider.cluster.x-k8s.io/name: azure
         provider.cluster.x-k8s.io/type: infrastructure
-  version: v1.9.2
+  version: v1.9.5
 status: {}

--- a/assets/infrastructure-providers/infrastructure-azure.yaml
+++ b/assets/infrastructure-providers/infrastructure-azure.yaml
@@ -459,6 +459,6 @@ metadata:
   labels:
     provider.cluster.x-k8s.io/name: azure
     provider.cluster.x-k8s.io/type: infrastructure
-    provider.cluster.x-k8s.io/version: v1.9.2
+    provider.cluster.x-k8s.io/version: v1.9.5
   name: azure
   namespace: openshift-cluster-api

--- a/manifests/0000_30_cluster-api_02_crd.infrastructure-azure.yaml
+++ b/manifests/0000_30_cluster-api_02_crd.infrastructure-azure.yaml
@@ -1467,7 +1467,7 @@ spec:
                   is only a subset of options that are available in azure cloud provider
                   config. Some values for the cloud provider config are inferred from
                   other parts of cluster api provider azure spec, and may not be available
-                  for overrides. See: https://kubernetes-sigs.github.io/cloud-provider-azure/install/configs
+                  for overrides. See: https://cloud-provider-azure.sigs.k8s.io/install/configs
                   Note: All cloud provider config values can be customized by creating
                   the secret beforehand. CloudProviderConfigOverrides is only used
                   when the secret is managed by the Azure Provider.'
@@ -2744,7 +2744,7 @@ spec:
                           that are available in azure cloud provider config. Some
                           values for the cloud provider config are inferred from other
                           parts of cluster api provider azure spec, and may not be
-                          available for overrides. See: https://kubernetes-sigs.github.io/cloud-provider-azure/install/configs
+                          available for overrides. See: https://cloud-provider-azure.sigs.k8s.io/install/configs
                           Note: All cloud provider config values can be customized
                           by creating the secret beforehand. CloudProviderConfigOverrides
                           is only used when the secret is managed by the Azure Provider.'

--- a/manifests/0000_30_cluster-api_02_providers.configmap.yaml
+++ b/manifests/0000_30_cluster-api_02_providers.configmap.yaml
@@ -12,7 +12,7 @@ data:
     - name: azure
       type: InfrastructureProvider
       branch: release-4.14
-      version: v1.9.2
+      version: v1.9.5
     - name: gcp
       type: InfrastructureProvider
       branch: release-4.14

--- a/providers-list.yaml
+++ b/providers-list.yaml
@@ -9,7 +9,7 @@
 - name: azure
   type: InfrastructureProvider
   branch: release-4.14
-  version: v1.9.2
+  version: v1.9.5
 - name: gcp
   type: InfrastructureProvider
   branch: release-4.14


### PR DESCRIPTION
The provider was rebased to v1.9.5, so we need to bump it here too.