### PR TITLE
OCPBUGS-28230: enforce termination message policy on all platform pods

### DIFF
--- a/manifests/0000_30_cluster-api_11_deployment.yaml
+++ b/manifests/0000_30_cluster-api_11_deployment.yaml
@@ -42,6 +42,7 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - name: images
           mountPath: /etc/cluster-api-config-images/


### PR DESCRIPTION
found in https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.16-e2e-azure-ovn-techpreview-serial/1785629293024382976

We want to be sure we are getting logs from failed containers.