### PR TITLE
OCPBUGS-39298: manifests-gen: fix: readd missing metadata

### DIFF
--- a/manifests-gen/providers.go
+++ b/manifests-gen/providers.go
@@ -180,7 +180,7 @@ func addComponentsToConfigMap(cm corev1.ConfigMap, objs []unstructured.Unstructu
 			"components-zstd": compressed.Bytes(),
 		}
 	} else {
-		cm.Data = map[string]string{"components": string(combined)}
+		cm.Data["components"] = string(combined)
 	}
 
 	return cm, nil


### PR DESCRIPTION
The transport configMap metadata would get entirely overridden when setting components rather than it being additive.

This is a regression introduced by #170 