### PR TITLE
OCPBUGS-37718: fix: align openstack e2e branch

### DIFF
--- a/hack/e2e-openstack.sh
+++ b/hack/e2e-openstack.sh
@@ -7,6 +7,8 @@ echo "Running e2e-openstack.sh"
 unset GOFLAGS
 tmp="$(mktemp -d)"
 
-git clone --depth=1 "https://github.com/openshift/cluster-api-provider-openstack.git" "$tmp"
+echo "cloning github.com/openshift/cluster-api-provider-openstack at branch '$PULL_BASE_REF'"
+git clone --single-branch --branch="$PULL_BASE_REF" --depth=1 "https://github.com/openshift/cluster-api-provider-openstack.git" "$tmp"
 
+echo "running cluster-api-provider-openstack's: make e2e"
 exec make -C "$tmp/openshift" e2e


### PR DESCRIPTION
Align openstack e2e branch, as it would otherwise go out of sync with the go version used in the two projects.
Based on https://github.com/openshift/cluster-api-provider-aws/blob/master/openshift/e2e-tests.sh