### PR TITLE
OCPBUGS-33170: All containers must fallback to logs on error

### DIFF
--- a/manifests-gen/customizations.go
+++ b/manifests-gen/customizations.go
@@ -234,6 +234,9 @@ func customizeDeployments(obj *unstructured.Unstructured) {
 		if container.Name == "kube-rbac-proxy" {
 			container.Image = "registry.ci.openshift.org/openshift:kube-rbac-proxy"
 		}
+
+		// This helps with debugging and is enforced in OCP, see https://issues.redhat.com/browse/OCPBUGS-33170.
+		container.TerminationMessagePolicy = corev1.TerminationMessageFallbackToLogsOnError
 	}
 
 	if err := scheme.Convert(deployment, obj, nil); err != nil {


### PR DESCRIPTION
In 4.17, we are enforcing this value for all OpenShift containers via tests, link in bug comment. This helps with debugging to ensure we have logs available.