### PR TITLE
METAL-966: manifests-gen: process ConfigMaps

### DIFF
--- a/manifests-gen/customizations.go
+++ b/manifests-gen/customizations.go
@@ -106,6 +106,8 @@ func processObjects(objs []unstructured.Unstructured, providerName string) map[r
 			providerConfigMapObjs = append(providerConfigMapObjs, obj)
 		case "ValidatingAdmissionPolicyBinding":
 			providerConfigMapObjs = append(providerConfigMapObjs, obj)
+		case "ConfigMap":
+			providerConfigMapObjs = append(providerConfigMapObjs, obj)
 		case "Certificate", "Issuer", "Namespace", "Secret": // skip
 		}
 	}


### PR DESCRIPTION
`openshift/cluster-api-provider-metal3` requires certain `ConfigMap`s to be installed in order for the deployment to start.  We add them to the list here so they can have their namespaces updated.