### PR TITLE
OCPBUGS-22403: Disable CAPI Azure Infrastructure Provider

### DIFF
--- a/manifests/0000_30_cluster-api_02_providers.configmap.yaml
+++ b/manifests/0000_30_cluster-api_02_providers.configmap.yaml
@@ -9,10 +9,6 @@ data:
       type: InfrastructureProvider
       branch: release-4.15
       version: v2.2.4
-    - name: azure
-      type: InfrastructureProvider
-      branch: release-4.15
-      version: v1.11.2
     - name: gcp
       type: InfrastructureProvider
       branch: release-4.15

--- a/providers-list.yaml
+++ b/providers-list.yaml
@@ -6,10 +6,6 @@
   type: InfrastructureProvider
   branch: release-4.15
   version: v2.2.4
-- name: azure
-  type: InfrastructureProvider
-  branch: release-4.15
-  version: v1.11.2
 - name: gcp
   type: InfrastructureProvider
   branch: release-4.15


### PR DESCRIPTION
It is causing issues and we don't leverage it yet.