### PR TITLE
MULTIARCH-3761: Power VS CAPI Remove deprecated flag

### DIFF
--- a/assets/infrastructure-providers/infrastructure-ibmcloud.yaml
+++ b/assets/infrastructure-providers/infrastructure-ibmcloud.yaml
@@ -57,8 +57,8 @@ data:
           - args:
             - --leader-elect
             - --metrics-bind-addr=127.0.0.1:8080
-            - --powervs-provider-id-fmt=v2
-            - --provider-id-fmt=${PROVIDER_ID_FORMAT:=v1}
+            - --powervs-provider-id-fmt=${POWERVS_PROVIDER_ID_FORMAT:=v1}
+            - --provider-id-fmt=v2
             - --service-endpoint=${SERVICE_ENDPOINT:=none}
             - --v=${LOGLEVEL:=0}
             command:

--- a/hack/assets/providercustomizations.go
+++ b/hack/assets/providercustomizations.go
@@ -119,8 +119,8 @@ func powerVSCustomizations(obj *unstructured.Unstructured) {
 			if container.Name == "manager" {
 				for j := range container.Args {
 					arg := &container.Args[j]
-					if *arg == "--powervs-provider-id-fmt=${POWERVS_PROVIDER_ID_FORMAT:=v1}" {
-						container.Args[j] = "--powervs-provider-id-fmt=v2"
+					if *arg == "--provider-id-fmt=${PROVIDER_ID_FORMAT:=v1}" {
+						container.Args[j] = "--provider-id-fmt=v2"
 					}
 				}
 			}


### PR DESCRIPTION
`powervs-provider-id-fmt` flag is deprecated and we are supposed to use `provider-id-fmt` flag. [Reference](https://github.com/openshift/cluster-api-provider-ibmcloud/blob/main/main.go#L168C2-L175)