### PR TITLE
OCPBUGS-19841: Add format key into the worker-user-data secret

### DIFF
--- a/pkg/controllers/secretsync/secret_sync_controller.go
+++ b/pkg/controllers/secretsync/secret_sync_controller.go
@@ -2,6 +2,7 @@ package secretsync
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"reflect"
 
@@ -102,10 +103,13 @@ func (r *UserDataSecretController) syncSecretData(ctx context.Context, source *c
 		return fmt.Errorf("source secret does not have user data")
 	}
 
+	formatEncoded := base64.StdEncoding.EncodeToString([]byte("ignition"))
+
 	target.SetName(managedUserDataSecretName)
 	target.SetNamespace(r.ManagedNamespace)
 	target.Data = map[string][]byte{
-		"value": userData,
+		"value":  userData,
+		"format": []byte(formatEncoded),
 	}
 	target.StringData = source.StringData
 	target.Immutable = source.Immutable

--- a/pkg/controllers/secretsync/secret_sync_controller_test.go
+++ b/pkg/controllers/secretsync/secret_sync_controller_test.go
@@ -138,6 +138,12 @@ var _ = Describe("User Data Secret controller", func() {
 			if err != nil {
 				return false, err
 			}
+
+			_, ok := syncedUserDataSecret.Data["format"]
+			if !ok {
+				return false, nil
+			}
+
 			return bytes.Equal(syncedUserDataSecret.Data[capiUserDataKey], []byte(defaultSecretValue)), nil
 		}, timeout).Should(BeTrue())
 	})
@@ -153,6 +159,12 @@ var _ = Describe("User Data Secret controller", func() {
 			if err != nil {
 				return false, err
 			}
+
+			_, ok := syncedUserDataSecret.Data["format"]
+			if !ok {
+				return false, nil
+			}
+
 			return bytes.Equal(syncedUserDataSecret.Data[capiUserDataKey], []byte("managed one changed")), nil
 		}, timeout).Should(BeTrue())
 	})
@@ -170,6 +182,12 @@ var _ = Describe("User Data Secret controller", func() {
 			if err != nil {
 				return false, err
 			}
+
+			_, ok := syncedUserDataSecret.Data["format"]
+			if !ok {
+				return false, nil
+			}
+
 			return bytes.Equal(syncedUserDataSecret.Data[capiUserDataKey], []byte(defaultSecretValue)), nil
 		}, timeout).Should(BeTrue())
 


### PR DESCRIPTION
There is a consensus in the upstream community, that every provider, that supports ignition as its bootstrapping method should adopt field `format` with value `ignition` (encoded as base64 string) to indicate that the user intends to use this feature. If this value would be empty, the upstream providers operator would assume that the user wants to use the other option called `cloud-init` that we don't intend to support in the future.