### PR TITLE
OCPCLOUD-2750: Add fuzz conversion testing for MAPI2CAPI conversions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/onsi/gomega v1.33.1
 	github.com/openshift/api v0.0.0-20240909041644-5852b58f4b10
 	github.com/openshift/client-go v0.0.0-20240528061634-b054aa794d87
-	github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20240906160452-4c3bebacbb5b
+	github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20240923124618-33cbd9255614
 	github.com/openshift/cluster-control-plane-machine-set-operator v0.0.0-20240909043600-373ac49835bf
 	github.com/openshift/library-go v0.0.0-20240711192904-190fec8c3f09
 	github.com/pkg/errors v0.9.1
@@ -34,6 +34,10 @@ require (
 	sigs.k8s.io/cluster-api-provider-vsphere v1.10.0
 	sigs.k8s.io/controller-runtime v0.18.5
 	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20240531134648-6636df17d67b
+)
+
+require (
+	github.com/google/gofuzz v1.2.0
 	sigs.k8s.io/yaml v1.4.0
 )
 
@@ -134,7 +138,6 @@ require (
 	github.com/google/cel-go v0.17.8 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
-	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20240424215950-a892ee059fd6 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gordonklaus/ineffassign v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -419,8 +419,8 @@ github.com/openshift/api v0.0.0-20240909041644-5852b58f4b10 h1:/K3I8q4K+LDj0DfdT
 github.com/openshift/api v0.0.0-20240909041644-5852b58f4b10/go.mod h1:OOh6Qopf21pSzqNVCB5gomomBXb8o5sGKZxG2KNpaXM=
 github.com/openshift/client-go v0.0.0-20240528061634-b054aa794d87 h1:JtLhaGpSEconE+1IKmIgCOof/Len5ceG6H1pk43yv5U=
 github.com/openshift/client-go v0.0.0-20240528061634-b054aa794d87/go.mod h1:3IPD4U0qyovZS4EFady2kqY32m8lGcbs/Wx+yprg9z8=
-github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20240906160452-4c3bebacbb5b h1:OcX/ucLKa0XznPAtaopGB4V1lnaMyagwLQYhs+RpGO4=
-github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20240906160452-4c3bebacbb5b/go.mod h1:osVq9/R6qKHBQxDP4cYTvkgXVBKOMs1SOfPLFfn0m7A=
+github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20240923124618-33cbd9255614 h1:0dlbDVMjXnbpi+HZxgnmEiVZmPJXMBnRXj6k7Rq2ATI=
+github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20240923124618-33cbd9255614/go.mod h1:osVq9/R6qKHBQxDP4cYTvkgXVBKOMs1SOfPLFfn0m7A=
 github.com/openshift/cluster-control-plane-machine-set-operator v0.0.0-20240909043600-373ac49835bf h1:mfMmaD9+vZIZQq3MGXsS/AGHXekj4wIn3zc1Cs1EY8M=
 github.com/openshift/cluster-control-plane-machine-set-operator v0.0.0-20240909043600-373ac49835bf/go.mod h1:2fZsjZ3QSPkoMUc8QntXfeBb8AnvW+WIYwwQX8vmgvQ=
 github.com/openshift/library-go v0.0.0-20240711192904-190fec8c3f09 h1:2Ed1mxJTRFpbHIynxkuIyADeWdtyQ6NEZkTaf0wG39M=

--- a/pkg/conversion/capi2mapi/aws.go
+++ b/pkg/conversion/capi2mapi/aws.go
@@ -72,8 +72,8 @@ func FromMachineSetAndAWSMachineTemplateAndAWSCluster(ms *capiv1.MachineSet, mts
 		machineAndAWSMachineAndAWSCluster: &machineAndAWSMachineAndAWSCluster{
 			machine: &capiv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      ms.Spec.Template.Labels,
-					Annotations: ms.Spec.Template.Annotations,
+					Labels:      ms.Spec.Template.ObjectMeta.Labels,
+					Annotations: ms.Spec.Template.ObjectMeta.Annotations,
 				},
 				Spec: ms.Spec.Template.Spec,
 			},
@@ -238,7 +238,11 @@ func (m machineSetAndAWSMachineTemplateAndAWSCluster) ToMachineSet() (*mapiv1.Ma
 		errors = append(errors, err)
 	}
 
-	mapiMachineSet.Spec.Template.Spec.ProviderSpec.Value = mapaMachine.Spec.ProviderSpec.Value
+	mapiMachineSet.Spec.Template.Spec = mapaMachine.Spec
+
+	// Copy the labels and annotations from the Machine to the template.
+	mapiMachineSet.Spec.Template.ObjectMeta.Annotations = mapaMachine.ObjectMeta.Annotations
+	mapiMachineSet.Spec.Template.ObjectMeta.Labels = mapaMachine.ObjectMeta.Labels
 
 	if len(errors) > 0 {
 		return nil, warnings, utilerrors.NewAggregate(errors)

--- a/pkg/conversion/capi2mapi/aws.go
+++ b/pkg/conversion/capi2mapi/aws.go
@@ -106,7 +106,7 @@ func (m machineAndAWSMachineAndAWSCluster) toProviderSpec() (*mapiv1.AWSMachineP
 	}
 
 	mapiAWSMetadataOptions, warn, errs := convertAWSMetadataOptionsToMAPI(fldPath.Child("instanceMetadataOptions"), m.awsMachine.Spec.InstanceMetadataOptions)
-	if err != nil {
+	if errs != nil {
 		errors = append(errors, errs...)
 	}
 
@@ -131,16 +131,14 @@ func (m machineAndAWSMachineAndAWSCluster) toProviderSpec() (*mapiv1.AWSMachineP
 		IAMInstanceProfile: &mapiv1.AWSResourceReference{
 			ID: &m.awsMachine.Spec.IAMInstanceProfile,
 		},
-		UserDataSecret: &corev1.LocalObjectReference{
-			Name: ptr.Deref(m.machine.Spec.Bootstrap.DataSecretName, "worker-user-data"),
-		},
+		// UserDataSecret - Populated below.
 		// CredentialsSecret - TODO(OCPCLOUD-2713)
 		KeyName: m.awsMachine.Spec.SSHKeyName,
 		// DeviceIndex - TODO(OCPCLOUD-2707) Not currently supported in CAPA.
-		PublicIP: m.awsMachine.Spec.PublicIP,
-		// NetworkInterfaceType - TODO(OCPCLOUD-2708) Not currently supported in CAPA.
-		SecurityGroups: convertAWSSecurityGroupstoMAPI(m.awsMachine.Spec.AdditionalSecurityGroups), // OCPCLOUD-2712: We need to ensure that this is the correct way to convert the security groups.
-		Subnet:         convertAWSResourceReferenceToMAPI(ptr.Deref(m.awsMachine.Spec.Subnet, capav1.AWSResourceReference{})),
+		PublicIP:             m.awsMachine.Spec.PublicIP,
+		NetworkInterfaceType: mapiv1.AWSENANetworkInterfaceType,                                          // TODO(OCPCLOUD-2708) This is the default value for MAPA, but other values are not configurable in CAPA.
+		SecurityGroups:       convertAWSSecurityGroupstoMAPI(m.awsMachine.Spec.AdditionalSecurityGroups), // OCPCLOUD-2712: We need to ensure that this is the correct way to convert the security groups.
+		Subnet:               convertAWSResourceReferenceToMAPI(ptr.Deref(m.awsMachine.Spec.Subnet, capav1.AWSResourceReference{})),
 		Placement: mapiv1.Placement{
 			AvailabilityZone: ptr.Deref(m.machine.Spec.FailureDomain, ""),
 			Tenancy:          mapaTenancy,
@@ -153,6 +151,13 @@ func (m machineAndAWSMachineAndAWSCluster) toProviderSpec() (*mapiv1.AWSMachineP
 		PlacementGroupName:      m.awsMachine.Spec.PlacementGroupName,
 		PlacementGroupPartition: convertAWSPlacementGroupPartition(m.awsMachine.Spec.PlacementGroupPartition),
 		CapacityReservationID:   ptr.Deref(m.awsMachine.Spec.CapacityReservationID, ""),
+	}
+
+	userDataSecretName := ptr.Deref(m.machine.Spec.Bootstrap.DataSecretName, "")
+	if userDataSecretName != "" {
+		mapaProviderConfig.UserDataSecret = &corev1.LocalObjectReference{
+			Name: userDataSecretName,
+		}
 	}
 
 	// Below this line are fields not used from the CAPI AWSMachine.
@@ -283,19 +288,19 @@ func convertAWSMetadataOptionsToMAPI(fldPath *field.Path, capiMetadataOpts *capa
 		errors = append(errors, field.Invalid(fldPath.Child("httpTokens"), capiMetadataOpts.HTTPTokens, errUnsupportedHTTPTokensState))
 	}
 
-	if capiMetadataOpts.HTTPEndpoint != "enabled" {
+	if capiMetadataOpts.HTTPEndpoint != "" && capiMetadataOpts.HTTPEndpoint != "enabled" {
 		// This defaults to "enabled" in CAPI and on the AWS side, so if it's not "enabled", the user explicitly chose another option.
 		// TODO(OCPCLOUD-2710): We should implement this within MAPI to create feature parity.
 		errors = append(errors, field.Invalid(fldPath.Child("httpEndpoint"), capiMetadataOpts.HTTPEndpoint, "httpEndpoint values other than \"enabled\" are not supported"))
 	}
 
-	if capiMetadataOpts.HTTPPutResponseHopLimit != 1 {
+	if capiMetadataOpts.HTTPPutResponseHopLimit != 0 && capiMetadataOpts.HTTPPutResponseHopLimit != 1 {
 		// This defaults to 1 in CAPI and on the AWS side, so if it's not 1, the user explicitly chose another option.
 		// TODO(OCPCLOUD-2710): We should implement this within MAPI to create feature parity.
 		errors = append(errors, field.Invalid(fldPath.Child("httpPutResponseHopLimit"), capiMetadataOpts.HTTPPutResponseHopLimit, "httpPutResponseHopLimit values other than 1 are not supported"))
 	}
 
-	if capiMetadataOpts.InstanceMetadataTags != "disabled" {
+	if capiMetadataOpts.InstanceMetadataTags != "" && capiMetadataOpts.InstanceMetadataTags != "disabled" {
 		// This defaults to "disabled" in CAPI and on the AWS side, so if it's not "disabled", the user explicitly chose another option.
 		// TODO(OCPCLOUD-2710): We should implement this within MAPI to create feature parity.
 		errors = append(errors, field.Invalid(fldPath.Child("instanceMetadataTags"), capiMetadataOpts.InstanceMetadataTags, "instanceMetadataTags values other than \"disabled\" are not supported"))
@@ -384,34 +389,41 @@ func convertAWSTenancyToMAPI(fldPath *field.Path, capiTenancy string) (mapiv1.In
 
 func convertAWSBlockDeviceMappingSpecToMAPI(rootVolume *capav1.Volume, nonRootVolumes []capav1.Volume) []mapiv1.BlockDeviceMappingSpec {
 	blockDeviceMapping := []mapiv1.BlockDeviceMappingSpec{}
-	if rootVolume == nil {
-		return blockDeviceMapping
+
+	if rootVolume != nil && *rootVolume != (capav1.Volume{}) {
+		blockDeviceMapping = append(blockDeviceMapping, volumeToBlockDeviceMappingSpec(*rootVolume))
 	}
 
-	blockDeviceMapping = append(blockDeviceMapping, mapiv1.BlockDeviceMappingSpec{
-		EBS: &mapiv1.EBSBlockDeviceSpec{
-			VolumeSize: ptr.To(rootVolume.Size),
-			VolumeType: ptr.To(string(rootVolume.Type)),
-			Iops:       ptr.To(rootVolume.IOPS),
-			Encrypted:  rootVolume.Encrypted,
-			KMSKey:     convertKMSKeyToMAPI(rootVolume.EncryptionKey),
-		},
-	})
-
 	for _, volume := range nonRootVolumes {
-		blockDeviceMapping = append(blockDeviceMapping, mapiv1.BlockDeviceMappingSpec{
-			DeviceName: ptr.To(volume.DeviceName),
-			EBS: &mapiv1.EBSBlockDeviceSpec{
-				VolumeSize: ptr.To(volume.Size),
-				VolumeType: ptr.To(string(rootVolume.Type)),
-				Iops:       ptr.To(volume.IOPS),
-				Encrypted:  volume.Encrypted,
-				KMSKey:     convertKMSKeyToMAPI(volume.EncryptionKey),
-			},
-		})
+		blockDeviceMapping = append(blockDeviceMapping, volumeToBlockDeviceMappingSpec(volume))
 	}
 
 	return blockDeviceMapping
+}
+
+func volumeToBlockDeviceMappingSpec(volume capav1.Volume) mapiv1.BlockDeviceMappingSpec {
+	bdm := mapiv1.BlockDeviceMappingSpec{
+		EBS: &mapiv1.EBSBlockDeviceSpec{
+			DeleteOnTermination: ptr.To(true), // This is forced to true for now as CAPI doesn't support changing it.
+			VolumeSize:          ptr.To(volume.Size),
+			Encrypted:           volume.Encrypted,
+			KMSKey:              convertKMSKeyToMAPI(volume.EncryptionKey),
+		},
+	}
+
+	if volume.DeviceName != "" {
+		bdm.DeviceName = ptr.To(volume.DeviceName)
+	}
+
+	if volume.Type != "" {
+		bdm.EBS.VolumeType = ptr.To(string(volume.Type))
+	}
+
+	if volume.IOPS != 0 {
+		bdm.EBS.Iops = ptr.To(volume.IOPS)
+	}
+
+	return bdm
 }
 
 func convertKMSKeyToMAPI(kmsKey string) mapiv1.AWSResourceReference {

--- a/pkg/conversion/capi2mapi/machine.go
+++ b/pkg/conversion/capi2mapi/machine.go
@@ -116,6 +116,8 @@ func setCAPIManagedNodeLabelsToMAPINodeLabels(capiNodeLabels map[string]string, 
 	for k, v := range capiNodeLabels {
 		if conversionutil.IsCAPIManagedLabel(k) {
 			mapiNodeLabels[k] = v
+
+			delete(capiNodeLabels, k)
 		}
 	}
 }

--- a/pkg/conversion/capi2mapi/machineset.go
+++ b/pkg/conversion/capi2mapi/machineset.go
@@ -25,20 +25,11 @@ import (
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
-const (
-	mapiMachineSetAPIVersion = "machine.openshift.io/v1beta1"
-	mapiMachineSetKind       = "MachineSet"
-)
-
 // fromCAPIMachineSetToMAPIMachineSet takes a CAPI MachineSet and returns a converted MAPI MachineSet.
 func fromCAPIMachineSetToMAPIMachineSet(capiMachineSet *capiv1.MachineSet) (*mapiv1.MachineSet, error) {
 	errs := field.ErrorList{}
 
 	mapiMachineSet := &mapiv1.MachineSet{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       mapiMachineSetKind,
-			APIVersion: mapiMachineSetAPIVersion,
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        capiMachineSet.Name,
 			Namespace:   capiMachineSet.Namespace,

--- a/pkg/conversion/mapi2capi/aws_fuzz_test.go
+++ b/pkg/conversion/mapi2capi/aws_fuzz_test.go
@@ -1,0 +1,190 @@
+/*
+Copyright 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package mapi2capi_test
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	fuzz "github.com/google/gofuzz"
+
+	configv1 "github.com/openshift/api/config/v1"
+	mapiv1 "github.com/openshift/api/machine/v1beta1"
+	"github.com/openshift/cluster-capi-operator/pkg/conversion/capi2mapi"
+	"github.com/openshift/cluster-capi-operator/pkg/conversion/mapi2capi"
+	conversiontest "github.com/openshift/cluster-capi-operator/pkg/conversion/test"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/utils/ptr"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	capav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+var _ = Describe("AWS Fuzz (mapi2capi)", func() {
+	infra := &configv1.Infrastructure{
+		Spec: configv1.InfrastructureSpec{},
+		Status: configv1.InfrastructureStatus{
+			InfrastructureName: "sample-cluster-name",
+		},
+	}
+
+	infraCluster := &capav1.AWSCluster{
+		Spec: capav1.AWSClusterSpec{
+			Region: "us-east-1",
+		},
+	}
+
+	fromMachineAndAWSMachineAndAWSCluster := func(machine *capiv1.Machine, infraMachine client.Object, infraCluster client.Object) capi2mapi.MachineAndInfrastructureMachine {
+		awsMachine, ok := infraMachine.(*capav1.AWSMachine)
+		Expect(ok).To(BeTrue(), "input infra machine should be of type %T, got %T", &capav1.AWSMachine{}, infraMachine)
+
+		awsCluster, ok := infraCluster.(*capav1.AWSCluster)
+		Expect(ok).To(BeTrue(), "input infra cluster should be of type %T, got %T", &capav1.AWSCluster{}, infraCluster)
+
+		return capi2mapi.FromMachineAndAWSMachineAndAWSCluster(machine, awsMachine, awsCluster)
+	}
+
+	conversiontest.MAPI2CAPIRoundTripFuzzTest(
+		scheme,
+		infra,
+		infraCluster,
+		mapi2capi.FromAWSMachineAndInfra,
+		fromMachineAndAWSMachineAndAWSCluster,
+		conversiontest.ObjectMetaFuzzerFuncs("openshift-machine-api"),
+		conversiontest.MAPIMachineFuzzerFuncs(&mapiv1.AWSMachineProviderConfig{}, awsProviderIDFuzzer),
+		awsProviderSpecFuzzerFuncs,
+	)
+})
+
+func awsProviderIDFuzzer(c fuzz.Continue) string {
+	return "aws:///us-west-2a/i-" + strings.ReplaceAll(c.RandString(), "/", "")
+}
+
+//nolint:funlen
+func awsProviderSpecFuzzerFuncs(codecs runtimeserializer.CodecFactory) []interface{} {
+	return []interface{}{
+		func(nit *mapiv1.AWSNetworkInterfaceType, c fuzz.Continue) {
+			// Use this value always as this field doesn't currently get converted.
+			// The default value is always true in CAPI.
+			// TODO(OCPCLOUD-2708): Make this randomly choose between the three valid values.
+			*nit = mapiv1.AWSENANetworkInterfaceType
+		},
+		func(amiRef *mapiv1.AWSResourceReference, c fuzz.Continue) {
+			var amiID string
+			c.Fuzz(&amiID)
+
+			*amiRef = mapiv1.AWSResourceReference{
+				ID: &amiID,
+			}
+		},
+		func(bdm *mapiv1.BlockDeviceMappingSpec, c fuzz.Continue) {
+			c.FuzzNoCustom(bdm)
+
+			// Fuzz required fields so that they are not empty.
+			if bdm.EBS == nil {
+				ebs := &mapiv1.EBSBlockDeviceSpec{}
+				c.Fuzz(ebs)
+				bdm.EBS = ebs
+			}
+
+			// Clear fields that are not supported by conversion in the block device mapping.
+			// These fields exist in the API but are not implemented in MAPA.
+			bdm.NoDevice = nil
+			bdm.VirtualName = nil
+		},
+		func(ebs *mapiv1.EBSBlockDeviceSpec, c fuzz.Continue) {
+			c.FuzzNoCustom(ebs)
+
+			// Fuzz required fields so that they are not empty.
+			if ebs.VolumeSize == nil {
+				ebs.VolumeSize = ptr.To(c.Int63())
+			}
+
+			// Force DeleteOnTermination to be true.
+			ebs.DeleteOnTermination = ptr.To(true)
+
+			// Clear pointers to empty fields.
+			if ebs.VolumeType != nil && *ebs.VolumeType == "" {
+				ebs.VolumeType = nil
+			}
+			if ebs.Iops != nil && *ebs.Iops == 0 {
+				ebs.Iops = nil
+			}
+		},
+		func(tenancy *mapiv1.InstanceTenancy, c fuzz.Continue) {
+			switch c.Int31n(4) {
+			case 0:
+				*tenancy = mapiv1.DefaultTenancy
+			case 1:
+				*tenancy = mapiv1.DedicatedTenancy
+			case 2:
+				*tenancy = mapiv1.HostTenancy
+			case 3:
+				*tenancy = ""
+			}
+		},
+		func(msa *mapiv1.MetadataServiceAuthentication, c fuzz.Continue) {
+			switch c.Intn(3) {
+			case 0:
+				*msa = ""
+			case 1:
+				*msa = mapiv1.MetadataServiceAuthenticationOptional
+			case 2:
+				*msa = mapiv1.MetadataServiceAuthenticationRequired
+			}
+		},
+		func(ps *mapiv1.AWSMachineProviderConfig, c fuzz.Continue) {
+			c.FuzzNoCustom(ps)
+
+			// The type meta is always set to these values by the conversion.
+			ps.Kind = "AWSMachineProviderConfig"
+			ps.APIVersion = "machine.openshift.io/v1beta1"
+
+			// region must match the input AWSCluster so force it here.
+			ps.Placement.Region = "us-east-1"
+
+			// Clear fields that are not supported in the provider spec.
+			ps.DeviceIndex = 0
+			ps.LoadBalancers = nil
+			ps.ObjectMeta = metav1.ObjectMeta{}
+			ps.CredentialsSecret = nil
+
+			// At lest one device mapping must have no device name.
+			rootFound := false
+			for i := range ps.BlockDevices {
+				if ps.BlockDevices[i].DeviceName == nil {
+					rootFound = true
+					break
+				}
+			}
+
+			if !rootFound && len(ps.BlockDevices) > 0 {
+				ps.BlockDevices[0].DeviceName = nil
+			}
+
+			// Clear pointers to empty structs.
+			if ps.UserDataSecret != nil && ps.UserDataSecret.Name == "" {
+				ps.UserDataSecret = nil
+			}
+		},
+	}
+}

--- a/pkg/conversion/mapi2capi/aws_fuzz_test.go
+++ b/pkg/conversion/mapi2capi/aws_fuzz_test.go
@@ -53,26 +53,52 @@ var _ = Describe("AWS Fuzz (mapi2capi)", func() {
 		},
 	}
 
-	fromMachineAndAWSMachineAndAWSCluster := func(machine *capiv1.Machine, infraMachine client.Object, infraCluster client.Object) capi2mapi.MachineAndInfrastructureMachine {
-		awsMachine, ok := infraMachine.(*capav1.AWSMachine)
-		Expect(ok).To(BeTrue(), "input infra machine should be of type %T, got %T", &capav1.AWSMachine{}, infraMachine)
+	Context("AWSMachine Conversion", func() {
+		fromMachineAndAWSMachineAndAWSCluster := func(machine *capiv1.Machine, infraMachine client.Object, infraCluster client.Object) capi2mapi.MachineAndInfrastructureMachine {
+			awsMachine, ok := infraMachine.(*capav1.AWSMachine)
+			Expect(ok).To(BeTrue(), "input infra machine should be of type %T, got %T", &capav1.AWSMachine{}, infraMachine)
 
-		awsCluster, ok := infraCluster.(*capav1.AWSCluster)
-		Expect(ok).To(BeTrue(), "input infra cluster should be of type %T, got %T", &capav1.AWSCluster{}, infraCluster)
+			awsCluster, ok := infraCluster.(*capav1.AWSCluster)
+			Expect(ok).To(BeTrue(), "input infra cluster should be of type %T, got %T", &capav1.AWSCluster{}, infraCluster)
 
-		return capi2mapi.FromMachineAndAWSMachineAndAWSCluster(machine, awsMachine, awsCluster)
-	}
+			return capi2mapi.FromMachineAndAWSMachineAndAWSCluster(machine, awsMachine, awsCluster)
+		}
 
-	conversiontest.MAPI2CAPIRoundTripFuzzTest(
-		scheme,
-		infra,
-		infraCluster,
-		mapi2capi.FromAWSMachineAndInfra,
-		fromMachineAndAWSMachineAndAWSCluster,
-		conversiontest.ObjectMetaFuzzerFuncs("openshift-machine-api"),
-		conversiontest.MAPIMachineFuzzerFuncs(&mapiv1.AWSMachineProviderConfig{}, awsProviderIDFuzzer),
-		awsProviderSpecFuzzerFuncs,
-	)
+		conversiontest.MAPI2CAPIMachineRoundTripFuzzTest(
+			scheme,
+			infra,
+			infraCluster,
+			mapi2capi.FromAWSMachineAndInfra,
+			fromMachineAndAWSMachineAndAWSCluster,
+			conversiontest.ObjectMetaFuzzerFuncs("openshift-machine-api"),
+			conversiontest.MAPIMachineFuzzerFuncs(&mapiv1.AWSMachineProviderConfig{}, awsProviderIDFuzzer),
+			awsProviderSpecFuzzerFuncs,
+		)
+	})
+
+	Context("AWSMachineSet Conversion", func() {
+		fromMachineSetAndAWSMachineTemplateAndAWSCluster := func(machineSet *capiv1.MachineSet, infraMachineTemplate client.Object, infraCluster client.Object) capi2mapi.MachineSetAndMachineTemplate {
+			awsMachineTemplate, ok := infraMachineTemplate.(*capav1.AWSMachineTemplate)
+			Expect(ok).To(BeTrue(), "input infra machine template should be of type %T, got %T", &capav1.AWSMachineTemplate{}, infraMachineTemplate)
+
+			awsCluster, ok := infraCluster.(*capav1.AWSCluster)
+			Expect(ok).To(BeTrue(), "input infra cluster should be of type %T, got %T", &capav1.AWSCluster{}, infraCluster)
+
+			return capi2mapi.FromMachineSetAndAWSMachineTemplateAndAWSCluster(machineSet, awsMachineTemplate, awsCluster)
+		}
+
+		conversiontest.MAPI2CAPIMachineSetRoundTripFuzzTest(
+			scheme,
+			infra,
+			infraCluster,
+			mapi2capi.FromAWSMachineSetAndInfra,
+			fromMachineSetAndAWSMachineTemplateAndAWSCluster,
+			conversiontest.ObjectMetaFuzzerFuncs("openshift-machine-api"),
+			conversiontest.MAPIMachineFuzzerFuncs(&mapiv1.AWSMachineProviderConfig{}, awsProviderIDFuzzer),
+			conversiontest.MAPIMachineSetFuzzerFuncs(),
+			awsProviderSpecFuzzerFuncs,
+		)
+	})
 })
 
 func awsProviderIDFuzzer(c fuzz.Continue) string {

--- a/pkg/conversion/mapi2capi/aws_test.go
+++ b/pkg/conversion/mapi2capi/aws_test.go
@@ -55,5 +55,4 @@ var _ = Describe("mapi2capi AWS", func() {
 		Expect(capiMachineSet).To(Not(BeNil()), "should not have a nil CAPI MachineSet")
 		Expect(capiInfraMachineTemplate).To(Not(BeNil()), "should not have a nil CAPI MachineTemplate")
 	})
-
 })

--- a/pkg/conversion/mapi2capi/machine.go
+++ b/pkg/conversion/mapi2capi/machine.go
@@ -75,6 +75,10 @@ func fromMAPIMachineToCAPIMachine(mapiMachine *mapiv1.Machine) (*capiv1.Machine,
 		}
 	}
 
+	if capiMachine.Labels == nil {
+		capiMachine.Labels = map[string]string{}
+	}
+
 	errs = append(errs, setMAPINodeLabelsToCAPIManagedNodeLabels(field.NewPath("spec", "metadata", "labels"), mapiMachine.Spec.ObjectMeta.Labels, capiMachine.Labels)...)
 
 	// Unused fields - Below this line are fields not used from the MAPI Machine.
@@ -141,27 +145,38 @@ func handleUnsupportedMachineFields(spec mapiv1.MachineSpec) field.ErrorList {
 
 	fldPath := field.NewPath("spec")
 
-	// ObjectMeta related fields should never get converted (aside from labels and annotations).
-	// They are meaningless in MAPI and don't contribute to the logic of the product.
-	if spec.ObjectMeta.Name != "" {
-		errs = append(errs, field.Invalid(fldPath.Child("metadata", "name"), spec.ObjectMeta.Name, "name is not supported"))
-	}
-
-	if spec.ObjectMeta.GenerateName != "" {
-		errs = append(errs, field.Invalid(fldPath.Child("metadata", "generateName"), spec.ObjectMeta.GenerateName, "generateName is not supported"))
-	}
-
-	if spec.ObjectMeta.Namespace != "" {
-		errs = append(errs, field.Invalid(fldPath.Child("metadata", "namespace"), spec.ObjectMeta.Namespace, "namespace is not supported"))
-	}
-
-	if len(spec.ObjectMeta.OwnerReferences) > 0 {
-		errs = append(errs, field.Invalid(fldPath.Child("metadata", "ownerReferences"), spec.ObjectMeta.OwnerReferences, "ownerReferences are not supported"))
-	}
+	errs = append(errs, handleUnsupportedMAPIObjectMetaFields(fldPath.Child("metadata"), spec.ObjectMeta)...)
 
 	// TODO(OCPCLOUD-2680): Taints are not supported by CAPI. add support for them via CAPI BootstrapConfig + minimal bootstrap controller.
 	if len(spec.Taints) > 0 {
 		errs = append(errs, field.Invalid(fldPath.Child("taints"), spec.Taints, "taints are not currently supported"))
+	}
+
+	return errs
+}
+
+// handleUnsupportedMAPIObjectMetaFields checks for unsupported MAPI metadta fields and returns a list of errors
+// if any of them are currently set.
+// This is used to prevent usage of these fields in both the Machine and MachineSet specs.
+func handleUnsupportedMAPIObjectMetaFields(fldPath *field.Path, objectMeta mapiv1.ObjectMeta) field.ErrorList {
+	var errs field.ErrorList
+
+	// ObjectMeta related fields should never get converted (aside from labels and annotations).
+	// They are meaningless in MAPI and don't contribute to the logic of the product.
+	if objectMeta.Name != "" {
+		errs = append(errs, field.Invalid(fldPath.Child("name"), objectMeta.Name, "name is not supported"))
+	}
+
+	if objectMeta.GenerateName != "" {
+		errs = append(errs, field.Invalid(fldPath.Child("generateName"), objectMeta.GenerateName, "generateName is not supported"))
+	}
+
+	if objectMeta.Namespace != "" {
+		errs = append(errs, field.Invalid(fldPath.Child("namespace"), objectMeta.Namespace, "namespace is not supported"))
+	}
+
+	if len(objectMeta.OwnerReferences) > 0 {
+		errs = append(errs, field.Invalid(fldPath.Child("ownerReferences"), objectMeta.OwnerReferences, "ownerReferences are not supported"))
 	}
 
 	return errs

--- a/pkg/conversion/mapi2capi/machine.go
+++ b/pkg/conversion/mapi2capi/machine.go
@@ -67,8 +67,12 @@ func fromMAPIMachineToCAPIMachine(mapiMachine *mapiv1.Machine) (*capiv1.Machine,
 
 	// lifecycleHooks are handled via an annotation in Cluster API.
 	lifecycleAnnotations := getCAPILifecycleHookAnnotations(mapiMachine.Spec.LifecycleHooks)
-	for key, value := range lifecycleAnnotations {
-		capiMachine.Annotations[key] = value
+	if capiMachine.Annotations == nil {
+		capiMachine.Annotations = lifecycleAnnotations
+	} else {
+		for key, value := range lifecycleAnnotations {
+			capiMachine.Annotations[key] = value
+		}
 	}
 
 	errs = append(errs, setMAPINodeLabelsToCAPIManagedNodeLabels(field.NewPath("spec", "metadata", "labels"), mapiMachine.Spec.ObjectMeta.Labels, capiMachine.Labels)...)

--- a/pkg/conversion/mapi2capi/machineset.go
+++ b/pkg/conversion/mapi2capi/machineset.go
@@ -59,6 +59,8 @@ func fromMAPIMachineSetToCAPIMachineSet(mapiMachineSet *mapiv1.MachineSet) (*cap
 
 	// Unused fields - Below this line are fields not used from the MAPI MachineSet.
 
+	errs = append(errs, handleUnsupportedMAPIObjectMetaFields(field.NewPath("spec", "template", "metadata"), mapiMachineSet.Spec.Template.ObjectMeta)...)
+
 	// AuthoritativeAPI - Ignore, this is part of the conversion mechanism.
 
 	return capiMachineSet, errs.ToAggregate()

--- a/pkg/conversion/mapi2capi/suite_test.go
+++ b/pkg/conversion/mapi2capi/suite_test.go
@@ -13,16 +13,33 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package mapi2capi
+package mapi2capi_test
 
 import (
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	kubescheme "k8s.io/client-go/kubernetes/scheme"
+
+	mapiv1 "github.com/openshift/api/machine/v1beta1"
 )
 
-func TestAPIs(t *testing.T) {
+var scheme *runtime.Scheme
+
+func init() {
+	// Register the scheme for the test.
+	// This must be done before the tests are run as the fuzzer is needed before the test tree is compiled.
+	scheme = kubescheme.Scheme
+	if err := mapiv1.AddToScheme(scheme); err != nil {
+		panic(fmt.Sprintf("failed to add machine scheme: %v", err))
+	}
+}
+
+func TestFuzz(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "MAPI2CAPI Suite")
+	RunSpecs(t, "MAPI2CAPI Fuzz Suite")
 }

--- a/pkg/conversion/test/fuzz.go
+++ b/pkg/conversion/test/fuzz.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package fuzz
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	fuzz "github.com/google/gofuzz"
+
+	configv1 "github.com/openshift/api/config/v1"
+	mapiv1 "github.com/openshift/api/machine/v1beta1"
+	"github.com/openshift/cluster-api-actuator-pkg/testutils"
+	"github.com/openshift/cluster-capi-operator/pkg/conversion/capi2mapi"
+	"github.com/openshift/cluster-capi-operator/pkg/conversion/mapi2capi"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
+	metafuzzer "k8s.io/apimachinery/pkg/apis/meta/fuzzer"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/utils/ptr"
+
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+// CAPI2MAPIConverterConstructor is a function that constructs a CAPI to MAPI converter.
+// Since the CAPI to MAPI conversion relies on different types, it is expected that the constructor is wrapped in a closure
+// that handles type assertions to fit the interface.
+type CAPI2MAPIConverterConstructor func(*capiv1.Machine, client.Object, client.Object) capi2mapi.MachineAndInfrastructureMachine
+
+// MAPI2CAPIConverterConstructor is a function that constructs a MAPI to CAPI converter.
+type MAPI2CAPIConverterConstructor func(*mapiv1.Machine, *configv1.Infrastructure) mapi2capi.Machine
+
+// StringFuzzer is a function that returns a random string.
+type StringFuzzer func(fuzz.Continue) string
+
+// mapiToCapiFuzzInput is a struct that holds the input for the MAPI to CAPI fuzz test.
+type mapiToCapiFuzzInput struct {
+	machine                  *mapiv1.Machine
+	infra                    *configv1.Infrastructure
+	infraCluster             client.Object
+	mapiConverterConstructor MAPI2CAPIConverterConstructor
+	capiConverterConstructor CAPI2MAPIConverterConstructor
+}
+
+// MAPI2CAPIRoundTripFuzzTest is a generic test that can be used to test roundtrip conversion between MAPI and CAPI objects.
+// It leverages fuzz testing to generate random MAPI objects and then converts them to CAPI objects and back to MAPI objects.
+// The test then compares the original MAPI object with the final MAPI object to ensure that the conversion is lossless.
+// Any lossy conversions must be accounted for within the fuzz functions passed in.
+func MAPI2CAPIRoundTripFuzzTest(scheme *runtime.Scheme, infra *configv1.Infrastructure, infraCluster client.Object, mapiConverter MAPI2CAPIConverterConstructor, capiConverter CAPI2MAPIConverterConstructor, fuzzerFuncs ...fuzzer.FuzzerFuncs) {
+	machineFuzzInputs := []TableEntry{}
+	fz := getFuzzer(scheme, fuzzerFuncs...)
+
+	for i := 0; i < 1000; i++ {
+		m := &mapiv1.Machine{}
+		fz.Fuzz(m)
+
+		in := mapiToCapiFuzzInput{
+			machine:                  m,
+			infra:                    infra,
+			infraCluster:             infraCluster,
+			mapiConverterConstructor: mapiConverter,
+			capiConverterConstructor: capiConverter,
+		}
+
+		machineFuzzInputs = append(machineFuzzInputs, Entry(fmt.Sprintf("%d", i), in))
+	}
+
+	DescribeTable("should be able to roundtrip fuzzed Machines", func(in mapiToCapiFuzzInput) {
+		mapiConverter := in.mapiConverterConstructor(in.machine, in.infra)
+
+		capiMachine, infraMachine, warnings, err := mapiConverter.ToMachineAndInfrastructureMachine()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(warnings).To(BeEmpty())
+
+		capiConverter := in.capiConverterConstructor(capiMachine, infraMachine, in.infraCluster)
+
+		mapiMachine, warnings, err := capiConverter.ToMachine()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(warnings).To(BeEmpty())
+
+		// Break down the comparison to make it easier to debug sections that are failing conversion.
+
+		// Do not match on status yet, we do not support status conversion.
+		// Expect(mapiMachine.Status).To(Equal(in.machine.Status))
+
+		Expect(mapiMachine.TypeMeta).To(Equal(in.machine.TypeMeta))
+		Expect(mapiMachine.ObjectMeta).To(Equal(in.machine.ObjectMeta))
+		Expect(mapiMachine.Spec).To(WithTransform(ignoreProviderSpec, testutils.MatchViaJSON(ignoreProviderSpec(in.machine.Spec))))
+		Expect(mapiMachine.Spec.ProviderSpec.Value.Raw).To(MatchJSON(in.machine.Spec.ProviderSpec.Value.Raw))
+	}, machineFuzzInputs)
+}
+
+// getFuzzer returns a new fuzzer to be used for testing.
+func getFuzzer(scheme *runtime.Scheme, funcs ...fuzzer.FuzzerFuncs) *fuzz.Fuzzer {
+	funcs = append([]fuzzer.FuzzerFuncs{
+		metafuzzer.Funcs,
+	}, funcs...)
+
+	return fuzzer.FuzzerFor(
+		fuzzer.MergeFuzzerFuncs(funcs...),
+		rand.NewSource(rand.Int63()), //nolint:gosec
+		runtimeserializer.NewCodecFactory(scheme),
+	)
+}
+
+// ignoreProviderSpec returns a copy of the MachineSpec with the ProviderSpec field set to nil.
+// This is used so that we can separate the comparison of the ProviderSpec field.
+func ignoreProviderSpec(in mapiv1.MachineSpec) mapiv1.MachineSpec {
+	out := in.DeepCopy()
+	out.ProviderSpec.Value = nil
+
+	return *out
+}
+
+// ObjectMetaFuzzerFuncs returns a set of fuzzer functions that can be used to fuzz ObjectMeta objects.
+// The namespace is forced to the provided namespace as the conversion always sets specific namespaces.
+// Fields that are not required for conversion are cleared.
+func ObjectMetaFuzzerFuncs(namespace string) fuzzer.FuzzerFuncs {
+	return func(codecs runtimeserializer.CodecFactory) []interface{} {
+		return []interface{}{
+			func(o *metav1.ObjectMeta, c fuzz.Continue) {
+				c.FuzzNoCustom(o)
+
+				// Force the namespace else the conversion will fail as it always sets the namespaces deliberately.
+				o.Namespace = namespace
+
+				// Clear fields that are not required for conversion.
+				o.GenerateName = ""
+				o.SelfLink = "" //nolint:staticcheck
+				o.UID = ""
+				o.ResourceVersion = ""
+				o.Generation = 0
+				o.CreationTimestamp = metav1.Time{}
+				o.DeletionTimestamp = nil
+				o.DeletionGracePeriodSeconds = nil
+				o.Finalizers = nil // Finalizers are handled outside of the conversion library.
+				o.ManagedFields = nil
+
+				// Clear fields that are not currently supported in the conversion.
+				o.OwnerReferences = nil // TODO(OCPCLOUD-2716)
+
+				// Annotations and labels maps should be non-nil (Since the conversion initialises them).
+				if o.Annotations == nil {
+					o.Annotations = map[string]string{}
+				}
+				if o.Labels == nil {
+					o.Labels = map[string]string{}
+				}
+			},
+		}
+	}
+}
+
+// MAPIMachineFuzzerFuncs returns a set of fuzzer functions that can be used to fuzz MachineSpec objects.
+// The providerSpec should be a pointer to a providerSpec type for the platform being tested.
+// This will be fuzzed and then injected into the MachineSpec as a RawExtension.
+// The providerIDFuzz function should be a function that returns a valid providerID for the platform being tested.
+func MAPIMachineFuzzerFuncs(providerSpec runtime.Object, providerIDFuzz StringFuzzer) fuzzer.FuzzerFuncs {
+	return func(codecs runtimeserializer.CodecFactory) []interface{} {
+		return []interface{}{
+			// MAPI to CAPI conversion functions.
+			func(m *mapiv1.MachineSpec, c fuzz.Continue) {
+				c.FuzzNoCustom(m)
+				c.Fuzz(providerSpec)
+
+				bytes, err := json.Marshal(providerSpec)
+				if err != nil {
+					panic(err)
+				}
+
+				// Set the bytes field on the RawExtension
+				m.ProviderSpec.Value = &runtime.RawExtension{
+					Raw: bytes,
+				}
+
+				// Clear fields that are not supported in the machine spec.
+				m.ObjectMeta.Name = ""
+				m.ObjectMeta.GenerateName = ""
+				m.ObjectMeta.Namespace = ""
+				m.ObjectMeta.OwnerReferences = nil
+				m.AuthoritativeAPI = ""
+
+				// Clear fields that are not yet supported in the conversion.
+				// TODO(OCPCLOUD-2680): For taints and annotations.
+				m.ObjectMeta.Annotations = nil
+				m.Taints = nil
+
+				// Set the providerID to a valid providerID that will at least pass through the conversion.
+				m.ProviderID = ptr.To(providerIDFuzz(c))
+
+				// Labels to go onto the node have to have specific prefixes.
+				m.ObjectMeta.Labels = map[string]string{
+					"node-role.kubernetes.io/worker":                                                "",
+					"node-restriction.kubernetes.io/" + strings.ReplaceAll(c.RandString(), "/", ""): c.RandString(),
+					"node.cluster.x-k8s.io/" + strings.ReplaceAll(c.RandString(), "/", ""):          c.RandString(),
+					strings.ReplaceAll(c.RandString(), "/", "") + ".node-restriction.kubernetes.io": c.RandString(),
+					strings.ReplaceAll(c.RandString(), "/", "") + ".node.cluster.x-k8s.io":          c.RandString(),
+				}
+			},
+			func(hooks *mapiv1.LifecycleHooks, c fuzz.Continue) {
+				c.FuzzNoCustom(hooks)
+
+				// Clear the slices if they are empty.
+				// This aids in comparison with the conversion which doesn't initialise the slices.
+				if len(hooks.PreTerminate) == 0 {
+					hooks.PreTerminate = nil
+				}
+
+				if len(hooks.PreDrain) == 0 {
+					hooks.PreDrain = nil
+				}
+			},
+		}
+	}
+}

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/matchers.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/matchers.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package testutils
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/types"
+)
+
+// MatchViaJSON returns a custom matcher to check equality of an object by converting it to JSON.
+// Converting to JSON avoids the need to implement a custom matcher for each type.
+// This is useful for comparing objects that are not directly comparable (maps may have differing orders).
+func MatchViaJSON(expected interface{}) types.GomegaMatcher {
+	return &matchViaJSON{
+		expected: expected,
+	}
+}
+
+// matchViaJSON is the implementation of the MatchViaJSON matcher.
+// It holds a generic expected object to compare against.
+type matchViaJSON struct {
+	expected interface{}
+}
+
+// Match implements the matching logic for the MatchViaJSON matcher.
+// It converts the input objects to JSON and compares them.
+func (m matchViaJSON) Match(actual interface{}) (success bool, err error) {
+	expectedMachineJSON, err := json.Marshal(m.expected)
+	if err != nil {
+		return false, err
+	}
+
+	actualMachineJSON, err := json.Marshal(actual)
+	if err != nil {
+		return false, err
+	}
+
+	return gomega.MatchJSON(expectedMachineJSON).Match(actualMachineJSON)
+}
+
+// FailureMessage implements the failure message for the MatchViaJSON matcher.
+func (m matchViaJSON) FailureMessage(actual interface{}) (message string) {
+	actualString, expectedString, _ := m.prettyPrint(actual)
+	return format.Message(actualString, "to match JSON of", expectedString)
+}
+
+// NegatedFailureMessage implements the negated failure message for the MatchViaJSON matcher.
+func (m matchViaJSON) NegatedFailureMessage(actual interface{}) (message string) {
+	actualString, expectedString, _ := m.prettyPrint(actual)
+	return format.Message(actualString, "not to match JSON of", expectedString)
+}
+
+// prettyPrint formats the actual and expected objects as JSON.
+// This is somewhat copied from the gomega.MatchJSON matcher so that the output looks similar.
+func (m *matchViaJSON) prettyPrint(actual interface{}) (actualFormatted, expectedFormatted string, err error) {
+	expectedMachineJSON, err := json.Marshal(m.expected)
+	if err != nil {
+		return "", "", err
+	}
+
+	actualMachineJSON, err := json.Marshal(actual)
+	if err != nil {
+		return "", "", err
+	}
+
+	abuf := new(bytes.Buffer)
+	ebuf := new(bytes.Buffer)
+
+	if err := json.Indent(abuf, actualMachineJSON, "", "  "); err != nil {
+		// Ignore the style linter so that we are consistent with the gomega.MatchJSON matcher.
+		return "", "", fmt.Errorf("Actual '%s' should be valid JSON, but it is not.\nUnderlying error:%w", string(actualMachineJSON), err) //nolint:stylecheck
+	}
+
+	if err := json.Indent(ebuf, expectedMachineJSON, "", "  "); err != nil {
+		// Ignore the style linter so that we are consistent with the gomega.MatchJSON matcher.
+		return "", "", fmt.Errorf("Expected '%s' should be valid JSON, but it is not.\nUnderlying error:%w", string(expectedMachineJSON), err) //nolint:stylecheck
+	}
+
+	return abuf.String(), ebuf.String(), nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -922,7 +922,7 @@ github.com/openshift/client-go/config/informers/externalversions/config/v1alpha1
 github.com/openshift/client-go/config/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/config/listers/config/v1
 github.com/openshift/client-go/config/listers/config/v1alpha1
-# github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20240906160452-4c3bebacbb5b
+# github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20240923124618-33cbd9255614
 ## explicit; go 1.21
 github.com/openshift/cluster-api-actuator-pkg/testutils
 github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder


### PR DESCRIPTION
This PR adds fuzz conversion testing between MAPI machines to CAPI machines and back again, the idea is that, bar some exceptions where we cannot currently convert, we can round trip the machines and produce the same result at the other end.

Where there are things that we cannot convert, they will be tagged with the appropriate stories to fix the feature gaps and then updated once the gaps are added.

The intention here is to create a pattern for fuzz testing and libraries so that this is easy for other platforms to implement similar.