### PR TITLE
OCPCLOUD-2750: Add CAPI2MAPI Machine(Set) fuzz testing

### DIFF
--- a/pkg/conversion/capi2mapi/aws.go
+++ b/pkg/conversion/capi2mapi/aws.go
@@ -292,10 +292,10 @@ func convertAWSMetadataOptionsToMAPI(fldPath *field.Path, capiMetadataOpts *capa
 		errors = append(errors, field.Invalid(fldPath.Child("httpTokens"), capiMetadataOpts.HTTPTokens, errUnsupportedHTTPTokensState))
 	}
 
-	if capiMetadataOpts.HTTPEndpoint != "" && capiMetadataOpts.HTTPEndpoint != "enabled" {
+	if capiMetadataOpts.HTTPEndpoint != "" && capiMetadataOpts.HTTPEndpoint != capav1.InstanceMetadataEndpointStateEnabled {
 		// This defaults to "enabled" in CAPI and on the AWS side, so if it's not "enabled", the user explicitly chose another option.
 		// TODO(OCPCLOUD-2710): We should implement this within MAPI to create feature parity.
-		errors = append(errors, field.Invalid(fldPath.Child("httpEndpoint"), capiMetadataOpts.HTTPEndpoint, "httpEndpoint values other than \"enabled\" are not supported"))
+		errors = append(errors, field.Invalid(fldPath.Child("httpEndpoint"), capiMetadataOpts.HTTPEndpoint, fmt.Sprintf("httpEndpoint values other than %q are not supported", capav1.InstanceMetadataEndpointStateEnabled)))
 	}
 
 	if capiMetadataOpts.HTTPPutResponseHopLimit != 0 && capiMetadataOpts.HTTPPutResponseHopLimit != 1 {
@@ -304,10 +304,10 @@ func convertAWSMetadataOptionsToMAPI(fldPath *field.Path, capiMetadataOpts *capa
 		errors = append(errors, field.Invalid(fldPath.Child("httpPutResponseHopLimit"), capiMetadataOpts.HTTPPutResponseHopLimit, "httpPutResponseHopLimit values other than 1 are not supported"))
 	}
 
-	if capiMetadataOpts.InstanceMetadataTags != "" && capiMetadataOpts.InstanceMetadataTags != "disabled" {
+	if capiMetadataOpts.InstanceMetadataTags != "" && capiMetadataOpts.InstanceMetadataTags != capav1.InstanceMetadataEndpointStateDisabled {
 		// This defaults to "disabled" in CAPI and on the AWS side, so if it's not "disabled", the user explicitly chose another option.
 		// TODO(OCPCLOUD-2710): We should implement this within MAPI to create feature parity.
-		errors = append(errors, field.Invalid(fldPath.Child("instanceMetadataTags"), capiMetadataOpts.InstanceMetadataTags, "instanceMetadataTags values other than \"disabled\" are not supported"))
+		errors = append(errors, field.Invalid(fldPath.Child("instanceMetadataTags"), capiMetadataOpts.InstanceMetadataTags, fmt.Sprintf("instanceMetadataTags values other than %q are not supported", capav1.InstanceMetadataEndpointStateDisabled)))
 	}
 
 	metadataOpts := mapiv1.MetadataServiceOptions{
@@ -499,6 +499,18 @@ func handleUnsupportedAWSMachineFields(fldPath *field.Path, spec capav1.AWSMachi
 	if spec.PrivateDNSName != nil {
 		// TODO(OCPCLOUD-2711): Not required for our use case, add VAP to prevent usage.
 		errs = append(errs, field.Invalid(fldPath.Child("privateDNSName"), spec.PrivateDNSName, "privateDNSName is not supported"))
+	}
+
+	if spec.Ignition != nil {
+		if spec.Ignition.Proxy != nil {
+			// TODO(OCPCLOUD-2711): Ignition proxy is not configurable in MAPI. Not required for our use case, add VAP to prevent usage.
+			errs = append(errs, field.Invalid(fldPath.Child("ignition", "proxy"), spec.Ignition.Proxy, "ignition proxy is not supported"))
+		}
+
+		if spec.Ignition.TLS != nil {
+			// TODO(OCPCLOUD-2711): Ignition TLS is not configurable in MAPI. Not required for our use case, add VAP to prevent usage.
+			errs = append(errs, field.Invalid(fldPath.Child("ignition", "tls"), spec.Ignition.TLS, "ignition tls is not supported"))
+		}
 	}
 
 	return errs

--- a/pkg/conversion/capi2mapi/aws_fuzz_test.go
+++ b/pkg/conversion/capi2mapi/aws_fuzz_test.go
@@ -40,6 +40,7 @@ const (
 	awsMachineAPIVersion = "infrastructure.cluster.x-k8s.io/v1beta2"
 	awsMachineKind       = "AWSMachine"
 	awsTemplateKind      = "AWSMachineTemplate"
+	capiNamespace        = "openshift-cluster-api"
 )
 
 var _ = Describe("AWS Fuzz (mapi2capi)", func() {
@@ -74,7 +75,7 @@ var _ = Describe("AWS Fuzz (mapi2capi)", func() {
 			&capav1.AWSMachine{},
 			mapi2capi.FromAWSMachineAndInfra,
 			fromMachineAndAWSMachineAndAWSCluster,
-			conversiontest.ObjectMetaFuzzerFuncs("openshift-cluster-api"),
+			conversiontest.ObjectMetaFuzzerFuncs(capiNamespace),
 			conversiontest.CAPIMachineFuzzerFuncs(awsProviderIDFuzzer, awsMachineKind, awsMachineAPIVersion, infra.Status.InfrastructureName),
 			awsMachineFuzzerFuncs,
 		)
@@ -98,7 +99,7 @@ var _ = Describe("AWS Fuzz (mapi2capi)", func() {
 			&capav1.AWSMachineTemplate{},
 			mapi2capi.FromAWSMachineSetAndInfra,
 			fromMachineSetAndAWSMachineTemplateAndAWSCluster,
-			conversiontest.ObjectMetaFuzzerFuncs("openshift-cluster-api"),
+			conversiontest.ObjectMetaFuzzerFuncs(capiNamespace),
 			conversiontest.CAPIMachineFuzzerFuncs(awsProviderIDFuzzer, awsTemplateKind, awsMachineAPIVersion, infra.Status.InfrastructureName),
 			conversiontest.CAPIMachineSetFuzzerFuncs(awsTemplateKind, awsMachineAPIVersion, infra.Status.InfrastructureName),
 			awsMachineFuzzerFuncs,

--- a/pkg/conversion/capi2mapi/aws_fuzz_test.go
+++ b/pkg/conversion/capi2mapi/aws_fuzz_test.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package capi2mapi_test
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	fuzz "github.com/google/gofuzz"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-capi-operator/pkg/conversion/capi2mapi"
+	"github.com/openshift/cluster-capi-operator/pkg/conversion/mapi2capi"
+	conversiontest "github.com/openshift/cluster-capi-operator/pkg/conversion/test"
+
+	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	capav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+const (
+	awsTemplateAPIVersion = "infrastructure.cluster.x-k8s.io/v1beta2"
+	awsTemplateKind       = "AWSMachineTemplate"
+)
+
+var _ = Describe("AWS Fuzz (mapi2capi)", func() {
+	infra := &configv1.Infrastructure{
+		Spec: configv1.InfrastructureSpec{},
+		Status: configv1.InfrastructureStatus{
+			InfrastructureName: "sample-cluster-name",
+		},
+	}
+
+	infraCluster := &capav1.AWSCluster{
+		Spec: capav1.AWSClusterSpec{
+			Region: "us-east-1",
+		},
+	}
+
+	Context("AWSMachine Conversion", func() {
+		fromMachineAndAWSMachineAndAWSCluster := func(machine *capiv1.Machine, infraMachine client.Object, infraCluster client.Object) capi2mapi.MachineAndInfrastructureMachine {
+			awsMachine, ok := infraMachine.(*capav1.AWSMachine)
+			Expect(ok).To(BeTrue(), "input infra machine should be of type %T, got %T", &capav1.AWSMachine{}, infraMachine)
+
+			awsCluster, ok := infraCluster.(*capav1.AWSCluster)
+			Expect(ok).To(BeTrue(), "input infra cluster should be of type %T, got %T", &capav1.AWSCluster{}, infraCluster)
+
+			return capi2mapi.FromMachineAndAWSMachineAndAWSCluster(machine, awsMachine, awsCluster)
+		}
+
+		conversiontest.CAPI2MAPIMachineRoundTripFuzzTest(
+			scheme,
+			infra,
+			infraCluster,
+			&capav1.AWSMachine{},
+			mapi2capi.FromAWSMachineAndInfra,
+			fromMachineAndAWSMachineAndAWSCluster,
+			conversiontest.ObjectMetaFuzzerFuncs("openshift-cluster-api"),
+			conversiontest.CAPIMachineFuzzerFuncs(awsProviderIDFuzzer, awsTemplateKind, awsTemplateAPIVersion, infra.Status.InfrastructureName),
+			awsMachineFuzzerFuncs,
+		)
+	})
+})
+
+func awsProviderIDFuzzer(c fuzz.Continue) string {
+	return "aws:///us-west-2a/i-" + strings.ReplaceAll(c.RandString(), "/", "")
+}
+
+//nolint:funlen
+func awsMachineFuzzerFuncs(codecs runtimeserializer.CodecFactory) []interface{} {
+	return []interface{}{
+		func(imdo *capav1.InstanceMetadataOptions, c fuzz.Continue) {
+			c.FuzzNoCustom(imdo)
+
+			// TODO(OCPCLOUD-2710): Fields not yet supported by MAPI.
+			imdo.HTTPEndpoint = capav1.InstanceMetadataEndpointStateEnabled
+			imdo.HTTPPutResponseHopLimit = 0
+			imdo.InstanceMetadataTags = capav1.InstanceMetadataEndpointStateDisabled
+		},
+		func(tokenState *capav1.HTTPTokensState, c fuzz.Continue) {
+			switch c.Int31n(2) {
+			case 0:
+				*tokenState = capav1.HTTPTokensStateOptional
+			case 1:
+				*tokenState = capav1.HTTPTokensStateRequired
+			}
+		},
+		func(ami *capav1.AMIReference, c fuzz.Continue) {
+			c.FuzzNoCustom(ami)
+
+			// Ensure that the AMI ID is set.
+			for ami.ID == nil || *ami.ID == "" {
+				c.Fuzz(&ami.ID)
+			}
+
+			// Not required for our use case. Can be ignored.
+			ami.EKSOptimizedLookupType = nil
+		},
+		func(ignition *capav1.Ignition, c fuzz.Continue) {
+			// We force these fields, so they must be fuzzed in this way.
+			*ignition = capav1.Ignition{
+				Version:     "3.4",
+				StorageType: capav1.IgnitionStorageTypeOptionUnencryptedUserData,
+			}
+		},
+		func(spec *capav1.AWSMachineSpec, c fuzz.Continue) {
+			c.FuzzNoCustom(spec)
+
+			fuzzAWSMachineSpecTenancy(&spec.Tenancy, c)
+
+			// Fields not required for our use case can be ignored.
+			spec.ImageLookupFormat = ""
+			spec.ImageLookupOrg = ""
+			spec.ImageLookupBaseOS = ""
+			spec.NetworkInterfaces = nil
+			spec.CloudInit = capav1.CloudInit{}
+			spec.UncompressedUserData = nil
+			spec.PrivateDNSName = nil
+
+			// Fields not yet supported for conversion.
+			// TODO(OCPCLOUD-2712): Security group overrides still need investigation.
+			spec.SecurityGroupOverrides = nil
+		},
+		func(m *capav1.AWSMachine, c fuzz.Continue) {
+			c.FuzzNoCustom(m)
+
+			// Ensure the type meta is set correctly.
+			m.TypeMeta.APIVersion = capav1.GroupVersion.String()
+			m.TypeMeta.Kind = "AWSMachine"
+		},
+	}
+}
+
+func fuzzAWSMachineSpecTenancy(tenancy *string, c fuzz.Continue) {
+	switch c.Int31n(4) {
+	case 0:
+		*tenancy = "default"
+	case 1:
+		*tenancy = "dedicated"
+	case 2:
+		*tenancy = "host"
+	case 3:
+		*tenancy = ""
+	}
+}

--- a/pkg/conversion/capi2mapi/suite_test.go
+++ b/pkg/conversion/capi2mapi/suite_test.go
@@ -13,14 +13,36 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package capi2mapi
+package capi2mapi_test
 
 import (
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	kubescheme "k8s.io/client-go/kubernetes/scheme"
+
+	capav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
+
+var scheme *runtime.Scheme
+
+func init() {
+	// Register the scheme for the test.
+	// This must be done before the tests are run as the fuzzer is needed before the test tree is compiled.
+	scheme = kubescheme.Scheme
+	if err := capiv1.AddToScheme(scheme); err != nil {
+		panic(fmt.Sprintf("failed to add cluster API scheme: %v", err))
+	}
+
+	if err := capav1.AddToScheme(scheme); err != nil {
+		panic(fmt.Sprintf("failed to add aws scheme: %v", err))
+	}
+}
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/conversion/mapi2capi/aws_fuzz_test.go
+++ b/pkg/conversion/mapi2capi/aws_fuzz_test.go
@@ -39,6 +39,10 @@ import (
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
+const (
+	mapiNamespace = "openshift-machine-api"
+)
+
 var _ = Describe("AWS Fuzz (mapi2capi)", func() {
 	infra := &configv1.Infrastructure{
 		Spec: configv1.InfrastructureSpec{},
@@ -70,7 +74,7 @@ var _ = Describe("AWS Fuzz (mapi2capi)", func() {
 			infraCluster,
 			mapi2capi.FromAWSMachineAndInfra,
 			fromMachineAndAWSMachineAndAWSCluster,
-			conversiontest.ObjectMetaFuzzerFuncs("openshift-machine-api"),
+			conversiontest.ObjectMetaFuzzerFuncs(mapiNamespace),
 			conversiontest.MAPIMachineFuzzerFuncs(&mapiv1.AWSMachineProviderConfig{}, awsProviderIDFuzzer),
 			awsProviderSpecFuzzerFuncs,
 		)
@@ -93,7 +97,7 @@ var _ = Describe("AWS Fuzz (mapi2capi)", func() {
 			infraCluster,
 			mapi2capi.FromAWSMachineSetAndInfra,
 			fromMachineSetAndAWSMachineTemplateAndAWSCluster,
-			conversiontest.ObjectMetaFuzzerFuncs("openshift-machine-api"),
+			conversiontest.ObjectMetaFuzzerFuncs(mapiNamespace),
 			conversiontest.MAPIMachineFuzzerFuncs(&mapiv1.AWSMachineProviderConfig{}, awsProviderIDFuzzer),
 			conversiontest.MAPIMachineSetFuzzerFuncs(),
 			awsProviderSpecFuzzerFuncs,

--- a/pkg/conversion/test/fuzz.go
+++ b/pkg/conversion/test/fuzz.go
@@ -33,9 +33,11 @@ import (
 	"github.com/openshift/cluster-capi-operator/pkg/conversion/mapi2capi"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
 	metafuzzer "k8s.io/apimachinery/pkg/apis/meta/fuzzer"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/utils/ptr"
@@ -61,6 +63,83 @@ type MAPI2CAPIMachineSetConverterConstructor func(*mapiv1.MachineSet, *configv1.
 
 // StringFuzzer is a function that returns a random string.
 type StringFuzzer func(fuzz.Continue) string
+
+// capiToMapiMachineFuzzInput is a struct that holds the input for the CAPI to MAPI fuzz test.
+type capiToMapiMachineFuzzInput struct {
+	machine                  *capiv1.Machine
+	infra                    *configv1.Infrastructure
+	infraMachine             client.Object
+	infraCluster             client.Object
+	mapiConverterConstructor MAPI2CAPIMachineConverterConstructor
+	capiConverterConstructor CAPI2MAPIMachineConverterConstructor
+}
+
+// CAPI2MAPIMachineRoundTripFuzzTest is a generic test that can be used to test roundtrip conversion between CAPI and MAPI Machine objects.
+// It leverages fuzz testing to generate random CAPI objects and then converts them to MAPI objects and back to CAPI objects.
+// The test then compares the original CAPI object with the final CAPI object to ensure that the conversion is lossless.
+// Any lossy conversions must be accounted for within the fuzz functions passed in.
+func CAPI2MAPIMachineRoundTripFuzzTest(scheme *runtime.Scheme, infra *configv1.Infrastructure, infraCluster, infraMachine client.Object, mapiConverter MAPI2CAPIMachineConverterConstructor, capiConverter CAPI2MAPIMachineConverterConstructor, fuzzerFuncs ...fuzzer.FuzzerFuncs) {
+	machineFuzzInputs := []TableEntry{}
+	fz := getFuzzer(scheme, fuzzerFuncs...)
+
+	for i := 0; i < 1000; i++ {
+		m := &capiv1.Machine{}
+		fz.Fuzz(m)
+		fz.Fuzz(infraMachine)
+
+		// The infraMachine should always have the same name, namespace labels and annotations as its parent machine.
+		// https://github.com/kubernetes-sigs/cluster-api/blob/f88d7ae5155700c2cc367b31ddcc151c9ad579e4/internal/controllers/machineset/machineset_controller.go#L575-L579
+		infraMachine.SetName(m.Name)
+		infraMachine.SetNamespace(m.Namespace)
+		infraMachine.SetLabels(m.GetLabels())
+		infraMachine.SetAnnotations(m.GetAnnotations())
+
+		in := capiToMapiMachineFuzzInput{
+			machine:                  m,
+			infra:                    infra,
+			infraMachine:             infraMachine,
+			infraCluster:             infraCluster,
+			mapiConverterConstructor: mapiConverter,
+			capiConverterConstructor: capiConverter,
+		}
+
+		machineFuzzInputs = append(machineFuzzInputs, Entry(fmt.Sprintf("%d", i), in))
+	}
+
+	DescribeTable("should be able to roundtrip fuzzed Machines", func(in capiToMapiMachineFuzzInput) {
+		capiConverter := in.capiConverterConstructor(in.machine, in.infraMachine, in.infraCluster)
+
+		mapiMachine, warnings, err := capiConverter.ToMachine()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(warnings).To(BeEmpty())
+
+		mapiConverter := in.mapiConverterConstructor(mapiMachine, in.infra)
+
+		capiMachine, infraMachine, warnings, err := mapiConverter.ToMachineAndInfrastructureMachine()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(warnings).To(BeEmpty())
+
+		// Break down the comparison to make it easier to debug sections that are failing conversion.
+
+		// Do not match on status yet, we do not support status conversion.
+		// Expect(capiMachine.Status).To(Equal(in.machine.Status))
+		// Expect(infraMachine.Status).To(Equal(in.infraMachine.Status))
+
+		Expect(capiMachine.TypeMeta).To(Equal(in.machine.TypeMeta))
+		Expect(capiMachine.ObjectMeta).To(Equal(in.machine.ObjectMeta))
+		Expect(capiMachine.Spec).To(Equal(in.machine.Spec))
+
+		infraMachineJSON, err := json.Marshal(infraMachine)
+		Expect(err).ToNot(HaveOccurred())
+
+		infraMachineUnstructured := &unstructured.Unstructured{}
+		Expect(json.Unmarshal(infraMachineJSON, infraMachineUnstructured)).To(Succeed())
+
+		Expect(infraMachine.GetObjectKind().GroupVersionKind()).To(Equal(in.infraMachine.GetObjectKind().GroupVersionKind()))
+		Expect(infraMachine).To(HaveField("ObjectMeta", testutils.MatchViaJSON(infraMachineUnstructured.Object["metadata"])))
+		Expect(infraMachine).To(HaveField("Spec", testutils.MatchViaJSON(infraMachineUnstructured.Object["spec"])))
+	}, machineFuzzInputs)
+}
 
 // mapiToCapiMachineFuzzInput is a struct that holds the input for the MAPI to CAPI fuzz test.
 type mapiToCapiMachineFuzzInput struct {
@@ -240,6 +319,60 @@ func ObjectMetaFuzzerFuncs(namespace string) fuzzer.FuzzerFuncs {
 				}
 				if o.Labels == nil {
 					o.Labels = map[string]string{}
+				}
+			},
+		}
+	}
+}
+
+// CAPIMachineFuzzerFuncs returns a set of fuzzer functions that can be used to fuzz MachineSpec objects.
+func CAPIMachineFuzzerFuncs(providerIDFuzz StringFuzzer, infraKind, infraAPIVersion, clusterName string) fuzzer.FuzzerFuncs {
+	return func(codecs runtimeserializer.CodecFactory) []interface{} {
+		return []interface{}{
+			func(b *capiv1.Bootstrap, c fuzz.Continue) {
+				c.FuzzNoCustom(b)
+
+				// Clear fields that are not supported in the bootstrap spec.
+				b.ConfigRef = nil
+
+				// If we fuzzed an empty string, nil it out to match the behaviour of the converter.
+				if b.DataSecretName != nil && *b.DataSecretName == "" {
+					b.DataSecretName = nil
+				}
+			},
+			func(m *capiv1.MachineSpec, c fuzz.Continue) {
+				c.FuzzNoCustom(m)
+
+				m.ClusterName = clusterName
+				m.ProviderID = ptr.To(providerIDFuzz(c))
+
+				// Clear fields that are not supported in the machine spec.
+				m.Version = nil
+
+				// Clear fields that are not yet supported in the conversion.
+				// TODO(OCPCLOUD-2715): Implement support for node draining options in MAPI.
+				m.NodeDrainTimeout = nil
+				m.NodeVolumeDetachTimeout = nil
+				m.NodeDeletionTimeout = nil
+
+				// Clear fields that are zero valued.
+				if m.FailureDomain != nil && *m.FailureDomain == "" {
+					m.FailureDomain = nil
+				}
+			},
+			func(m *capiv1.Machine, c fuzz.Continue) {
+				c.FuzzNoCustom(m)
+
+				// The reference from a Machine to the InfraMachine should
+				// always use the same name and namespace as the Machine itself.
+				// The kind and APIVersion should be set to the InfraMachine's kind and APIVersion.
+				// This is fixed in the conversion so we fix it here.
+				// Other fields are not required for conversion.
+				m.Spec.InfrastructureRef = corev1.ObjectReference{
+					APIVersion: infraAPIVersion,
+					Kind:       infraKind,
+					Name:       m.Name,
+					Namespace:  m.Namespace,
 				}
 			},
 		}

--- a/pkg/conversion/test/fuzz.go
+++ b/pkg/conversion/test/fuzz.go
@@ -106,7 +106,7 @@ func CAPI2MAPIMachineRoundTripFuzzTest(scheme *runtime.Scheme, infra *configv1.I
 		machineFuzzInputs = append(machineFuzzInputs, Entry(fmt.Sprintf("%d", i), in))
 	}
 
-	DescribeTable("should be able to roundtrip fuzzed Machines", func(in capiToMapiMachineFuzzInput) {
+	DescribeTable("should be able to roundtrip fuzzed Machines", func(in capiToMapiMachineFuzzInput) { //nolint:dupl
 		capiConverter := in.capiConverterConstructor(in.machine, in.infraMachine, in.infraCluster)
 
 		mapiMachine, warnings, err := capiConverter.ToMachine()
@@ -176,7 +176,7 @@ func CAPI2MAPIMachineSetRoundTripFuzzTest(scheme *runtime.Scheme, infra *configv
 		machineFuzzInputs = append(machineFuzzInputs, Entry(fmt.Sprintf("%d", i), in))
 	}
 
-	DescribeTable("should be able to roundtrip fuzzed Machines", func(in capiToMapiMachineSetFuzzInput) {
+	DescribeTable("should be able to roundtrip fuzzed MachineSets", func(in capiToMapiMachineSetFuzzInput) { //nolint:dupl
 		capiConverter := in.capiConverterConstructor(in.machineSet, in.infraMachineTemplate, in.infraCluster)
 
 		mapiMachineSet, warnings, err := capiConverter.ToMachineSet()


### PR DESCRIPTION
This follows on from #208 and adds conversion round trip fuzz testing for the CAPI to MAPI side of the equation. 