### PR TITLE
OCPCLOUD-2707: Clarify why DeviceIndex is always zero

### DIFF
--- a/pkg/conversion/capi2mapi/aws.go
+++ b/pkg/conversion/capi2mapi/aws.go
@@ -134,7 +134,7 @@ func (m machineAndAWSMachineAndAWSCluster) toProviderSpec() (*mapiv1.AWSMachineP
 		// UserDataSecret - Populated below.
 		// CredentialsSecret - TODO(OCPCLOUD-2713)
 		KeyName: m.awsMachine.Spec.SSHKeyName,
-		// DeviceIndex - TODO(OCPCLOUD-2707) Not currently supported in CAPA.
+		// DeviceIndex - OCPCLOUD-2707: Value must always be zero. No other values are valid in MAPA even though the value is configurable.
 		PublicIP:             m.awsMachine.Spec.PublicIP,
 		NetworkInterfaceType: mapiv1.AWSENANetworkInterfaceType,                                          // TODO(OCPCLOUD-2708) This is the default value for MAPA, but other values are not configurable in CAPA.
 		SecurityGroups:       convertAWSSecurityGroupstoMAPI(m.awsMachine.Spec.AdditionalSecurityGroups), // OCPCLOUD-2712: We need to ensure that this is the correct way to convert the security groups.

--- a/pkg/conversion/mapi2capi/aws.go
+++ b/pkg/conversion/mapi2capi/aws.go
@@ -277,7 +277,9 @@ func (m *awsMachineAndInfra) toAWSMachine(providerSpec mapiv1.AWSMachineProvider
 	}
 
 	if providerSpec.DeviceIndex != 0 {
-		// TODO(OCPCLOUD-2707): We should understand if this value works when non-zero, and determine from that if we should support it.
+		// In MAPA, valid machines only have a DeviceIndex value of 0 or unset. Since only a single network interface is supported, which must have a device index of 0.
+		// If a machine is created with a DeviceIndex value other than 0, it will be in a failed state.
+		// For more context, see OCPCLOUD-2707.
 		errs = append(errs, field.Invalid(fldPath.Child("deviceIndex"), providerSpec.DeviceIndex, "deviceIndex must be 0 or unset"))
 	}
 


### PR DESCRIPTION
Updates comment for the mapi->capi conversion of deviceIndex in aws providerSpec.

No change required for capi->mapi as deviceIndex is stored inside the NetworkInterfaces field, which is already disabled due to being unsupported.