### PR TITLE
OCPCLOUD-2643: Machinesetsync split reconcile

### DIFF
--- a/pkg/controllers/machinesetsync/suite_test.go
+++ b/pkg/controllers/machinesetsync/suite_test.go
@@ -18,21 +18,17 @@ package machinesetsync
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	configv1 "github.com/openshift/api/config/v1"
-	machinev1 "github.com/openshift/api/machine/v1"
-	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	configv1builder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/config/v1"
+	"github.com/openshift/cluster-capi-operator/pkg/test"
 	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/util"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/textlogger"
@@ -64,30 +60,12 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(textlogger.NewLogger(textlogger.NewConfig()))
 
 	By("bootstrapping test environment")
-	testEnv = &envtest.Environment{
-		CRDInstallOptions: envtest.CRDInstallOptions{
-			Paths: []string{
-				filepath.Join("..", "..", "..", "vendor", "github.com", "openshift", "api", "machine", "v1beta1", "zz_generated.crd-manifests", "0000_10_machine-api_01_machines-CustomNoUpgrade.crd.yaml"),
-				filepath.Join("..", "..", "..", "vendor", "github.com", "openshift", "api", "machine", "v1beta1", "zz_generated.crd-manifests", "0000_10_machine-api_01_machinesets-CustomNoUpgrade.crd.yaml"),
-				filepath.Join("..", "..", "..", "vendor", "github.com", "openshift", "api", "config", "v1", "zz_generated.crd-manifests", "0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml"),
-			},
-		},
-	}
-
 	var err error
-	cfg, err = testEnv.Start()
+	testEnv = &envtest.Environment{}
+	cfg, k8sClient, err = test.StartEnvTest(testEnv)
+
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
-
-	testScheme = scheme.Scheme
-	Expect(machinev1.Install(testScheme)).To(Succeed())
-	Expect(machinev1beta1.Install(testScheme)).To(Succeed())
-	Expect(configv1.Install(testScheme)).To(Succeed())
-
-	//+kubebuilder:scaffold:scheme
-
-	k8sClient, err = client.New(cfg, client.Options{Scheme: testScheme})
-	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
 	infrastructure := configv1builder.Infrastructure().AsAWS("test", "eu-west-2").WithName(util.InfrastructureName).Build()

--- a/pkg/controllers/machinesync/machine_sync_controller.go
+++ b/pkg/controllers/machinesync/machine_sync_controller.go
@@ -168,7 +168,7 @@ func (r *MachineSyncReconciler) Reconcile(ctx context.Context, req reconcile.Req
 		logger.Info("machine currently migrating", "machine", mapiMachine.GetName())
 		return ctrl.Result{}, nil
 	default:
-		logger.Info("machine AuthoritativeAPI has unexpected value", "AuthoritativeAPI", mapiMachine.Status.AuthoritativeAPI, "machine", mapiMachine.GetName())
+		logger.Info("machine AuthoritativeAPI has unexpected value", "AuthoritativeAPI", mapiMachine.Status.AuthoritativeAPI)
 		return ctrl.Result{}, nil
 	}
 }

--- a/pkg/controllers/machinesync/machine_sync_controller.go
+++ b/pkg/controllers/machinesync/machine_sync_controller.go
@@ -47,10 +47,6 @@ const (
 var (
 	// errPlatformNotSupported is returned when the platform is not supported.
 	errPlatformNotSupported = errors.New("error determining InfraMachine type, platform not supported")
-
-	// errAuthoritativeAPIUnexpected is returned when we receive an unexpected
-	// AuthoritativeAPI.
-	errAuthoritativeAPIUnexpected = errors.New("AuthoritativeAPI unexpected value")
 )
 
 // MachineSyncReconciler reconciles CAPI and MAPI machines.
@@ -172,7 +168,8 @@ func (r *MachineSyncReconciler) Reconcile(ctx context.Context, req reconcile.Req
 		logger.Info("machine currently migrating", "machine", mapiMachine.GetName())
 		return ctrl.Result{}, nil
 	default:
-		return ctrl.Result{}, fmt.Errorf("%w: %s", errAuthoritativeAPIUnexpected, mapiMachine.Spec.AuthoritativeAPI)
+		logger.Info("machine AuthoritativeAPI has unexpected value", "AuthoritativeAPI", mapiMachine.Status.AuthoritativeAPI, "machine", mapiMachine.GetName())
+		return ctrl.Result{}, nil
 	}
 }
 

--- a/pkg/test/crdbuilder.go
+++ b/pkg/test/crdbuilder.go
@@ -49,11 +49,17 @@ var (
 	// fakeClusterCRD is a fake Cluster CRD.
 	fakeClusterCRD = generateCRD(clusterGroupVersion.WithKind(fakeClusterKind))
 
-	// fakeClusterKind is the Kind for the Cluster.
+	// fakeMachineKind is the Kind for the Machine.
 	fakeMachineKind = "Machine"
 
-	// fakeClusterCRD is a fake Cluster CRD.
+	// fakeMachineCRD is a fake Machine CRD.
 	fakeMachineCRD = generateCRD(clusterGroupVersion.WithKind(fakeMachineKind))
+
+	// fakeMachineSetKind is the kind for the MachineSet.
+	fakeMachineSetKind = "MachineSet"
+
+	// fakeMachineSetCRD is a fake MachineSet CRD.
+	fakeMachineSetCRD = generateCRD(clusterGroupVersion.WithKind(fakeMachineSetKind))
 
 	// v1beta2InfrastructureGroupVersion is a v1beta2 group version used for infrastructure objects.
 	v1beta2InfrastructureGroupVersion = schema.GroupVersion{Group: "infrastructure.cluster.x-k8s.io", Version: "v1beta2"}

--- a/pkg/test/envtest.go
+++ b/pkg/test/envtest.go
@@ -60,6 +60,7 @@ func StartEnvTest(testEnv *envtest.Environment) (*rest.Config, client.Client, er
 		fakeInfrastructureProviderCRD,
 		fakeClusterCRD,
 		fakeMachineCRD,
+		fakeMachineSetCRD,
 		fakeAWSClusterCRD,
 		fakeAzureClusterCRD,
 		fakeGCPClusterCRD,


### PR DESCRIPTION
-> Updates MachineSetSync reconciler to not return an error if AuthoritativeAPI has an unexpected value
-> Adds split reconciliation logic to split the reconciliation depending on which MachineAuthority is set.
-> Reworks MachineSet test suite to use helper funcs from `/pkg/test`
-> Updates helper funcs in `/pkg/test` to contain fake MachineSet CRD 