### PR TITLE
OCPCLOUD-2643: MachineSetSync controller bootstrap

### DIFF
--- a/cmd/machine-api-migration/main.go
+++ b/cmd/machine-api-migration/main.go
@@ -26,6 +26,7 @@ import (
 	configv1client "github.com/openshift/client-go/config/clientset/versioned"
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
 	"github.com/openshift/cluster-capi-operator/pkg/controllers"
+	"github.com/openshift/cluster-capi-operator/pkg/controllers/machinesetsync"
 	"github.com/openshift/cluster-capi-operator/pkg/controllers/machinesync"
 	"github.com/openshift/cluster-capi-operator/pkg/util"
 
@@ -203,15 +204,27 @@ func main() {
 		os.Exit(1)
 	}
 
-	reconciler := machinesync.MachineSyncReconciler{
+	machineSyncReconciler := machinesync.MachineSyncReconciler{
 		Platform: provider,
 
 		MAPINamespace: *mapiManagedNamespace,
 		CAPINamespace: *capiManagedNamespace,
 	}
 
-	if err := reconciler.SetupWithManager(mgr); err != nil {
-		klog.Error(err, "failed to set up reconciler with manager")
+	if err := machineSyncReconciler.SetupWithManager(mgr); err != nil {
+		klog.Error(err, "failed to set up machine sync reconciler with manager")
+		os.Exit(1)
+	}
+
+	machineSetSyncReconciler := machinesetsync.MachineSetSyncReconciler{
+		Platform: provider,
+
+		MAPINamespace: *mapiManagedNamespace,
+		CAPINamespace: *capiManagedNamespace,
+	}
+
+	if err := machineSetSyncReconciler.SetupWithManager(mgr); err != nil {
+		klog.Error(err, "failed to set up machineset sync reconciler with manager")
 		os.Exit(1)
 	}
 

--- a/pkg/controllers/machinesetsync/machineset_sync_controller.go
+++ b/pkg/controllers/machinesetsync/machineset_sync_controller.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machinesetsync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	"github.com/openshift/cluster-capi-operator/pkg/util"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	awscapiv1beta1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta1"
+	capiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	capiNamespace string = "openshift-cluster-api"
+	mapiNamespace string = "openshift-machine-api"
+)
+
+var (
+	// errPlatformNotSupported is returned when the platform is not supported.
+	errPlatformNotSupported = errors.New("error determining InfraMachineTemplate type, platform not supported")
+)
+
+// MachineSetSyncReconciler reconciles CAPI and MAPI MachineSets.
+type MachineSetSyncReconciler struct {
+	client.Client
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
+
+	Platform      configv1.PlatformType
+	CAPINamespace string
+	MAPINamespace string
+}
+
+// SetupWithManager sets the CoreClusterReconciler controller up with the given manager.
+func (r *MachineSetSyncReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	infraMachineTemplate, err := getInfraMachineTemplateFromProvider(r.Platform)
+	if err != nil {
+		return fmt.Errorf("failed to get InfraMachine from Provider: %w", err)
+	}
+	// Allow the namespaces to be set externally for test purposes, when not set,
+	// default to the production namespaces.
+	if r.CAPINamespace == "" {
+		r.CAPINamespace = capiNamespace
+	}
+
+	if r.MAPINamespace == "" {
+		r.MAPINamespace = mapiNamespace
+	}
+
+	if err := ctrl.NewControllerManagedBy(mgr).
+		For(&machinev1beta1.MachineSet{}, builder.WithPredicates(util.FilterNamespace(r.MAPINamespace))).
+		Watches(
+			&capiv1beta1.MachineSet{},
+			handler.EnqueueRequestsFromMapFunc(util.RewriteNamespace(r.MAPINamespace)),
+			builder.WithPredicates(util.FilterNamespace(r.CAPINamespace)),
+		).
+		Watches(
+			infraMachineTemplate,
+			handler.EnqueueRequestsFromMapFunc(util.ResolveCAPIMachineSetFromObject(r.MAPINamespace)),
+			builder.WithPredicates(util.FilterNamespace(r.CAPINamespace)),
+		).
+		Complete(r); err != nil {
+		return fmt.Errorf("failed to create controller: %w", err)
+	}
+
+	// Set up API helpers from the manager.
+	r.Client = mgr.GetClient()
+	r.Scheme = mgr.GetScheme()
+	r.Recorder = mgr.GetEventRecorderFor("machineset-sync-controller")
+
+	return nil
+}
+
+// Reconcile reconciles CAPI and MAPI machines for their respective namespaces.
+func (r *MachineSetSyncReconciler) Reconcile(ctx context.Context, req reconcile.Request) (ctrl.Result, error) {
+	return ctrl.Result{}, nil
+}
+
+// getInfraMachineTemplateFromProvider returns the correct InfraMachineTemplate implementation
+// for a given provider.
+//
+// As we implement other cloud providers, we'll need to update this list.
+func getInfraMachineTemplateFromProvider(platform configv1.PlatformType) (client.Object, error) {
+	switch platform {
+	case configv1.AWSPlatformType:
+		return &awscapiv1beta1.AWSMachineTemplate{}, nil
+	default:
+		return nil, fmt.Errorf("%w: %s", errPlatformNotSupported, platform)
+	}
+}

--- a/pkg/controllers/machinesetsync/machineset_sync_controller_test.go
+++ b/pkg/controllers/machinesetsync/machineset_sync_controller_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machinesetsync
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	corev1resourcebuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/core/v1"
+	machinev1resourcebuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/openshift/cluster-capi-operator/pkg/test"
+)
+
+var _ = Describe("MachineSetSync Reconciler", func() {
+	var mgrCancel context.CancelFunc
+	var mgrDone chan struct{}
+	var mgr manager.Manager
+	var reconciler *MachineSetSyncReconciler
+
+	var namespace *corev1.Namespace
+	var namespaceName string
+
+	var machineSetBuilder machinev1resourcebuilder.MachineSetBuilder
+	var machineset *machinev1beta1.MachineSet
+
+	startManager := func(mgr *manager.Manager) (context.CancelFunc, chan struct{}) {
+		mgrCtx, mgrCancel := context.WithCancel(context.Background())
+		mgrDone := make(chan struct{})
+
+		go func() {
+			defer GinkgoRecover()
+			defer close(mgrDone)
+
+			Expect((*mgr).Start(mgrCtx)).To(Succeed())
+		}()
+
+		return mgrCancel, mgrDone
+	}
+
+	stopManager := func() {
+		mgrCancel()
+		// Wait for the mgrDone to be closed, which will happen once the mgr has stopped
+		<-mgrDone
+	}
+
+	BeforeEach(func() {
+		By("Setting up a namespace for the test")
+		namespace = corev1resourcebuilder.Namespace().WithGenerateName("machineset-sync-controller-").Build()
+		Expect(k8sClient.Create(ctx, namespace)).To(Succeed())
+		namespaceName = namespace.GetName()
+
+		By("Setting up the machineset builder")
+		machineSetBuilder = machinev1resourcebuilder.MachineSet().
+			WithNamespace(namespaceName).
+			WithGenerateName("foo-").
+			WithProviderSpecBuilder(machinev1resourcebuilder.AWSProviderSpec())
+
+		By("Setting up a manager and controller")
+		var err error
+		mgr, err = ctrl.NewManager(cfg, ctrl.Options{
+			Scheme: testScheme,
+		})
+		Expect(err).ToNot(HaveOccurred(), "Manager should be able to be created")
+
+		reconciler = &MachineSetSyncReconciler{
+			Client:   mgr.GetClient(),
+			Platform: configv1.AWSPlatformType,
+		}
+		Expect(reconciler.SetupWithManager(mgr)).To(Succeed(), "Reconciler should be able to setup with manager")
+	})
+
+	AfterEach(func() {
+		Expect(test.CleanupAndWait(ctx, k8sClient, machineset)).To(Succeed())
+	})
+
+	JustBeforeEach(func() {
+		By("Starting the manager")
+		mgrCancel, mgrDone = startManager(&mgr)
+	})
+
+	JustAfterEach(func() {
+		By("Stopping the manager")
+		stopManager()
+	})
+
+	It("should reconcile without erroring", func() {
+		machineset = machineSetBuilder.Build()
+
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: namespaceName,
+				Name:      machineset.Name,
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+	})
+})

--- a/pkg/controllers/machinesetsync/suite_test.go
+++ b/pkg/controllers/machinesetsync/suite_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machinesetsync
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	configv1 "github.com/openshift/api/config/v1"
+	machinev1 "github.com/openshift/api/machine/v1"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	configv1builder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/config/v1"
+	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/util"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/textlogger"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	//+kubebuilder:scaffold:imports
+)
+
+var cfg *rest.Config
+var k8sClient client.Client
+var testEnv *envtest.Environment
+var testScheme *runtime.Scheme
+var testRESTMapper meta.RESTMapper
+var ctx = context.Background()
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Controller Suite")
+}
+
+var _ = BeforeSuite(func() {
+	klog.SetOutput(GinkgoWriter)
+
+	logf.SetLogger(textlogger.NewLogger(textlogger.NewConfig()))
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths: []string{
+				filepath.Join("..", "..", "..", "vendor", "github.com", "openshift", "api", "machine", "v1beta1", "zz_generated.crd-manifests", "0000_10_machine-api_01_machines-CustomNoUpgrade.crd.yaml"),
+				filepath.Join("..", "..", "..", "vendor", "github.com", "openshift", "api", "machine", "v1beta1", "zz_generated.crd-manifests", "0000_10_machine-api_01_machinesets-CustomNoUpgrade.crd.yaml"),
+				filepath.Join("..", "..", "..", "vendor", "github.com", "openshift", "api", "config", "v1", "zz_generated.crd-manifests", "0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml"),
+			},
+		},
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	testScheme = scheme.Scheme
+	Expect(machinev1.Install(testScheme)).To(Succeed())
+	Expect(machinev1beta1.Install(testScheme)).To(Succeed())
+	Expect(configv1.Install(testScheme)).To(Succeed())
+
+	//+kubebuilder:scaffold:scheme
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: testScheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	infrastructure := configv1builder.Infrastructure().AsAWS("test", "eu-west-2").WithName(util.InfrastructureName).Build()
+	Expect(k8sClient.Create(ctx, infrastructure)).To(Succeed())
+
+	httpClient, err := rest.HTTPClientFor(cfg)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(httpClient).NotTo(BeNil())
+
+	testRESTMapper, err = apiutil.NewDynamicRESTMapper(cfg, httpClient)
+	Expect(err).NotTo(HaveOccurred())
+
+	komega.SetClient(k8sClient)
+	komega.SetContext(ctx)
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/pkg/controllers/machinesync/machine_sync_controller.go
+++ b/pkg/controllers/machinesync/machine_sync_controller.go
@@ -46,10 +46,10 @@ const (
 
 var (
 	// errPlatformNotSupported is returned when the platform is not supported.
-	errPlatformNotSupported = errors.New("error determining InfraMachine" +
-		" type, platform not supported")
+	errPlatformNotSupported = errors.New("error determining InfraMachine type, platform not supported")
 
-	// errAuthoritativeAPIUnexpected is returned when we receive an unexpected AuthoritativeAPI.
+	// errAuthoritativeAPIUnexpected is returned when we receive an unexpected
+	// AuthoritativeAPI.
 	errAuthoritativeAPIUnexpected = errors.New("AuthoritativeAPI unexpected value")
 )
 
@@ -85,12 +85,12 @@ func (r *MachineSyncReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&machinev1beta1.Machine{}, builder.WithPredicates(util.FilterNamespace(r.MAPINamespace))).
 		Watches(
 			&capiv1beta1.Machine{},
-			handler.EnqueueRequestsFromMapFunc(util.CAPIMachineToMAPIMachine(r.MAPINamespace)),
+			handler.EnqueueRequestsFromMapFunc(util.RewriteNamespace(r.MAPINamespace)),
 			builder.WithPredicates(util.FilterNamespace(r.CAPINamespace)),
 		).
 		Watches(
 			infraMachine,
-			handler.EnqueueRequestsFromMapFunc(util.CAPIMachineToMAPIMachine(r.MAPINamespace)),
+			handler.EnqueueRequestsFromMapFunc(util.RewriteNamespace(r.MAPINamespace)),
 			builder.WithPredicates(util.FilterNamespace(r.CAPINamespace)),
 		).
 		Complete(r); err != nil {


### PR DESCRIPTION
-> Bootstraps MachineSet Sync controller
-> Adds basic test suite & empty test.
-> Fetches resources + dynamic watching of InfraMachineTemplates 