### PR TITLE
OCPBUGS-29519: manifests-gen: also add CustomNoUpgrade annotation value

### DIFF
--- a/manifests-gen/providers.go
+++ b/manifests-gen/providers.go
@@ -109,7 +109,7 @@ func (p *provider) writeProviderComponentsConfigmap(fileName string, objs []unst
 	}
 
 	annotations := openshiftAnnotations
-	annotations[techPreviewAnnotation] = techPreviewAnnotationValue
+	annotations[featureSetAnnotationKey] = featureSetAnnotationValue
 
 	cm := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
Together with the `TechPreviewNoUpgrade` `release.openshift.io/feature-set` we also need to add  `CustomNoUpgrade` as that is used in certain scenarios where CAPI provider ConfigMaps and CRDs are required.