### PR TITLE
OCPBUGS-29476: manifests-gen: store core capi crds also in their own manifest

### DIFF
--- a/manifests-gen/customizations.go
+++ b/manifests-gen/customizations.go
@@ -18,11 +18,8 @@ import (
 type resourceKey string
 
 const (
-	crdKey        resourceKey = "crds"
-	otherKey      resourceKey = "other"
-	rbacKey       resourceKey = "rbac"
-	deploymentKey resourceKey = "deployment"
-	serviceKey    resourceKey = "service"
+	crdKey   resourceKey = "crds"
+	otherKey resourceKey = "other"
 )
 
 var (
@@ -46,11 +43,8 @@ var (
 
 func processObjects(objs []unstructured.Unstructured, providerName string) map[resourceKey][]unstructured.Unstructured {
 	resourceMap := map[resourceKey][]unstructured.Unstructured{}
-	finalObjs := []unstructured.Unstructured{}
-	rbacObjs := []unstructured.Unstructured{}
+	providerConfigMapObjs := []unstructured.Unstructured{}
 	crdObjs := []unstructured.Unstructured{}
-	deploymentObjs := []unstructured.Unstructured{}
-	serviceObjs := []unstructured.Unstructured{}
 
 	serviceSecretNames := findWebhookServiceSecretName(objs)
 
@@ -60,9 +54,7 @@ func processObjects(objs []unstructured.Unstructured, providerName string) map[r
 		case "ClusterRole", "Role", "ClusterRoleBinding", "RoleBinding", "ServiceAccount":
 			setOpenShiftAnnotations(obj, false)
 			setTechPreviewAnnotation(obj)
-			rbacObjs = append(rbacObjs, obj)
-
-			finalObjs = append(finalObjs, obj)
+			providerConfigMapObjs = append(providerConfigMapObjs, obj)
 		case "MutatingWebhookConfiguration":
 			// Explicitly remove defaulting webhooks for the cluster-api provider.
 			// We don't need CAPI to set any default to the cluster object because
@@ -70,41 +62,42 @@ func processObjects(objs []unstructured.Unstructured, providerName string) map[r
 			// For more information: https://issues.redhat.com/browse/OCPCLOUD-1506
 			removeClusterDefaultingWebhooks(&obj)
 			replaceCertManagerAnnotations(&obj)
-			finalObjs = append(finalObjs, obj)
+			providerConfigMapObjs = append(providerConfigMapObjs, obj)
 		case "ValidatingWebhookConfiguration":
 			removeClusterValidatingWebhooks(&obj)
 			replaceCertManagerAnnotations(&obj)
-			finalObjs = append(finalObjs, obj)
+			providerConfigMapObjs = append(providerConfigMapObjs, obj)
 		case "CustomResourceDefinition":
 			replaceCertManagerAnnotations(&obj)
 			removeConversionWebhook(&obj)
 			setOpenShiftAnnotations(obj, true)
 			setTechPreviewAnnotation(obj)
-			crdObjs = append(crdObjs, obj)
-			finalObjs = append(finalObjs, obj)
+			// Store Core CAPI CRDs in their own manifest to get them applied by CVO directly.
+			// We want these to be installed independently from whether the cluster-capi-operator is enabled,
+			// as other Openshift components rely on them.
+			if providerName == coreCAPIProvider {
+				crdObjs = append(crdObjs, obj)
+			} else {
+				providerConfigMapObjs = append(providerConfigMapObjs, obj)
+			}
 		case "Service":
 			replaceCertMangerServiceSecret(&obj, serviceSecretNames)
 			setOpenShiftAnnotations(obj, true)
 			setTechPreviewAnnotation(obj)
-			serviceObjs = append(serviceObjs, obj)
-			finalObjs = append(finalObjs, obj)
+			providerConfigMapObjs = append(providerConfigMapObjs, obj)
 		case "Deployment":
 			customizeDeployments(&obj)
 			if providerName == "operator" {
 				setOpenShiftAnnotations(obj, false)
 				setTechPreviewAnnotation(obj)
 			}
-			deploymentObjs = append(deploymentObjs, obj)
-			finalObjs = append(finalObjs, obj)
+			providerConfigMapObjs = append(providerConfigMapObjs, obj)
 		case "Certificate", "Issuer", "Namespace", "Secret": // skip
 		}
 	}
 
-	resourceMap[rbacKey] = rbacObjs
 	resourceMap[crdKey] = crdObjs
-	resourceMap[deploymentKey] = deploymentObjs
-	resourceMap[serviceKey] = serviceObjs
-	resourceMap[otherKey] = finalObjs
+	resourceMap[otherKey] = providerConfigMapObjs
 
 	return resourceMap
 }


### PR DESCRIPTION
Store Core CAPI CRDs also in their own manifest to get them applied by CVO directly. We want these to be installed independently from whether the cluster-capi-operator is enabled, as other Openshift components rely on them.