### PR TITLE
OCPBUGS-29676: create openshift-cluster-api namespace in CustomNoUpgrade

### DIFF
--- a/manifests/0000_30_cluster-api_00_namespace.yaml
+++ b/manifests/0000_30_cluster-api_00_namespace.yaml
@@ -5,7 +5,7 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
-    release.openshift.io/feature-set: "TechPreviewNoUpgrade"    
+    release.openshift.io/feature-set: "CustomNoUpgrade,TechPreviewNoUpgrade"
     openshift.io/node-selector: ""
     workload.openshift.io/allowed: "management"
   labels:


### PR DESCRIPTION
The namespace is required in CustomNoUpgrade now that we are deploying the core CAPI provider ConfigMap since https://github.com/openshift/cluster-api/pull/196