### PR TITLE
OCPBUGS-42490: fix: azure: do not deploy CAPI on AzureStackCloud

### DIFF
--- a/cmd/cluster-capi-operator/main.go
+++ b/cmd/cluster-capi-operator/main.go
@@ -267,10 +267,10 @@ func setupPlatformReconcilers(mgr manager.Manager, infra *configv1.Infrastructur
 		if azureCloudEnvironment == configv1.AzureStackCloud {
 			klog.Infof("Detected Azure Cloud Environment %q on platform %q is not supported, skipping capi controllers setup", azureCloudEnvironment, platform)
 			setupUnsupportedController(mgr, managedNamespace)
+		} else {
+			setupReconcilers(mgr, infra, platform, &azurev1.AzureCluster{}, containerImages, applyClient, apiextensionsClient, managedNamespace)
+			setupWebhooks(mgr)
 		}
-
-		setupReconcilers(mgr, infra, platform, &azurev1.AzureCluster{}, containerImages, applyClient, apiextensionsClient, managedNamespace)
-		setupWebhooks(mgr)
 	case configv1.PowerVSPlatformType:
 		setupReconcilers(mgr, infra, platform, &ibmpowervsv1.IBMPowerVSCluster{}, containerImages, applyClient, apiextensionsClient, managedNamespace)
 		setupWebhooks(mgr)


### PR DESCRIPTION
Following up from https://github.com/openshift/cluster-capi-operator/pull/210 the logic was wrong and kept setting up the normal reconcilers even after the NoopReconciler was set up. This should instead be set up as an alternative to the other controllers in the case of running on ASH.