### PR TITLE
fix: infracluster: do not attempt vsphere secret recreation

### DIFF
--- a/pkg/controllers/infracluster/vsphere.go
+++ b/pkg/controllers/infracluster/vsphere.go
@@ -139,6 +139,9 @@ func (r *InfraClusterController) ensureVSphereSecret(ctx context.Context, vspher
 
 	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(vSphereSecret), vSphereSecret); err != nil && !cerrors.IsNotFound(err) {
 		return fmt.Errorf("failed to get CAPI VSphere credentials secret: %w", err)
+	} else if err == nil {
+		// The secret already exists.
+		return nil
 	}
 
 	username, password, err := r.getVSphereCredentials(ctx, vsphereServerAddr)


### PR DESCRIPTION
Do not attempt vsphere secret recreation when it already exists.
Otherwise this yields `resourceVersion should not be set on objects to be created` errors.