### PR TITLE
[release-4.14] OCPBUGS-22314: fix: add missing azure identity diff

### DIFF
--- a/assets/infrastructure-providers/infrastructure-azure.yaml
+++ b/assets/infrastructure-providers/infrastructure-azure.yaml
@@ -27,6 +27,7 @@ data:
           creationTimestamp: null
           labels:
             aadpodidbinding: capz-controller-aadpodidentity-selector
+            azure.workload.identity/use: "true"
             cluster.x-k8s.io/provider: infrastructure-azure
             control-plane: capz-controller-manager
         spec:
@@ -105,6 +106,9 @@ data:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert
               readOnly: true
+            - mountPath: /var/run/secrets/azure/tokens
+              name: azure-identity-token
+              readOnly: true
           priorityClassName: system-cluster-critical
           securityContext:
             runAsNonRoot: true
@@ -122,6 +126,14 @@ data:
             secret:
               defaultMode: 420
               secretName: capz-webhook-service-cert
+          - name: azure-identity-token
+            projected:
+              defaultMode: 420
+              sources:
+              - serviceAccountToken:
+                  audience: api://AzureADTokenExchange
+                  expirationSeconds: 3600
+                  path: azure-identity-token
     status: {}
     ---
     apiVersion: admissionregistration.k8s.io/v1

--- a/manifests/0000_30_cluster-api_02_crd.infrastructure-azure.yaml
+++ b/manifests/0000_30_cluster-api_02_crd.infrastructure-azure.yaml
@@ -4161,6 +4161,7 @@ spec:
                 - UserAssignedMSI
                 - ManualServicePrincipal
                 - ServicePrincipalCertificate
+                - WorkloadIdentity
                 type: string
             required:
             - clientID


### PR DESCRIPTION
When the carry patch https://github.com/openshift/cluster-api-provider-azure/pull/274 was merged, `make assets` wasn't rerun on the cluster-capi-operator.

To fix this we need to rerun asset generation and check in the changes showing up.