### PR TITLE
OCPCLOUD-2012: Add granular permissions for Azure

### DIFF
--- a/assets/infrastructure-providers/infrastructure-azure.yaml
+++ b/assets/infrastructure-providers/infrastructure-azure.yaml
@@ -27,6 +27,7 @@ data:
           creationTimestamp: null
           labels:
             aadpodidbinding: capz-controller-aadpodidentity-selector
+            azure.workload.identity/use: "true"
             cluster.x-k8s.io/provider: infrastructure-azure
             control-plane: capz-controller-manager
         spec:
@@ -105,6 +106,9 @@ data:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert
               readOnly: true
+            - mountPath: /var/run/secrets/azure/tokens
+              name: azure-identity-token
+              readOnly: true
           priorityClassName: system-cluster-critical
           securityContext:
             runAsNonRoot: true
@@ -122,6 +126,14 @@ data:
             secret:
               defaultMode: 420
               secretName: capz-webhook-service-cert
+          - name: azure-identity-token
+            projected:
+              defaultMode: 420
+              sources:
+              - serviceAccountToken:
+                  audience: api://AzureADTokenExchange
+                  expirationSeconds: 3600
+                  path: azure-identity-token
     status: {}
     ---
     apiVersion: admissionregistration.k8s.io/v1

--- a/manifests/0000_30_cluster-api_00_credentials-request.yaml
+++ b/manifests/0000_30_cluster-api_00_credentials-request.yaml
@@ -70,6 +70,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: "TechPreviewNoUpgrade"
 spec:
+  cloudTokenPath: /var/run/secrets/azure/tokens
   serviceAccountNames:
     - cluster-capi-operator
   secretRef:

--- a/manifests/0000_30_cluster-api_00_credentials-request.yaml
+++ b/manifests/0000_30_cluster-api_00_credentials-request.yaml
@@ -70,14 +70,77 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: "TechPreviewNoUpgrade"
 spec:
+  serviceAccountNames:
+    - cluster-capi-operator
   secretRef:
     name: capz-manager-bootstrap-credentials
     namespace: openshift-cluster-api
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1
     kind: AzureProviderSpec
-    roleBindings:
-    - role: Contributor
+    permissions:
+    - Microsoft.ApiManagement/service/groups/delete
+    - Microsoft.ApiManagement/service/groups/read
+    - Microsoft.ApiManagement/service/groups/write
+    - Microsoft.ApiManagement/service/workspaces/tags/read
+    - Microsoft.ApiManagement/service/workspaces/tags/write
+    - Microsoft.Authorization/roleAssignments/read
+    - Microsoft.Authorization/roleAssignments/write
+    - Microsoft.Compute/availabilitySets/delete
+    - Microsoft.Compute/availabilitySets/write
+    - Microsoft.Compute/disks/delete
+    - Microsoft.Compute/images/read
+    - Microsoft.Compute/images/write
+    - Microsoft.Compute/locations/diskOperations/read
+    - Microsoft.Compute/skus/read
+    - Microsoft.Compute/virtualMachineScaleSets/delete
+    - Microsoft.Compute/virtualMachineScaleSets/read
+    - Microsoft.Compute/virtualMachineScaleSets/write
+    - Microsoft.Compute/virtualMachines/extensions/write
+    - Microsoft.ContainerService/managedClusters/agentPools/write
+    - Microsoft.ContainerService/managedClusters/delete
+    - Microsoft.ContainerService/managedClusters/write
+    - Microsoft.Network/applicationSecurityGroups/delete
+    - Microsoft.Network/applicationSecurityGroups/read
+    - Microsoft.Network/applicationSecurityGroups/write
+    - Microsoft.Network/bastionHosts/delete
+    - Microsoft.Network/bastionHosts/write
+    - Microsoft.Network/loadBalancers/inboundNatRules/delete
+    - Microsoft.Network/loadBalancers/inboundNatRules/write
+    - Microsoft.Network/natGateways/delete
+    - Microsoft.Network/natGateways/read
+    - Microsoft.Network/natGateways/write
+    - Microsoft.Network/networkInterfaces/delete
+    - Microsoft.Network/networkInterfaces/read
+    - Microsoft.Network/networkInterfaces/write
+    - Microsoft.Network/networkSecurityGroups/delete
+    - Microsoft.Network/networkSecurityGroups/read
+    - Microsoft.Network/networkSecurityGroups/write
+    - Microsoft.Network/privateDnsZones/delete
+    - Microsoft.Network/privateDnsZones/write
+    - Microsoft.Network/privateEndpoints/delete
+    - Microsoft.Network/privateEndpoints/write
+    - Microsoft.Network/publicIPAddresses/delete
+    - Microsoft.Network/publicIPAddresses/read
+    - Microsoft.Network/publicIPAddresses/write
+    - Microsoft.Network/routeTables/delete
+    - Microsoft.Network/routeTables/read
+    - Microsoft.Network/routeTables/write
+    - Microsoft.Network/virtualNetworks/delete
+    - Microsoft.Network/virtualNetworks/delete
+    - Microsoft.Network/virtualNetworks/read
+    - Microsoft.Network/virtualNetworks/subnets/delete
+    - Microsoft.Network/virtualNetworks/subnets/read
+    - Microsoft.Network/virtualNetworks/subnets/write
+    - Microsoft.Network/virtualNetworks/virtualNetworkPeerings/read
+    - Microsoft.Network/virtualNetworks/virtualNetworkPeerings/write
+    - Microsoft.Network/virtualNetworks/write
+    - Microsoft.Resourcehealth/healthevent/action
+    - Microsoft.Resources/subscriptions/resourceGroups/delete
+    - Microsoft.Resources/subscriptions/resourceGroups/read
+    - Microsoft.Resources/subscriptions/resourceGroups/write
+    - Microsoft.ClassicStorage/storageAccounts/vmImages/read
+    - Microsoft.ClassicStorage/storageAccounts/vmImages/write
 ---
 apiVersion: cloudcredential.openshift.io/v1
 kind: CredentialsRequest

--- a/manifests/0000_30_cluster-api_02_crd.infrastructure-azure.yaml
+++ b/manifests/0000_30_cluster-api_02_crd.infrastructure-azure.yaml
@@ -4161,6 +4161,7 @@ spec:
                 - UserAssignedMSI
                 - ManualServicePrincipal
                 - ServicePrincipalCertificate
+                - WorkloadIdentity
                 type: string
             required:
             - clientID


### PR DESCRIPTION
Instead of using predefined roles on Azure, we want to use granular permissions to gain more control of what can be done on the cluster.