### PR TITLE
OCPBUGS-24301: openstack: Don't substitute manager container command

### DIFF
--- a/pkg/controllers/capiinstaller/component_customizer.go
+++ b/pkg/controllers/capiinstaller/component_customizer.go
@@ -28,8 +28,6 @@ func providerNameToImageKey(name string) string {
 		return "vsphere-cluster-api-controllers"
 	case "ibmcloud":
 		return "ibmcloud-cluster-api-controllers"
-	case "openstack":
-		return "openstack-cluster-api-controllers"
 	case "cluster-api":
 		return "cluster-capi-controllers"
 	default:
@@ -39,7 +37,7 @@ func providerNameToImageKey(name string) string {
 
 func providerNameToCommand(name string) string {
 	switch name {
-	case "aws", "azure", "gcp", "vsphere", "ibmcloud", "openstack":
+	case "aws", "azure", "gcp", "vsphere", "ibmcloud":
 		return "./bin/cluster-api-provider-" + name + "-controller-manager"
 	case "cluster-api":
 		return "./bin/cluster-api-controller-manager"


### PR DESCRIPTION
Also remove openstack from image replacement as openstack is not in cluster-capi-operator's image-references and does its own release image substitution anyway.