### PR TITLE
OCPBUGS-18504: e2e: set ControlPlaneEndpoint in AWSCluster

### DIFF
--- a/assets/infrastructure-providers/infrastructure-azure.yaml
+++ b/assets/infrastructure-providers/infrastructure-azure.yaml
@@ -27,6 +27,7 @@ data:
           creationTimestamp: null
           labels:
             aadpodidbinding: capz-controller-aadpodidentity-selector
+            azure.workload.identity/use: "true"
             cluster.x-k8s.io/provider: infrastructure-azure
             control-plane: capz-controller-manager
         spec:
@@ -105,6 +106,9 @@ data:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert
               readOnly: true
+            - mountPath: /var/run/secrets/azure/tokens
+              name: azure-identity-token
+              readOnly: true
           priorityClassName: system-cluster-critical
           securityContext:
             runAsNonRoot: true
@@ -122,6 +126,14 @@ data:
             secret:
               defaultMode: 420
               secretName: capz-webhook-service-cert
+          - name: azure-identity-token
+            projected:
+              defaultMode: 420
+              sources:
+              - serviceAccountToken:
+                  audience: api://AzureADTokenExchange
+                  expirationSeconds: 3600
+                  path: azure-identity-token
     status: {}
     ---
     apiVersion: admissionregistration.k8s.io/v1

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -25,10 +25,11 @@ const (
 )
 
 var (
-	cl          runtimeclient.Client
-	ctx         = context.Background()
-	platform    configv1.PlatformType
-	clusterName string
+	cl                 runtimeclient.Client
+	ctx                = context.Background()
+	platform           configv1.PlatformType
+	clusterName        string
+	mapiInfrastructure *configv1.Infrastructure
 )
 
 func init() {
@@ -58,6 +59,7 @@ var _ = BeforeSuite(func() {
 	}
 	Expect(cl.Get(ctx, infraName, infra)).To(Succeed())
 	Expect(infra.Status.PlatformStatus).ToNot(BeNil())
+	mapiInfrastructure = infra
 	clusterName = infra.Status.InfrastructureName
 	platform = infra.Status.PlatformStatus.Type
 })

--- a/hack/clusters/create-aws.sh
+++ b/hack/clusters/create-aws.sh
@@ -10,6 +10,9 @@ printcolor "Getting required variables"
 export CLUSTER_NAME=$(kubectl get infrastructure cluster -o jsonpath="{.status.infrastructureName}")
 export AWS_REGION=$(kubectl get machineset.machine.openshift.io -n openshift-machine-api -o jsonpath="{.items[0].spec.template.spec.providerSpec.value.placement.region}")
 export INFRASTRUCTURE_KIND=AWSCluster
+export CLUSTER_CONTROLPLANE_ENDPOINT=$(kubectl get infrastructure cluster -o jsonpath="{.status.apiServerInternalURI}" | sed -E "s|https?://(.*)$|\1|g")
+export CLUSTER_CONTROLPLANE_HOST=$(echo ${CLUSTER_CONTROLPLANE_ENDPOINT} | cut -d':' -f1)
+export CLUSTER_CONTROLPLANE_PORT=$(echo ${CLUSTER_CONTROLPLANE_ENDPOINT} | cut -d':' -f2)
 
 printcolor "Creating AWS infrastructure cluster"
 envsubst <hack/clusters/templates/aws.yaml | kubectl apply -f -

--- a/hack/clusters/templates/aws.yaml
+++ b/hack/clusters/templates/aws.yaml
@@ -5,3 +5,6 @@ metadata:
   namespace: openshift-cluster-api
 spec:
   region: ${AWS_REGION}
+  controlPlaneEndpoint:
+    host: "${CLUSTER_CONTROLPLANE_HOST}"
+    port: ${CLUSTER_CONTROLPLANE_PORT}

--- a/manifests/0000_30_cluster-api_02_crd.infrastructure-azure.yaml
+++ b/manifests/0000_30_cluster-api_02_crd.infrastructure-azure.yaml
@@ -4161,6 +4161,7 @@ spec:
                 - UserAssignedMSI
                 - ManualServicePrincipal
                 - ServicePrincipalCertificate
+                - WorkloadIdentity
                 type: string
             required:
             - clientID


### PR DESCRIPTION
This sets the ControlPlaneEndpoint before Cluster object creation. To make the Cluster go into `Provisioned` state.
This is a temporary workaround, as we expect the Cluster & InfrastructureCluster objects creation and the population of the ControlPlaneEndpoint is going to happen in a dedicated controller within the operator.