### PR TITLE
Use the workload identity

### DIFF
--- a/assets/infrastructure-providers/infrastructure-azure.yaml
+++ b/assets/infrastructure-providers/infrastructure-azure.yaml
@@ -27,6 +27,7 @@ data:
           creationTimestamp: null
           labels:
             aadpodidbinding: capz-controller-aadpodidentity-selector
+            azure.workload.identity/use: "true"
             cluster.x-k8s.io/provider: infrastructure-azure
             control-plane: capz-controller-manager
         spec:
@@ -105,6 +106,9 @@ data:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert
               readOnly: true
+            - mountPath: /var/run/secrets/azure/tokens
+              name: azure-identity-token
+              readOnly: true
           priorityClassName: system-cluster-critical
           securityContext:
             runAsNonRoot: true
@@ -122,6 +126,14 @@ data:
             secret:
               defaultMode: 420
               secretName: capz-webhook-service-cert
+          - name: azure-identity-token
+            projected:
+              defaultMode: 420
+              sources:
+              - serviceAccountToken:
+                  audience: api://AzureADTokenExchange
+                  expirationSeconds: 3600
+                  path: azure-identity-token
     status: {}
     ---
     apiVersion: admissionregistration.k8s.io/v1

--- a/manifests/0000_30_cluster-api_00_credentials-request.yaml
+++ b/manifests/0000_30_cluster-api_00_credentials-request.yaml
@@ -70,6 +70,8 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: "TechPreviewNoUpgrade"
 spec:
+  serviceAccountNames:
+    - cluster-capi-operator
   secretRef:
     name: capz-manager-bootstrap-credentials
     namespace: openshift-cluster-api

--- a/manifests/0000_30_cluster-api_02_crd.infrastructure-azure.yaml
+++ b/manifests/0000_30_cluster-api_02_crd.infrastructure-azure.yaml
@@ -4155,12 +4155,13 @@ spec:
                 type: string
               type:
                 description: Type is the type of Azure Identity used. ServicePrincipal,
-                  ServicePrincipalCertificate, UserAssignedMSI or ManualServicePrincipal.
+                  ServicePrincipalCertificate, UserAssignedMSI, ManualServicePrincipal or WorkloadIdentity.
                 enum:
                 - ServicePrincipal
                 - UserAssignedMSI
                 - ManualServicePrincipal
                 - ServicePrincipalCertificate
+                - WorkloadIdentity
                 type: string
             required:
             - clientID


### PR DESCRIPTION
This PR splits the introduction of workload identity part of #124 and allows us to do the granular permissions in later PR.

