### PR TITLE
OCPCLOUD-2643: MachineSyncReconciler - split reconciles

### DIFF
--- a/pkg/test/crdbuilder.go
+++ b/pkg/test/crdbuilder.go
@@ -49,6 +49,12 @@ var (
 	// fakeClusterCRD is a fake Cluster CRD.
 	fakeClusterCRD = generateCRD(clusterGroupVersion.WithKind(fakeClusterKind))
 
+	// fakeClusterKind is the Kind for the Cluster.
+	fakeMachineKind = "Machine"
+
+	// fakeClusterCRD is a fake Cluster CRD.
+	fakeMachineCRD = generateCRD(clusterGroupVersion.WithKind(fakeMachineKind))
+
 	// v1beta2InfrastructureGroupVersion is a v1beta2 group version used for infrastructure objects.
 	v1beta2InfrastructureGroupVersion = schema.GroupVersion{Group: "infrastructure.cluster.x-k8s.io", Version: "v1beta2"}
 

--- a/pkg/test/envtest.go
+++ b/pkg/test/envtest.go
@@ -20,6 +20,8 @@ import (
 	"path"
 	goruntime "runtime"
 
+	machinev1 "github.com/openshift/api/machine/v1"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -37,6 +39,8 @@ import (
 
 func init() {
 	utilruntime.Must(configv1.Install(scheme.Scheme))
+	utilruntime.Must(machinev1.Install(scheme.Scheme))
+	utilruntime.Must(machinev1beta1.Install(scheme.Scheme))
 	utilruntime.Must(clusteroperatorv1.Install(scheme.Scheme))
 	utilruntime.Must(apiextensionsv1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(awsv1.AddToScheme(scheme.Scheme))
@@ -55,6 +59,7 @@ func StartEnvTest(testEnv *envtest.Environment) (*rest.Config, client.Client, er
 		fakeCoreProviderCRD,
 		fakeInfrastructureProviderCRD,
 		fakeClusterCRD,
+		fakeMachineCRD,
 		fakeAWSClusterCRD,
 		fakeAzureClusterCRD,
 		fakeGCPClusterCRD,
@@ -62,6 +67,7 @@ func StartEnvTest(testEnv *envtest.Environment) (*rest.Config, client.Client, er
 	testEnv.CRDDirectoryPaths = []string{
 		path.Join(root, "vendor", "github.com", "openshift", "api", "config", "v1", "zz_generated.crd-manifests"),
 		path.Join(root, "vendor", "github.com", "openshift", "api", "operator", "v1", "zz_generated.crd-manifests"),
+		path.Join(root, "vendor", "github.com", "openshift", "api", "machine", "v1beta1", "zz_generated.crd-manifests"),
 	}
 	testEnv.ErrorIfCRDPathMissing = true
 


### PR DESCRIPTION
This change adds the logic to split the reconciliation depending on which MachineAuthority is set.