### PR TITLE
OCPBUGS-23467: manifests/0000_30_cluster-api_10_webhooks: Deletion manifest for validating-webhook-configuration

### DIFF
--- a/manifests/0000_30_cluster-api_10_webhooks.yaml
+++ b/manifests/0000_30_cluster-api_10_webhooks.yaml
@@ -100,3 +100,14 @@ webhooks:
         resources:
           - providers
     sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    release.openshift.io/delete: "true"
+  name: validating-webhook-configuration


### PR DESCRIPTION
The resource was renamed to `cluster-capi-operator` in 1096d5c8ee (#132), and that's a much more specific name for the cluster-scoped resource.  However, clusters upating from 4.15.0-ec.1 with the old name should not have two similar-but-not-quite-matching versions of the webhook configuration, or updates can stick with `cluster-api` ClusterOperator going `Degraded=True` on `SyncingFailed` [with][1]:

    Failed to resync for operator: 4.15.0-ec.2 because &{%!e(string=unable to reconcile CoreProvider: unable to create or update CoreProvider: Internal error occurred: failed calling webhook "vcoreprovider.operator.cluster.x-k8s.io": failed to call webhook: the server could not find the requested resource)}

This commit adds [a deletion manifest][2] to ask the cluster-version operator to remove the resource, to avoid leaking the old resource into new clusters.

[1]: https://issues.redhat.com/browse/OCPBUGS-23467
[2]: https://github.com/openshift/enhancements/blob/8a11b7085c69b078690d50958f541d2a817d85df/dev-guide/cluster-version-operator/dev/object-deletion.md