### PR TITLE
OCPCLOUD-2749: capi2mapi conversion pkg negative testing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/onsi/gomega v1.34.2
 	github.com/openshift/api v0.0.0-20241009131553-a1523024209f
 	github.com/openshift/client-go v0.0.0-20241001162912-da6d55e4611f
-	github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20241007145816-7038c320d36c
+	github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20241021095320-149bd4ea9cf3
 	github.com/openshift/cluster-control-plane-machine-set-operator v0.0.0-20241008085214-8d85b2cb2c1d
 	github.com/openshift/library-go v0.0.0-20240919205913-c96b82b3762b
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -423,8 +423,8 @@ github.com/openshift/api v0.0.0-20241009131553-a1523024209f h1:nxQl2ZH5Lr7KzM1zH
 github.com/openshift/api v0.0.0-20241009131553-a1523024209f/go.mod h1:Shkl4HanLwDiiBzakv+con/aMGnVE2MAGvoKp5oyYUo=
 github.com/openshift/client-go v0.0.0-20241001162912-da6d55e4611f h1:FRc0bVNWprihWS0GqQWzb3dY4dkCwpOP3mDw5NwSoR4=
 github.com/openshift/client-go v0.0.0-20241001162912-da6d55e4611f/go.mod h1:KiZi2mJRH1TOJ3FtBDYS6YvUL30s/iIXaGSUrSa36mo=
-github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20241007145816-7038c320d36c h1:9A/0QoTZo2xh5j6nmh5CGNVBG8Ql1RmXmCcrikBnG+w=
-github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20241007145816-7038c320d36c/go.mod h1:EN1Sv7kcVtaLUiXpZ8V0iSiJxNPPz1H3ZhCmNRpJWZM=
+github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20241021095320-149bd4ea9cf3 h1:5j+bmEkqDctzac5sVTqfQV0s/j+vv1otYWqbZNzC0KM=
+github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20241021095320-149bd4ea9cf3/go.mod h1:Ns6d57JhMddy6w5c61HHWQ4jqF8Pvrv8mgs2gxg5jKU=
 github.com/openshift/cluster-control-plane-machine-set-operator v0.0.0-20241008085214-8d85b2cb2c1d h1:X4NkXsGOvS5pRBYaaLfLoUVMYbXl00I07dJFnNdxbq0=
 github.com/openshift/cluster-control-plane-machine-set-operator v0.0.0-20241008085214-8d85b2cb2c1d/go.mod h1:u+45mmWUg2ld7nsPDXzntjMsxannCV0CVmcUj9tIDvU=
 github.com/openshift/library-go v0.0.0-20240919205913-c96b82b3762b h1:y2DduJug7UZqTu0QTkRPAu73nskuUbFA66fmgxVf/fI=

--- a/pkg/conversion/capi2mapi/aws_test.go
+++ b/pkg/conversion/capi2mapi/aws_test.go
@@ -18,75 +18,240 @@ package capi2mapi
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
+	capibuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/cluster-api/core/v1beta1"
+	capabuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2"
+	"github.com/openshift/cluster-capi-operator/pkg/conversion/test/matchers"
 	"k8s.io/utils/ptr"
 	capav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
-	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
-var _ = Describe("capi2mapi AWS", func() {
+var _ = Describe("capi2mapi AWS conversion", func() {
+	var (
+		awsCAPIMachineBase    = capibuilder.Machine()
+		awsCAPIAWSMachineBase = capabuilder.AWSMachine()
+		awsCAPIAWSClusterBase = capabuilder.AWSCluster()
+	)
 
-	awsMachineTemplate := &capav1.AWSMachineTemplate{
-		Spec: capav1.AWSMachineTemplateSpec{
-			Template: capav1.AWSMachineTemplateResource{
-				Spec: capav1.AWSMachineSpec{
-					ProviderID: ptr.To("test-123"),
-					InstanceID: ptr.To("test-123"),
-					PublicIP:   ptr.To(false),
-				},
-			},
-		},
-		Status: capav1.AWSMachineTemplateStatus{},
+	type awsCAPI2MAPIMachineConversionInput struct {
+		machineBuilder    capibuilder.MachineBuilder
+		awsMachineBuilder capabuilder.AWSMachineBuilder
+		awsClusterBuilder capabuilder.AWSClusterBuilder
+		expectedErrors    []string
+		expectedWarnings  []string
 	}
 
-	awsMachine := &capav1.AWSMachine{
-		Spec: capav1.AWSMachineSpec{
-			ProviderID: ptr.To("test-123"),
-			InstanceID: ptr.To("test-123"),
-			PublicIP:   ptr.To(false),
-		},
+	type awsCAPI2MAPIMachinesetConversionInput struct {
+		machineSetBuilder         capibuilder.MachineSetBuilder
+		awsMachineTemplateBuilder capabuilder.AWSMachineTemplateBuilder
+		awsClusterBuilder         capabuilder.AWSClusterBuilder
+		expectedErrors            []string
+		expectedWarnings          []string
 	}
 
-	capiMachine := &capiv1.Machine{
-		Spec: capiv1.MachineSpec{
-			ClusterName: "test-123",
+	var _ = DescribeTable("capi2mapi AWS convert CAPI Machine/InfraMachine/InfraCluster to a MAPI Machine",
+		func(in awsCAPI2MAPIMachineConversionInput) {
+			_, warns, err := FromMachineAndAWSMachineAndAWSCluster(
+				in.machineBuilder.Build(),
+				in.awsMachineBuilder.Build(),
+				in.awsClusterBuilder.Build(),
+			).ToMachine()
+			Expect(err).To(matchers.ConsistOfMatchErrorSubstrings(in.expectedErrors),
+				"should match expected errors while converting AWS CAPI resources to MAPI Machine")
+			Expect(warns).To(matchers.ConsistOfSubstrings(in.expectedWarnings),
+				"should match expected warnings while converting AWS CAPI resources to MAPI Machine")
 		},
-	}
 
-	awsMachineSet := &capiv1.MachineSet{
-		Spec: capiv1.MachineSetSpec{
-			Replicas:    ptr.To(int32(2)),
-			ClusterName: "test-123",
-			Template: capiv1.MachineTemplateSpec{
-				Spec: capiv1.MachineSpec{
-					ClusterName: "test-123",
-				},
-			},
+		// Base Case.
+		Entry("With a Base configuration", awsCAPI2MAPIMachineConversionInput{
+			awsClusterBuilder: awsCAPIAWSClusterBase,
+			awsMachineBuilder: awsCAPIAWSMachineBase,
+			machineBuilder:    awsCAPIMachineBase,
+			expectedErrors:    []string{},
+			expectedWarnings:  []string{},
+		}),
+		Entry("With unsupported EKSOptimizedLookupType", awsCAPI2MAPIMachineConversionInput{
+			awsClusterBuilder: awsCAPIAWSClusterBase,
+			awsMachineBuilder: capabuilder.AWSMachine().
+				WithAMI(capav1.AMIReference{
+					EKSOptimizedLookupType: ptr.To(capav1.EKSAMILookupType("unsupported")),
+				}),
+			machineBuilder:   awsCAPIMachineBase,
+			expectedErrors:   []string{"spec.ami.eksOptimizedLookupType: Invalid value: \"unsupported\": eksOptimizedLookupType is not supported"},
+			expectedWarnings: []string{},
+		}),
+
+		Entry("With unsupported ImageLookupFormat", awsCAPI2MAPIMachineConversionInput{
+			awsClusterBuilder: awsCAPIAWSClusterBase,
+			awsMachineBuilder: awsCAPIAWSMachineBase.WithImageLookupFormat("unsupported"),
+			machineBuilder:    awsCAPIMachineBase,
+			expectedErrors:    []string{"spec.imageLookupFormat: Invalid value: \"unsupported\": imageLookupFormat is not supported"},
+			expectedWarnings:  []string{},
+		}),
+
+		Entry("With unsupported ImageLookupOrg", awsCAPI2MAPIMachineConversionInput{
+			awsClusterBuilder: awsCAPIAWSClusterBase,
+			awsMachineBuilder: awsCAPIAWSMachineBase.WithImageLookupOrg("unsupported"),
+			machineBuilder:    awsCAPIMachineBase,
+			expectedErrors:    []string{"spec.imageLookupOrg: Invalid value: \"unsupported\": imageLookupOrg is not supported"},
+			expectedWarnings:  []string{},
+		}),
+
+		Entry("With unsupported ImageLookupBaseOS", awsCAPI2MAPIMachineConversionInput{
+			awsClusterBuilder: awsCAPIAWSClusterBase,
+			awsMachineBuilder: awsCAPIAWSMachineBase.WithImageLookupBaseOS("unsupported"),
+			machineBuilder:    awsCAPIMachineBase,
+			expectedErrors:    []string{"spec.imageLookupBaseOS: Invalid value: \"unsupported\": imageLookupBaseOS is not supported"},
+			expectedWarnings:  []string{},
+		}),
+
+		Entry("With unsupported SecurityGroupOverrides", awsCAPI2MAPIMachineConversionInput{
+			awsClusterBuilder: awsCAPIAWSClusterBase,
+			awsMachineBuilder: awsCAPIAWSMachineBase.WithSecurityGroupOverrides(map[capav1.SecurityGroupRole]string{"sg-1": "sg-2"}),
+			machineBuilder:    awsCAPIMachineBase,
+			expectedErrors:    []string{"spec.securityGroupOverrides: Invalid value: map[v1beta2.SecurityGroupRole]string{\"sg-1\":\"sg-2\"}: securityGroupOverrides are not supported"},
+			expectedWarnings:  []string{},
+		}),
+
+		Entry("With unsupported NetworkInterfaces", awsCAPI2MAPIMachineConversionInput{
+			awsClusterBuilder: awsCAPIAWSClusterBase,
+			awsMachineBuilder: awsCAPIAWSMachineBase.
+				WithNetworkInterfaces([]string{"eni-12345", "eni-67890"}),
+			machineBuilder:   awsCAPIMachineBase,
+			expectedErrors:   []string{"spec.networkInterfaces: Invalid value: []string{\"eni-12345\", \"eni-67890\"}: networkInterfaces are not supported"},
+			expectedWarnings: []string{},
+		}),
+
+		Entry("With unsupported UncompressedUserData", awsCAPI2MAPIMachineConversionInput{
+			awsClusterBuilder: awsCAPIAWSClusterBase,
+			awsMachineBuilder: awsCAPIAWSMachineBase.WithUncompressedUserData(ptr.To(true)),
+			machineBuilder:    awsCAPIMachineBase,
+			expectedErrors:    []string{"spec.uncompressedUserData: Invalid value: true: uncompressedUserData is not supported"},
+			expectedWarnings:  []string{},
+		}),
+
+		Entry("With unsupported CloudInit", awsCAPI2MAPIMachineConversionInput{
+			awsClusterBuilder: awsCAPIAWSClusterBase,
+			awsMachineBuilder: awsCAPIAWSMachineBase.WithCloudInit(capav1.CloudInit{InsecureSkipSecretsManager: true}),
+			machineBuilder:    awsCAPIMachineBase,
+			expectedErrors:    []string{"spec.cloudInit: Invalid value: v1beta2.CloudInit{InsecureSkipSecretsManager:true, SecretCount:0, SecretPrefix:\"\", SecureSecretsBackend:\"\"}: cloudInit is not supported"},
+			expectedWarnings:  []string{},
+		}),
+
+		Entry("With unsupported PrivateDNSName", awsCAPI2MAPIMachineConversionInput{
+			awsClusterBuilder: awsCAPIAWSClusterBase,
+			awsMachineBuilder: awsCAPIAWSMachineBase.WithPrivateDNSName(&capav1.PrivateDNSName{}),
+			machineBuilder:    awsCAPIMachineBase,
+			expectedErrors:    []string{"spec.privateDNSName: Invalid value: v1beta2.PrivateDNSName{EnableResourceNameDNSAAAARecord:(*bool)(nil), EnableResourceNameDNSARecord:(*bool)(nil), HostnameType:(*string)(nil)}: privateDNSName is not supported"},
+			expectedWarnings:  []string{},
+		}),
+
+		Entry("With unsupported Ignition Proxy", awsCAPI2MAPIMachineConversionInput{
+			awsClusterBuilder: awsCAPIAWSClusterBase,
+			awsMachineBuilder: awsCAPIAWSMachineBase.
+				WithIgnition(&capav1.Ignition{
+					Proxy: &capav1.IgnitionProxy{},
+				}),
+			machineBuilder:   awsCAPIMachineBase,
+			expectedErrors:   []string{"spec.ignition.proxy: Invalid value: v1beta2.IgnitionProxy{HTTPProxy:(*string)(nil), HTTPSProxy:(*string)(nil), NoProxy:[]v1beta2.IgnitionNoProxy(nil)}: ignition proxy is not supported"},
+			expectedWarnings: []string{},
+		}),
+
+		Entry("With unsupported Ignition TLS", awsCAPI2MAPIMachineConversionInput{
+			awsClusterBuilder: awsCAPIAWSClusterBase,
+			awsMachineBuilder: awsCAPIAWSMachineBase.
+				WithIgnition(&capav1.Ignition{
+					TLS: &capav1.IgnitionTLS{
+						CASources: []capav1.IgnitionCASource{"a", "b"},
+					},
+				}),
+			machineBuilder:   awsCAPIMachineBase,
+			expectedErrors:   []string{"spec.ignition.tls: Invalid value: v1beta2.IgnitionTLS{CASources:[]v1beta2.IgnitionCASource{\"a\", \"b\"}}: ignition tls is not supported"},
+			expectedWarnings: []string{},
+		}),
+		Entry("With unsupported httpEndpoint", awsCAPI2MAPIMachineConversionInput{
+			awsClusterBuilder: awsCAPIAWSClusterBase,
+			awsMachineBuilder: awsCAPIAWSMachineBase.
+				WithInstanceMetadataOptions(&capav1.InstanceMetadataOptions{
+					HTTPEndpoint: capav1.InstanceMetadataEndpointStateDisabled,
+				}),
+			machineBuilder:   awsCAPIMachineBase,
+			expectedErrors:   []string{"spec.instanceMetadataOptions.httpEndpoint: Invalid value: \"disabled\": httpEndpoint values other than \"enabled\" are not supported"},
+			expectedWarnings: []string{},
+		}),
+
+		Entry("With unsupported httpPutResponseHopLimit", awsCAPI2MAPIMachineConversionInput{
+			awsClusterBuilder: awsCAPIAWSClusterBase,
+			awsMachineBuilder: awsCAPIAWSMachineBase.
+				WithInstanceMetadataOptions(&capav1.InstanceMetadataOptions{
+					HTTPPutResponseHopLimit: 2,
+				}),
+			machineBuilder:   awsCAPIMachineBase,
+			expectedErrors:   []string{"spec.instanceMetadataOptions.httpPutResponseHopLimit: Invalid value: 2: httpPutResponseHopLimit values other than 1 are not supported"},
+			expectedWarnings: []string{},
+		}),
+
+		Entry("With unsupported httpTokens", awsCAPI2MAPIMachineConversionInput{
+			awsClusterBuilder: awsCAPIAWSClusterBase,
+			awsMachineBuilder: awsCAPIAWSMachineBase.
+				WithInstanceMetadataOptions(&capav1.InstanceMetadataOptions{
+					HTTPTokens: "unsupported",
+				}),
+			machineBuilder:   awsCAPIMachineBase,
+			expectedErrors:   []string{"spec.instanceMetadataOptions.httpTokens: Invalid value: \"unsupported\": unable to convert httpTokens state, unknown value"},
+			expectedWarnings: []string{},
+		}),
+
+		Entry("With unsupported instanceMetadataTags", awsCAPI2MAPIMachineConversionInput{
+			awsClusterBuilder: awsCAPIAWSClusterBase,
+			awsMachineBuilder: awsCAPIAWSMachineBase.
+				WithInstanceMetadataOptions(&capav1.InstanceMetadataOptions{
+					InstanceMetadataTags: capav1.InstanceMetadataEndpointStateEnabled,
+				}),
+			machineBuilder:   awsCAPIMachineBase,
+			expectedErrors:   []string{"spec.instanceMetadataOptions.instanceMetadataTags: Invalid value: \"enabled\": instanceMetadataTags values other than \"disabled\" are not supported"},
+			expectedWarnings: []string{},
+		}),
+
+		// Test case for multiple metadata-related fields
+		Entry("With multiple unsupported metadata options", awsCAPI2MAPIMachineConversionInput{
+			awsClusterBuilder: awsCAPIAWSClusterBase,
+			awsMachineBuilder: awsCAPIAWSMachineBase.
+				WithInstanceMetadataOptions(&capav1.InstanceMetadataOptions{
+					HTTPEndpoint:            capav1.InstanceMetadataEndpointStateDisabled,
+					HTTPPutResponseHopLimit: 2,
+					HTTPTokens:              "unsupported",
+					InstanceMetadataTags:    capav1.InstanceMetadataEndpointStateEnabled,
+				}),
+			machineBuilder: awsCAPIMachineBase,
+			expectedErrors: []string{
+				"spec.instanceMetadataOptions.httpTokens: Invalid value: \"unsupported\": unable to convert httpTokens state, unknown value",
+				"spec.instanceMetadataOptions.httpEndpoint: Invalid value: \"disabled\": httpEndpoint values other than \"enabled\" are not supported",
+				"spec.instanceMetadataOptions.httpPutResponseHopLimit: Invalid value: 2: httpPutResponseHopLimit values other than 1 are not supported",
+				"spec.instanceMetadataOptions.instanceMetadataTags: Invalid value: \"enabled\": instanceMetadataTags values other than \"disabled\" are not supported"},
+			expectedWarnings: []string{},
+		}),
+	)
+
+	var _ = DescribeTable("capi2mapi AWS convert CAPI MachineSet/InfraMachineTemplate/InfraCluster to MAPI MachineSet",
+		func(in awsCAPI2MAPIMachinesetConversionInput) {
+			_, warns, err := FromMachineSetAndAWSMachineTemplateAndAWSCluster(
+				in.machineSetBuilder.Build(),
+				in.awsMachineTemplateBuilder.Build(),
+				in.awsClusterBuilder.Build(),
+			).ToMachineSet()
+			Expect(err).To(matchers.ConsistOfMatchErrorSubstrings(in.expectedErrors),
+				"should match expected errors while converting AWS CAPI resources to MAPI MachineSet")
+			Expect(warns).To(matchers.ConsistOfSubstrings(in.expectedWarnings),
+				"should match expected warnings while converting AWS CAPI resources to MAPI MachineSet")
 		},
-	}
 
-	capiAWSCluster := &capav1.AWSCluster{
-		Spec: capav1.AWSClusterSpec{
-			Region: "us-east-2",
-		},
-		Status: capav1.AWSClusterStatus{
-			Ready: true,
-		},
-	}
-
-	It("should be able to convert a CAPI Machine to a MAPI Machine", func() {
-		mapiMachine, warns, err :=
-			FromMachineAndAWSMachineAndAWSCluster(capiMachine, awsMachine, capiAWSCluster).ToMachine()
-		Expect(mapiMachine).To(Not(BeNil()), "should not have a nil MAPI Machine")
-		Expect(err).ToNot(HaveOccurred(), "should have been able to convert CAPI Machine/AWSMachineTemplate to MAPI Machine")
-		Expect(warns).To(BeEmpty(), "should have not warned while converting CAPI Machine/AWSMachineTemplate to MAPI Machine")
-	})
-
-	It("should be able to convert a MAPI MachineSet to a CAPI MachineSet", func() {
-		mapiMachineSet, warns, err :=
-			FromMachineSetAndAWSMachineTemplateAndAWSCluster(awsMachineSet, awsMachineTemplate, capiAWSCluster).ToMachineSet()
-		Expect(mapiMachineSet).To(Not(BeNil()), "should not have a nil MAPI MachineSet")
-		Expect(err).ToNot(HaveOccurred(), "should have been able to convert CAPI MachineSet/AWSMachineTemplate to MAPI MachineSet")
-		Expect(warns).To(BeEmpty(), "should have not warned while converting CAPI MachineSet/AWSMachineTemplate to MAPI MachineSet")
-	})
+		// Base Case.
+		Entry("With a Base configuration", awsCAPI2MAPIMachinesetConversionInput{
+			awsClusterBuilder:         awsCAPIAWSClusterBase,
+			awsMachineTemplateBuilder: capabuilder.AWSMachineTemplate(),
+			machineSetBuilder:         capibuilder.MachineSet(),
+			expectedErrors:            []string{},
+			expectedWarnings:          []string{},
+		}),
+	)
 })

--- a/pkg/conversion/capi2mapi/machine.go
+++ b/pkg/conversion/capi2mapi/machine.go
@@ -34,8 +34,8 @@ const (
 // fromCAPIMachineToMAPIMachine translates a core CAPI Machine to its MAPI Machine correspondent.
 //
 //nolint:funlen
-func fromCAPIMachineToMAPIMachine(capiMachine *capiv1.Machine) (*mapiv1.Machine, error) {
-	errs := []*field.Error{}
+func fromCAPIMachineToMAPIMachine(capiMachine *capiv1.Machine) (*mapiv1.Machine, field.ErrorList) {
+	errs := field.ErrorList{}
 
 	mapiMachine := &mapiv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
@@ -97,7 +97,7 @@ func fromCAPIMachineToMAPIMachine(capiMachine *capiv1.Machine) (*mapiv1.Machine,
 
 	if len(errs) > 0 {
 		// Return the mapiMachine so that the logic continues and collects all possible conversion errors.
-		return mapiMachine, field.ErrorList(errs).ToAggregate()
+		return mapiMachine, errs
 	}
 
 	return mapiMachine, nil

--- a/pkg/conversion/capi2mapi/machine_test.go
+++ b/pkg/conversion/capi2mapi/machine_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package capi2mapi
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	capibuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/cluster-api/core/v1beta1"
+	capabuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2"
+	"github.com/openshift/cluster-capi-operator/pkg/conversion/test/matchers"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+var _ = Describe("capi2mapi Machine conversion", func() {
+	var (
+		capiMachineBase = capibuilder.Machine()
+	)
+
+	type capi2MAPIMachineConversionInput struct {
+		machineBuilder   capibuilder.MachineBuilder
+		expectedErrors   []string
+		expectedWarnings []string
+	}
+
+	var _ = DescribeTable("capi2mapi convert CAPI Machine/InfraMachine/InfraCluster to a MAPI Machine",
+		func(in capi2MAPIMachineConversionInput) {
+			_, warns, err := FromMachineAndAWSMachineAndAWSCluster(
+				in.machineBuilder.Build(),
+				capabuilder.AWSMachine().Build(),
+				capabuilder.AWSCluster().Build(),
+			).ToMachine()
+			Expect(err).To(matchers.ConsistOfMatchErrorSubstrings(in.expectedErrors),
+				"should match expected errors while converting CAPI resources to MAPI Machine")
+			Expect(warns).To(matchers.ConsistOfSubstrings(in.expectedWarnings),
+				"should match expected warnings while converting CAPI resources to MAPI Machine")
+		},
+
+		// Base Case.
+		Entry("With a Base configuration", capi2MAPIMachineConversionInput{
+			machineBuilder:   capiMachineBase,
+			expectedErrors:   []string{},
+			expectedWarnings: []string{},
+		}),
+		Entry("With unsupported Version", capi2MAPIMachineConversionInput{
+			machineBuilder:   capiMachineBase.WithVersion(ptr.To("v1.1.1")),
+			expectedErrors:   []string{"spec.version: Invalid value: \"v1.1.1\": version is not supported"},
+			expectedWarnings: []string{},
+		}),
+		Entry("With unsupported NodeDrainTimeout", capi2MAPIMachineConversionInput{
+			machineBuilder:   capiMachineBase.WithNodeDrainTimeout(ptr.To(metav1.Duration{Duration: 1 * time.Second})),
+			expectedErrors:   []string{"spec.nodeDrainTimeout: Invalid value: v1.Duration{Duration:1000000000}: nodeDrainTimeout is not supported"},
+			expectedWarnings: []string{},
+		}),
+		Entry("With unsupported NodeVolumeDetachTimeout", capi2MAPIMachineConversionInput{
+			machineBuilder:   capiMachineBase.WithNodeVolumeDetachTimeout(ptr.To(metav1.Duration{Duration: 1 * time.Second})),
+			expectedErrors:   []string{"spec.nodeVolumeDetachTimeout: Invalid value: v1.Duration{Duration:1000000000}: nodeVolumeDetachTimeout is not supported"},
+			expectedWarnings: []string{},
+		}),
+		Entry("With unsupported NodeDeletionTimeout", capi2MAPIMachineConversionInput{
+			machineBuilder:   capiMachineBase.WithNodeDeletionTimeout(ptr.To(metav1.Duration{Duration: 1 * time.Second})),
+			expectedErrors:   []string{"spec.nodeDeletionTimeout: Invalid value: v1.Duration{Duration:1000000000}: nodeDeletionTimeout is not supported"},
+			expectedWarnings: []string{},
+		}),
+	)
+})

--- a/pkg/conversion/capi2mapi/machineset_test.go
+++ b/pkg/conversion/capi2mapi/machineset_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package capi2mapi
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	capibuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/cluster-api/core/v1beta1"
+	capabuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2"
+	"github.com/openshift/cluster-capi-operator/pkg/conversion/test/matchers"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("capi2mapi MachineSet conversion", func() {
+	var (
+		capiMachineSetBase = capibuilder.MachineSet()
+	)
+
+	type capi2MAPIMachinesetConversionInput struct {
+		machineSetBuilder capibuilder.MachineSetBuilder
+		expectedErrors    []string
+		expectedWarnings  []string
+	}
+
+	var _ = DescribeTable("capi2mapi convert CAPI MachineSet/InfraMachineTemplate/InfraCluster to MAPI MachineSet",
+		func(in capi2MAPIMachinesetConversionInput) {
+			_, warns, err := FromMachineSetAndAWSMachineTemplateAndAWSCluster(
+				in.machineSetBuilder.Build(),
+				capabuilder.AWSMachineTemplate().Build(),
+				capabuilder.AWSCluster().Build(),
+			).ToMachineSet()
+			Expect(err).To(matchers.ConsistOfMatchErrorSubstrings(in.expectedErrors),
+				"should match expected errors while converting CAPI resources to MAPI MachineSet")
+			Expect(warns).To(matchers.ConsistOfSubstrings(in.expectedWarnings),
+				"should match expected warnings while converting CAPI resources to MAPI MachineSet")
+		},
+
+		// Base Case.
+		Entry("With a Base configuration", capi2MAPIMachinesetConversionInput{
+			machineSetBuilder: capiMachineSetBase,
+			expectedErrors:    []string{},
+			expectedWarnings:  []string{},
+		}),
+		Entry("With unsupported OwnerReferences", capi2MAPIMachinesetConversionInput{
+			machineSetBuilder: capiMachineSetBase.WithOwnerReferences([]metav1.OwnerReference{{Name: "a"}}),
+			expectedErrors:    []string{"metadata.ownerReferences: Invalid value: []v1.OwnerReference{v1.OwnerReference{APIVersion:\"\", Kind:\"\", Name:\"a\", UID:\"\", Controller:(*bool)(nil), BlockOwnerDeletion:(*bool)(nil)}}: ownerReferences are not supported"},
+			expectedWarnings:  []string{},
+		}),
+	)
+})

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/cluster-api/core/v1beta1/cluster.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/cluster-api/core/v1beta1/cluster.go
@@ -1,0 +1,234 @@
+/*
+Copyright 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	capierrors "sigs.k8s.io/cluster-api/errors"
+)
+
+// Cluster creates a new cluster builder.
+func Cluster() ClusterBuilder {
+	return ClusterBuilder{}
+}
+
+// ClusterBuilder is used to build out a Cluster object.
+type ClusterBuilder struct {
+	// Object meta fields.
+	annotations       map[string]string
+	creationTimestamp metav1.Time
+	deletionTimestamp *metav1.Time
+	generateName      string
+	labels            map[string]string
+	name              string
+	namespace         string
+	ownerReferences   []metav1.OwnerReference
+
+	// Spec fields.
+	clusterNetwork       *capiv1.ClusterNetwork
+	controlPlaneEndpoint capiv1.APIEndpoint
+	controlPlaneRef      *corev1.ObjectReference
+	infrastructureRef    *corev1.ObjectReference
+	paused               bool
+	topology             *capiv1.Topology
+
+	// Status fields.
+	conditions          capiv1.Conditions
+	controlPlaneReady   bool
+	failureDomains      capiv1.FailureDomains
+	failureMessage      *string
+	failureReason       *capierrors.ClusterStatusError
+	infrastructureReady bool
+	observedGeneration  int64
+	phase               string
+}
+
+// Build builds a new cluster based on the configuration provided.
+func (c ClusterBuilder) Build() *capiv1.Cluster {
+	cluster := &capiv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations:       c.annotations,
+			CreationTimestamp: c.creationTimestamp,
+			DeletionTimestamp: c.deletionTimestamp,
+			GenerateName:      c.generateName,
+			Labels:            c.labels,
+			Name:              c.name,
+			Namespace:         c.namespace,
+			OwnerReferences:   c.ownerReferences,
+		},
+		Spec: capiv1.ClusterSpec{
+			ClusterNetwork:       c.clusterNetwork,
+			ControlPlaneEndpoint: c.controlPlaneEndpoint,
+			ControlPlaneRef:      c.controlPlaneRef,
+			InfrastructureRef:    c.infrastructureRef,
+			Paused:               c.paused,
+			Topology:             c.topology,
+		},
+		Status: capiv1.ClusterStatus{
+			Conditions:          c.conditions,
+			ControlPlaneReady:   c.controlPlaneReady,
+			FailureDomains:      c.failureDomains,
+			FailureMessage:      c.failureMessage,
+			FailureReason:       c.failureReason,
+			InfrastructureReady: c.infrastructureReady,
+			ObservedGeneration:  c.observedGeneration,
+			Phase:               c.phase,
+		},
+	}
+
+	return cluster
+}
+
+// Object meta field.
+
+// WithAnnotations sets the annotations for the cluster builder.
+func (c ClusterBuilder) WithAnnotations(annotations map[string]string) ClusterBuilder {
+	c.annotations = annotations
+	return c
+}
+
+// WithGenerateName sets the generateName for the cluster builder.
+func (c ClusterBuilder) WithGenerateName(generateName string) ClusterBuilder {
+	c.generateName = generateName
+	return c
+}
+
+// WithCreationTimestamp sets the creationTimestamp for the cluster builder.
+func (c ClusterBuilder) WithCreationTimestamp(timestamp metav1.Time) ClusterBuilder {
+	c.creationTimestamp = timestamp
+	return c
+}
+
+// WithDeletionTimestamp sets the deletionTimestamp for the cluster builder.
+func (c ClusterBuilder) WithDeletionTimestamp(timestamp *metav1.Time) ClusterBuilder {
+	c.deletionTimestamp = timestamp
+	return c
+}
+
+// WithLabels sets the labels for the cluster builder.
+func (c ClusterBuilder) WithLabels(labels map[string]string) ClusterBuilder {
+	c.labels = labels
+	return c
+}
+
+// WithName sets the name for the cluster builder.
+func (c ClusterBuilder) WithName(name string) ClusterBuilder {
+	c.name = name
+	return c
+}
+
+// WithNamespace sets the namespace for the cluster builder.
+func (c ClusterBuilder) WithNamespace(namespace string) ClusterBuilder {
+	c.namespace = namespace
+	return c
+}
+
+// WithOwnerReferences sets the OwnerReferences for the cluster builder.
+func (c ClusterBuilder) WithOwnerReferences(ownerRefs []metav1.OwnerReference) ClusterBuilder {
+	c.ownerReferences = ownerRefs
+	return c
+}
+
+// Spec fields.
+
+// WithClusterNetwork sets the cluster network for the cluster builder.
+func (c ClusterBuilder) WithClusterNetwork(network *capiv1.ClusterNetwork) ClusterBuilder {
+	c.clusterNetwork = network
+	return c
+}
+
+// WithControlPlaneEndpoint sets the control plane endpoint for the cluster builder.
+func (c ClusterBuilder) WithControlPlaneEndpoint(endpoint capiv1.APIEndpoint) ClusterBuilder {
+	c.controlPlaneEndpoint = endpoint
+	return c
+}
+
+// WithControlPlaneRef sets the control plane reference for the cluster builder.
+func (c ClusterBuilder) WithControlPlaneRef(ref *corev1.ObjectReference) ClusterBuilder {
+	c.controlPlaneRef = ref
+	return c
+}
+
+// WithInfrastructureRef sets the infrastructure reference for the cluster builder.
+func (c ClusterBuilder) WithInfrastructureRef(ref *corev1.ObjectReference) ClusterBuilder {
+	c.infrastructureRef = ref
+	return c
+}
+
+// WithPaused sets the paused state for the cluster builder.
+func (c ClusterBuilder) WithPaused(paused bool) ClusterBuilder {
+	c.paused = paused
+	return c
+}
+
+// WithTopology sets the topology for the cluster builder.
+func (c ClusterBuilder) WithTopology(topology *capiv1.Topology) ClusterBuilder {
+	c.topology = topology
+	return c
+}
+
+// Status fields.
+
+// WithConditions sets the conditions for the cluster builder.
+func (c ClusterBuilder) WithConditions(conditions capiv1.Conditions) ClusterBuilder {
+	c.conditions = conditions
+	return c
+}
+
+// WithControlPlaneReady sets the control plane ready state for the cluster builder.
+func (c ClusterBuilder) WithControlPlaneReady(ready bool) ClusterBuilder {
+	c.controlPlaneReady = ready
+	return c
+}
+
+// WithFailureDomains sets the failure domains for the cluster builder.
+func (c ClusterBuilder) WithFailureDomains(failureDomains capiv1.FailureDomains) ClusterBuilder {
+	c.failureDomains = failureDomains
+	return c
+}
+
+// WithFailureMessage sets the failure message for the cluster builder.
+func (c ClusterBuilder) WithFailureMessage(message string) ClusterBuilder {
+	c.failureMessage = &message
+	return c
+}
+
+// WithFailureReason sets the failure reason for the cluster builder.
+func (c ClusterBuilder) WithFailureReason(reason capierrors.ClusterStatusError) ClusterBuilder {
+	c.failureReason = &reason
+	return c
+}
+
+// WithInfrastructureReady sets the infrastructure ready state for the cluster builder.
+func (c ClusterBuilder) WithInfrastructureReady(ready bool) ClusterBuilder {
+	c.infrastructureReady = ready
+	return c
+}
+
+// WithObservedGeneration sets the observed generation for the cluster builder.
+func (c ClusterBuilder) WithObservedGeneration(generation int64) ClusterBuilder {
+	c.observedGeneration = generation
+	return c
+}
+
+// WithPhase sets the phase for the cluster builder.
+func (c ClusterBuilder) WithPhase(phase string) ClusterBuilder {
+	c.phase = phase
+	return c
+}

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/cluster-api/core/v1beta1/machine.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/cluster-api/core/v1beta1/machine.go
@@ -1,0 +1,290 @@
+/*
+Copyright 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	capierrors "sigs.k8s.io/cluster-api/errors"
+)
+
+// Machine creates a new machine builder.
+func Machine() MachineBuilder {
+	return MachineBuilder{}
+}
+
+// MachineBuilder is used to build out a Machine object.
+type MachineBuilder struct {
+	// Object meta fields.
+	annotations       map[string]string
+	creationTimestamp metav1.Time
+	deletionTimestamp *metav1.Time
+	generateName      string
+	labels            map[string]string
+	name              string
+	namespace         string
+	ownerReferences   []metav1.OwnerReference
+
+	// Spec fields.
+	bootstrap               capiv1.Bootstrap
+	clusterName             string
+	failureDomain           *string
+	infrastructureRef       corev1.ObjectReference
+	nodeDeletionTimeout     *metav1.Duration
+	nodeDrainTimeout        *metav1.Duration
+	nodeVolumeDetachTimeout *metav1.Duration
+	providerID              *string
+	version                 *string
+
+	// Status fields.
+	addresses              capiv1.MachineAddresses
+	bootstrapReady         bool
+	certificatesExpiryDate *metav1.Time
+	conditions             capiv1.Conditions
+	failureMessage         *string
+	failureReason          *capierrors.MachineStatusError
+	infrastructureReady    bool
+	lastUpdated            *metav1.Time
+	nodeInfo               *corev1.NodeSystemInfo
+	nodeRef                *corev1.ObjectReference
+	observedGeneration     int64
+	phase                  capiv1.MachinePhase
+}
+
+// Build builds a new Machine based on the configuration provided.
+func (m MachineBuilder) Build() *capiv1.Machine {
+	machine := &capiv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations:       m.annotations,
+			CreationTimestamp: m.creationTimestamp,
+			DeletionTimestamp: m.deletionTimestamp,
+			GenerateName:      m.generateName,
+			Labels:            m.labels,
+			Name:              m.name,
+			Namespace:         m.namespace,
+			OwnerReferences:   m.ownerReferences,
+		},
+		Spec: capiv1.MachineSpec{
+			Bootstrap:               m.bootstrap,
+			ClusterName:             m.clusterName,
+			FailureDomain:           m.failureDomain,
+			InfrastructureRef:       m.infrastructureRef,
+			NodeDeletionTimeout:     m.nodeDeletionTimeout,
+			NodeDrainTimeout:        m.nodeDrainTimeout,
+			NodeVolumeDetachTimeout: m.nodeVolumeDetachTimeout,
+			ProviderID:              m.providerID,
+			Version:                 m.version,
+		},
+		Status: capiv1.MachineStatus{
+			Addresses:              m.addresses,
+			BootstrapReady:         m.bootstrapReady,
+			CertificatesExpiryDate: m.certificatesExpiryDate,
+			Conditions:             m.conditions,
+			FailureMessage:         m.failureMessage,
+			FailureReason:          m.failureReason,
+			InfrastructureReady:    m.infrastructureReady,
+			LastUpdated:            m.lastUpdated,
+			NodeInfo:               m.nodeInfo,
+			NodeRef:                m.nodeRef,
+			ObservedGeneration:     m.observedGeneration,
+			Phase:                  string(m.phase),
+		},
+	}
+
+	return machine
+}
+
+// Object meta fields.
+
+// WithAnnotations sets the Annotations for the machine builder.
+func (m MachineBuilder) WithAnnotations(annotations map[string]string) MachineBuilder {
+	m.annotations = annotations
+	return m
+}
+
+// WithCreationTimestamp sets the creationTimestamp for the machine builder.
+func (m MachineBuilder) WithCreationTimestamp(timestamp metav1.Time) MachineBuilder {
+	m.creationTimestamp = timestamp
+	return m
+}
+
+// WithDeletionTimestamp sets the deletionTimestamp for the machine builder.
+func (m MachineBuilder) WithDeletionTimestamp(timestamp *metav1.Time) MachineBuilder {
+	m.deletionTimestamp = timestamp
+	return m
+}
+
+// WithGenerateName sets the generateName for the machine builder.
+func (m MachineBuilder) WithGenerateName(generateName string) MachineBuilder {
+	m.generateName = generateName
+	return m
+}
+
+// WithLabels sets the Labels for the machine builder.
+func (m MachineBuilder) WithLabels(labels map[string]string) MachineBuilder {
+	m.labels = labels
+	return m
+}
+
+// WithName sets the Name for the machine builder.
+func (m MachineBuilder) WithName(name string) MachineBuilder {
+	m.name = name
+	return m
+}
+
+// WithNamespace sets the Namespace for the machine builder.
+func (m MachineBuilder) WithNamespace(namespace string) MachineBuilder {
+	m.namespace = namespace
+	return m
+}
+
+// WithOwnerReferences sets the OwnerReferences for the machine builder.
+func (m MachineBuilder) WithOwnerReferences(ownerRefs []metav1.OwnerReference) MachineBuilder {
+	m.ownerReferences = ownerRefs
+	return m
+}
+
+// Spec fields.
+
+// WithBootstrap sets the Bootstrap for the machine builder.
+func (m MachineBuilder) WithBootstrap(bootstrap capiv1.Bootstrap) MachineBuilder {
+	m.bootstrap = bootstrap
+	return m
+}
+
+// WithClusterName sets the ClusterName for the machine builder.
+func (m MachineBuilder) WithClusterName(clusterName string) MachineBuilder {
+	m.clusterName = clusterName
+	return m
+}
+
+// WithFailureDomain sets the FailureDomain for the machine builder.
+func (m MachineBuilder) WithFailureDomain(failureDomain *string) MachineBuilder {
+	m.failureDomain = failureDomain
+	return m
+}
+
+// WithInfrastructureRef sets the InfrastructureRef for the machine builder.
+func (m MachineBuilder) WithInfrastructureRef(infraRef corev1.ObjectReference) MachineBuilder {
+	m.infrastructureRef = infraRef
+	return m
+}
+
+// WithNodeDeletionTimeout sets the NodeDeletionTimeout for the machine builder.
+func (m MachineBuilder) WithNodeDeletionTimeout(timeout *metav1.Duration) MachineBuilder {
+	m.nodeDeletionTimeout = timeout
+	return m
+}
+
+// WithNodeDrainTimeout sets the NodeDrainTimeout for the machine builder.
+func (m MachineBuilder) WithNodeDrainTimeout(timeout *metav1.Duration) MachineBuilder {
+	m.nodeDrainTimeout = timeout
+	return m
+}
+
+// WithNodeVolumeDetachTimeout sets the NodeVolumeDetachTimeout for the machine builder.
+func (m MachineBuilder) WithNodeVolumeDetachTimeout(timeout *metav1.Duration) MachineBuilder {
+	m.nodeVolumeDetachTimeout = timeout
+	return m
+}
+
+// WithNodeRef sets the NodeRef for the machine builder.
+func (m MachineBuilder) WithNodeRef(nodeRef *corev1.ObjectReference) MachineBuilder {
+	m.nodeRef = nodeRef
+	return m
+}
+
+// WithProviderID sets the ProviderID for the machine builder.
+func (m MachineBuilder) WithProviderID(providerID *string) MachineBuilder {
+	m.providerID = providerID
+	return m
+}
+
+// WithVersion sets the Version for the machine builder.
+func (m MachineBuilder) WithVersion(version *string) MachineBuilder {
+	m.version = version
+	return m
+}
+
+// Status Fields.
+
+// WithAddresses sets the Addresses for the machine builder.
+func (m MachineBuilder) WithAddresses(addresses capiv1.MachineAddresses) MachineBuilder {
+	m.addresses = addresses
+	return m
+}
+
+// WithBootstrapReady sets the BootstrapReady for the machine builder.
+func (m MachineBuilder) WithBootstrapReady(ready bool) MachineBuilder {
+	m.bootstrapReady = ready
+	return m
+}
+
+// WithCertificatesExpiryDate sets the CertificatesExpiryDate for the machine builder.
+func (m MachineBuilder) WithCertificatesExpiryDate(expiryDate *metav1.Time) MachineBuilder {
+	m.certificatesExpiryDate = expiryDate
+	return m
+}
+
+// WithConditions sets the Conditions for the machine builder.
+func (m MachineBuilder) WithConditions(conditions capiv1.Conditions) MachineBuilder {
+	m.conditions = conditions
+	return m
+}
+
+// WithFailureMessage sets the FailureMessage for the machine builder.
+func (m MachineBuilder) WithFailureMessage(message *string) MachineBuilder {
+	m.failureMessage = message
+	return m
+}
+
+// WithFailureReason sets the FailureReason for the machine builder.
+func (m MachineBuilder) WithFailureReason(reason *capierrors.MachineStatusError) MachineBuilder {
+	m.failureReason = reason
+	return m
+}
+
+// WithInfrastructureReady sets the InfrastructureReady for the machine builder.
+func (m MachineBuilder) WithInfrastructureReady(ready bool) MachineBuilder {
+	m.infrastructureReady = ready
+	return m
+}
+
+// WithLastUpdated sets the LastUpdated for the machine builder.
+func (m MachineBuilder) WithLastUpdated(lastUpdated *metav1.Time) MachineBuilder {
+	m.lastUpdated = lastUpdated
+	return m
+}
+
+// WithNodeInfo sets the NodeInfo for the machine builder.
+func (m MachineBuilder) WithNodeInfo(nodeInfo *corev1.NodeSystemInfo) MachineBuilder {
+	m.nodeInfo = nodeInfo
+	return m
+}
+
+// WithObservedGeneration sets the ObservedGeneration for the machine builder.
+func (m MachineBuilder) WithObservedGeneration(generation int64) MachineBuilder {
+	m.observedGeneration = generation
+	return m
+}
+
+// WithPhase sets the Phase for the machine builder.
+func (m MachineBuilder) WithPhase(phase capiv1.MachinePhase) MachineBuilder {
+	m.phase = phase
+	return m
+}

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/cluster-api/core/v1beta1/machineset.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/cluster-api/core/v1beta1/machineset.go
@@ -1,0 +1,241 @@
+/*
+Copyright 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	capierrors "sigs.k8s.io/cluster-api/errors"
+)
+
+// MachineSet creates a new MachineSet builder.
+func MachineSet() MachineSetBuilder {
+	return MachineSetBuilder{}
+}
+
+// MachineSetBuilder is used to build out a MachineSet object.
+type MachineSetBuilder struct {
+	// Object meta fields.
+	annotations       map[string]string
+	creationTimestamp metav1.Time
+	deletionTimestamp *metav1.Time
+	generateName      string
+	labels            map[string]string
+	name              string
+	namespace         string
+	ownerReferences   []metav1.OwnerReference
+
+	// Spec fields.
+	clusterName     string
+	deletePolicy    string
+	minReadySeconds int32
+	replicas        *int32
+	selector        metav1.LabelSelector
+	template        capiv1.MachineTemplateSpec
+
+	// Status fields.
+	availableReplicas    int32
+	conditions           capiv1.Conditions
+	failureMessage       *string
+	failureReason        *capierrors.MachineSetStatusError
+	fullyLabeledReplicas int32
+	observedGeneration   int64
+	readyReplicas        int32
+	statusReplicas       int32
+	statusSelector       string
+}
+
+// Build builds a new MachineSet based on the configuration provided.
+func (m MachineSetBuilder) Build() *capiv1.MachineSet {
+	machineSet := &capiv1.MachineSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations:       m.annotations,
+			CreationTimestamp: m.creationTimestamp,
+			DeletionTimestamp: m.deletionTimestamp,
+			GenerateName:      m.generateName,
+			Labels:            m.labels,
+			Name:              m.name,
+			Namespace:         m.namespace,
+			OwnerReferences:   m.ownerReferences,
+		},
+		Spec: capiv1.MachineSetSpec{
+			ClusterName:     m.clusterName,
+			DeletePolicy:    m.deletePolicy,
+			MinReadySeconds: m.minReadySeconds,
+			Replicas:        m.replicas,
+			Selector:        m.selector,
+			Template:        m.template,
+		},
+		Status: capiv1.MachineSetStatus{
+			AvailableReplicas:    m.availableReplicas,
+			Conditions:           m.conditions,
+			FailureMessage:       m.failureMessage,
+			FailureReason:        m.failureReason,
+			FullyLabeledReplicas: m.fullyLabeledReplicas,
+			ObservedGeneration:   m.observedGeneration,
+			ReadyReplicas:        m.readyReplicas,
+			Replicas:             m.statusReplicas,
+			Selector:             m.statusSelector,
+		},
+	}
+
+	return machineSet
+}
+
+// Object meta fields.
+
+// WithAnnotations sets the annotations for the MachineSet builder.
+func (m MachineSetBuilder) WithAnnotations(annotations map[string]string) MachineSetBuilder {
+	m.annotations = annotations
+	return m
+}
+
+// WithCreationTimestamp sets the creationTimestamp for the MachineSet builder.
+func (m MachineSetBuilder) WithCreationTimestamp(timestamp metav1.Time) MachineSetBuilder {
+	m.creationTimestamp = timestamp
+	return m
+}
+
+// WithDeletionTimestamp sets the deletionTimestamp for the MachineSet builder.
+func (m MachineSetBuilder) WithDeletionTimestamp(timestamp *metav1.Time) MachineSetBuilder {
+	m.deletionTimestamp = timestamp
+	return m
+}
+
+// WithGenerateName sets the generateName for the MachineSet builder.
+func (m MachineSetBuilder) WithGenerateName(generateName string) MachineSetBuilder {
+	m.generateName = generateName
+	return m
+}
+
+// WithLabels sets the labels for the MachineSet builder.
+func (m MachineSetBuilder) WithLabels(labels map[string]string) MachineSetBuilder {
+	m.labels = labels
+	return m
+}
+
+// WithName sets the name for the MachineSet builder.
+func (m MachineSetBuilder) WithName(name string) MachineSetBuilder {
+	m.name = name
+	return m
+}
+
+// WithNamespace sets the namespace for the MachineSet builder.
+func (m MachineSetBuilder) WithNamespace(namespace string) MachineSetBuilder {
+	m.namespace = namespace
+	return m
+}
+
+// WithOwnerReferences sets the OwnerReferences for the machine builder.
+func (m MachineSetBuilder) WithOwnerReferences(ownerRefs []metav1.OwnerReference) MachineSetBuilder {
+	m.ownerReferences = ownerRefs
+	return m
+}
+
+// Spec fields.
+
+// WithClusterName sets the clusterName for the MachineSet builder.
+func (m MachineSetBuilder) WithClusterName(clusterName string) MachineSetBuilder {
+	m.clusterName = clusterName
+	return m
+}
+
+// WithDeletePolicy sets the deletePolicy for the MachineSet builder.
+func (m MachineSetBuilder) WithDeletePolicy(deletePolicy string) MachineSetBuilder {
+	m.deletePolicy = deletePolicy
+	return m
+}
+
+// WithMinReadySeconds sets the minReadySeconds for the MachineSet builder.
+func (m MachineSetBuilder) WithMinReadySeconds(minReadySeconds int32) MachineSetBuilder {
+	m.minReadySeconds = minReadySeconds
+	return m
+}
+
+// WithReplicas sets the replicas for the MachineSet builder.
+func (m MachineSetBuilder) WithReplicas(replicas int32) MachineSetBuilder {
+	m.replicas = &replicas
+	return m
+}
+
+// WithSelector sets the selector for the MachineSet builder.
+func (m MachineSetBuilder) WithSelector(selector metav1.LabelSelector) MachineSetBuilder {
+	m.selector = selector
+	return m
+}
+
+// WithTemplate sets the template for the MachineSet builder.
+func (m MachineSetBuilder) WithTemplate(template capiv1.MachineTemplateSpec) MachineSetBuilder {
+	m.template = template
+	return m
+}
+
+// Status.
+
+// WithStatusAvailableReplicas sets the status availableReplicas for the MachineSet builder.
+func (m MachineSetBuilder) WithStatusAvailableReplicas(availableReplicas int32) MachineSetBuilder {
+	m.availableReplicas = availableReplicas
+	return m
+}
+
+// WithStatusConditions sets the status conditions for the MachineSet builder.
+func (m MachineSetBuilder) WithStatusConditions(conditions capiv1.Conditions) MachineSetBuilder {
+	m.conditions = conditions
+	return m
+}
+
+// WithStatusFailureMessage sets the status failureMessage for the MachineSet builder.
+func (m MachineSetBuilder) WithStatusFailureMessage(failureMessage string) MachineSetBuilder {
+	m.failureMessage = &failureMessage
+	return m
+}
+
+// WithStatusFailureReason sets the status failureReason for the MachineSet builder.
+func (m MachineSetBuilder) WithStatusFailureReason(failureReason capierrors.MachineSetStatusError) MachineSetBuilder {
+	m.failureReason = &failureReason
+	return m
+}
+
+// WithStatusFullyLabeledReplicas sets the status fullyLabeledReplicas for the MachineSet builder.
+func (m MachineSetBuilder) WithStatusFullyLabeledReplicas(fullyLabeledReplicas int32) MachineSetBuilder {
+	m.fullyLabeledReplicas = fullyLabeledReplicas
+	return m
+}
+
+// WithStatusObservedGeneration sets the status observedGeneration for the MachineSet builder.
+func (m MachineSetBuilder) WithStatusObservedGeneration(observedGeneration int64) MachineSetBuilder {
+	m.observedGeneration = observedGeneration
+	return m
+}
+
+// WithStatusReadyReplicas sets the status readyReplicas for the MachineSet builder.
+func (m MachineSetBuilder) WithStatusReadyReplicas(readyReplicas int32) MachineSetBuilder {
+	m.readyReplicas = readyReplicas
+	return m
+}
+
+// WithStatusReplicas sets the status replicas for the MachineSet builder.
+func (m MachineSetBuilder) WithStatusReplicas(replicas int32) MachineSetBuilder {
+	m.statusReplicas = replicas
+	return m
+}
+
+// WithStatusSelector sets the status selector for the MachineSet builder.
+func (m MachineSetBuilder) WithStatusSelector(selector string) MachineSetBuilder {
+	m.statusSelector = selector
+	return m
+}

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2/awscluster.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2/awscluster.go
@@ -1,0 +1,269 @@
+/*
+Copyright 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	capav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+// AWSCluster creates a new AWSClusterBuilder.
+func AWSCluster() AWSClusterBuilder {
+	return AWSClusterBuilder{}
+}
+
+// AWSClusterBuilder is used to build out an AWSCluster object.
+type AWSClusterBuilder struct {
+	// Object meta fields.
+	annotations       map[string]string
+	creationTimestamp metav1.Time
+	deletionTimestamp *metav1.Time
+	generateName      string
+	labels            map[string]string
+	name              string
+	namespace         string
+
+	// Spec fields.
+	additionalTags                    capav1.Tags
+	bastion                           capav1.Bastion
+	controlPlaneEndpoint              clusterv1.APIEndpoint
+	controlPlaneLoadBalancer          *capav1.AWSLoadBalancerSpec
+	identityRef                       *capav1.AWSIdentityReference
+	imageLookupBaseOS                 string
+	imageLookupFormat                 string
+	imageLookupOrg                    string
+	networkSpec                       capav1.NetworkSpec
+	partition                         string
+	region                            string
+	s3Bucket                          *capav1.S3Bucket
+	secondaryControlPlaneLoadBalancer *capav1.AWSLoadBalancerSpec
+	sshKeyName                        *string
+
+	// Status fields.
+	bastionInstance *capav1.Instance
+	conditions      clusterv1.Conditions
+	failureDomains  clusterv1.FailureDomains
+	network         capav1.NetworkStatus
+	ready           bool
+}
+
+// Build builds a new AWSCluster based on the configuration provided.
+func (a AWSClusterBuilder) Build() *capav1.AWSCluster {
+	awsCluster := &capav1.AWSCluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "infrastructure.cluster.x-k8s.io/v1beta2",
+			Kind:       "AWSCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations:       a.annotations,
+			CreationTimestamp: a.creationTimestamp,
+			DeletionTimestamp: a.deletionTimestamp,
+			GenerateName:      a.generateName,
+			Labels:            a.labels,
+			Name:              a.name,
+			Namespace:         a.namespace,
+		},
+		Spec: capav1.AWSClusterSpec{
+			AdditionalTags:                    a.additionalTags,
+			Bastion:                           a.bastion,
+			ControlPlaneEndpoint:              a.controlPlaneEndpoint,
+			ControlPlaneLoadBalancer:          a.controlPlaneLoadBalancer,
+			IdentityRef:                       a.identityRef,
+			ImageLookupBaseOS:                 a.imageLookupBaseOS,
+			ImageLookupFormat:                 a.imageLookupFormat,
+			ImageLookupOrg:                    a.imageLookupOrg,
+			NetworkSpec:                       a.networkSpec,
+			Partition:                         a.partition,
+			Region:                            a.region,
+			S3Bucket:                          a.s3Bucket,
+			SSHKeyName:                        a.sshKeyName,
+			SecondaryControlPlaneLoadBalancer: a.secondaryControlPlaneLoadBalancer,
+		},
+		Status: capav1.AWSClusterStatus{
+			Bastion:        a.bastionInstance,
+			Conditions:     a.conditions,
+			FailureDomains: a.failureDomains,
+			Network:        a.network,
+			Ready:          a.ready,
+		},
+	}
+
+	return awsCluster
+}
+
+// Object meta fields.
+
+// WithAnnotations sets the annotations for the AWSCluster builder.
+func (a AWSClusterBuilder) WithAnnotations(annotations map[string]string) AWSClusterBuilder {
+	a.annotations = annotations
+	return a
+}
+
+// WithCreationTimestamp sets the creationTimestamp for the AWSCluster builder.
+func (a AWSClusterBuilder) WithCreationTimestamp(timestamp metav1.Time) AWSClusterBuilder {
+	a.creationTimestamp = timestamp
+	return a
+}
+
+// WithDeletionTimestamp sets the deletionTimestamp for the AWSCluster builder.
+func (a AWSClusterBuilder) WithDeletionTimestamp(timestamp *metav1.Time) AWSClusterBuilder {
+	a.deletionTimestamp = timestamp
+	return a
+}
+
+// WithGenerateName sets the generateName for the AWSCluster builder.
+func (a AWSClusterBuilder) WithGenerateName(generateName string) AWSClusterBuilder {
+	a.generateName = generateName
+	return a
+}
+
+// WithLabels sets the labels for the AWSCluster builder.
+func (a AWSClusterBuilder) WithLabels(labels map[string]string) AWSClusterBuilder {
+	a.labels = labels
+	return a
+}
+
+// WithName sets the name for the AWSCluster builder.
+func (a AWSClusterBuilder) WithName(name string) AWSClusterBuilder {
+	a.name = name
+	return a
+}
+
+// WithNamespace sets the namespace for the AWSCluster builder.
+func (a AWSClusterBuilder) WithNamespace(namespace string) AWSClusterBuilder {
+	a.namespace = namespace
+	return a
+}
+
+// Spec fields.
+
+// WithAdditionalTags sets the additionalTags for the AWSCluster builder.
+func (a AWSClusterBuilder) WithAdditionalTags(tags capav1.Tags) AWSClusterBuilder {
+	a.additionalTags = tags
+	return a
+}
+
+// WithBastion sets the bastion for the AWSCluster builder.
+func (a AWSClusterBuilder) WithBastion(bastion capav1.Bastion) AWSClusterBuilder {
+	a.bastion = bastion
+	return a
+}
+
+// WithControlPlaneEndpoint sets the controlPlaneEndpoint for the AWSCluster builder.
+func (a AWSClusterBuilder) WithControlPlaneEndpoint(endpoint clusterv1.APIEndpoint) AWSClusterBuilder {
+	a.controlPlaneEndpoint = endpoint
+	return a
+}
+
+// WithControlPlaneLoadBalancer sets the controlPlaneLoadBalancer for the AWSCluster builder.
+func (a AWSClusterBuilder) WithControlPlaneLoadBalancer(lb *capav1.AWSLoadBalancerSpec) AWSClusterBuilder {
+	a.controlPlaneLoadBalancer = lb
+	return a
+}
+
+// WithIdentityRef sets the identityRef for the AWSCluster builder.
+func (a AWSClusterBuilder) WithIdentityRef(identityRef *capav1.AWSIdentityReference) AWSClusterBuilder {
+	a.identityRef = identityRef
+	return a
+}
+
+// WithImageLookupFormat sets the imageLookupFormat for the AWSCluster builder.
+func (a AWSClusterBuilder) WithImageLookupFormat(format string) AWSClusterBuilder {
+	a.imageLookupFormat = format
+	return a
+}
+
+// WithImageLookupOrg sets the imageLookupOrg for the AWSCluster builder.
+func (a AWSClusterBuilder) WithImageLookupOrg(org string) AWSClusterBuilder {
+	a.imageLookupOrg = org
+	return a
+}
+
+// WithImageLookupBaseOS sets the imageLookupBaseOS for the AWSCluster builder.
+func (a AWSClusterBuilder) WithImageLookupBaseOS(baseOS string) AWSClusterBuilder {
+	a.imageLookupBaseOS = baseOS
+	return a
+}
+
+// WithNetworkSpec sets the networkSpec for the AWSCluster builder.
+func (a AWSClusterBuilder) WithNetworkSpec(networkSpec capav1.NetworkSpec) AWSClusterBuilder {
+	a.networkSpec = networkSpec
+	return a
+}
+
+// WithPartition sets the partition for the AWSCluster builder.
+func (a AWSClusterBuilder) WithPartition(partition string) AWSClusterBuilder {
+	a.partition = partition
+	return a
+}
+
+// WithRegion sets the region for the AWSCluster builder.
+func (a AWSClusterBuilder) WithRegion(region string) AWSClusterBuilder {
+	a.region = region
+	return a
+}
+
+// WithSecondaryControlPlaneLoadBalancer sets the secondaryControlPlaneLoadBalancer for the AWSCluster builder.
+func (a AWSClusterBuilder) WithSecondaryControlPlaneLoadBalancer(lb *capav1.AWSLoadBalancerSpec) AWSClusterBuilder {
+	a.secondaryControlPlaneLoadBalancer = lb
+	return a
+}
+
+// WithSSHKeyName sets the sshKeyName for the AWSCluster builder.
+func (a AWSClusterBuilder) WithSSHKeyName(sshKeyName string) AWSClusterBuilder {
+	a.sshKeyName = &sshKeyName
+	return a
+}
+
+// WithS3Bucket sets the s3Bucket for the AWSCluster builder.
+func (a AWSClusterBuilder) WithS3Bucket(s3Bucket *capav1.S3Bucket) AWSClusterBuilder {
+	a.s3Bucket = s3Bucket
+	return a
+}
+
+// Status fields.
+
+// WithBastionStatus sets the bastion status for the AWSCluster builder.
+func (a AWSClusterBuilder) WithBastionStatus(bastionInstance *capav1.Instance) AWSClusterBuilder {
+	a.bastionInstance = bastionInstance
+	return a
+}
+
+// WithConditions sets the conditions for the AWSCluster builder.
+func (a AWSClusterBuilder) WithConditions(conditions clusterv1.Conditions) AWSClusterBuilder {
+	a.conditions = conditions
+	return a
+}
+
+// WithFailureDomains sets the failureDomains for the AWSCluster builder.
+func (a AWSClusterBuilder) WithFailureDomains(failureDomains clusterv1.FailureDomains) AWSClusterBuilder {
+	a.failureDomains = failureDomains
+	return a
+}
+
+// WithNetwork sets the network status for the AWSCluster builder.
+func (a AWSClusterBuilder) WithNetwork(network capav1.NetworkStatus) AWSClusterBuilder {
+	a.network = network
+	return a
+}
+
+// WithReady sets the ready status for the AWSCluster builder.
+func (a AWSClusterBuilder) WithReady(ready bool) AWSClusterBuilder {
+	a.ready = ready
+	return a
+}

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2/awsmachine.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2/awsmachine.go
@@ -1,0 +1,374 @@
+/*
+Copyright 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	capav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/errors"
+)
+
+// AWSMachine creates a new AWSMachine builder.
+func AWSMachine() AWSMachineBuilder {
+	return AWSMachineBuilder{}
+}
+
+// AWSMachineBuilder is used to build out an AWSMachine object.
+type AWSMachineBuilder struct {
+	// ObjectMeta fields.
+	annotations map[string]string
+	labels      map[string]string
+	name        string
+	namespace   string
+
+	// Spec fields.
+	additionalSecurityGroups []capav1.AWSResourceReference
+	additionalTags           capav1.Tags
+	ami                      capav1.AMIReference
+	capacityReservationID    *string
+	cloudInit                capav1.CloudInit
+	elasticIPPool            *capav1.ElasticIPPool
+	iamInstanceProfile       string
+	ignition                 *capav1.Ignition
+	imageLookupBaseOS        string
+	imageLookupFormat        string
+	imageLookupOrg           string
+	instanceID               *string
+	instanceMetadataOptions  *capav1.InstanceMetadataOptions
+	instanceType             string
+	networkInterfaces        []string
+	nonRootVolumes           []capav1.Volume
+	placementGroupName       string
+	placementGroupPartition  int64
+	privateDNSName           *capav1.PrivateDNSName
+	providerID               *string
+	publicIP                 *bool
+	rootVolume               *capav1.Volume
+	securityGroupOverrides   map[capav1.SecurityGroupRole]string
+	spotMarketOptions        *capav1.SpotMarketOptions
+	sshKeyName               *string
+	subnet                   *capav1.AWSResourceReference
+	tenancy                  string
+	uncompressedUserData     *bool
+
+	// Status fields.
+	addresses      []clusterv1.MachineAddress
+	conditions     clusterv1.Conditions
+	failureMessage *string
+	failureReason  *errors.MachineStatusError
+	instanceState  *capav1.InstanceState
+	interruptible  bool
+	ready          bool
+}
+
+// Build builds a new AWSMachine based on the configuration provided.
+func (a AWSMachineBuilder) Build() *capav1.AWSMachine {
+	awsMachine := &capav1.AWSMachine{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "infrastructure.cluster.x-k8s.io/v1beta2",
+			Kind:       "AWSMachine",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        a.name,
+			Namespace:   a.namespace,
+			Labels:      a.labels,
+			Annotations: a.annotations,
+		},
+		Spec: capav1.AWSMachineSpec{
+			AdditionalSecurityGroups: a.additionalSecurityGroups,
+			AdditionalTags:           a.additionalTags,
+			AMI:                      a.ami,
+			CapacityReservationID:    a.capacityReservationID,
+			CloudInit:                a.cloudInit,
+			ElasticIPPool:            a.elasticIPPool,
+			IAMInstanceProfile:       a.iamInstanceProfile,
+			Ignition:                 a.ignition,
+			ImageLookupBaseOS:        a.imageLookupBaseOS,
+			ImageLookupFormat:        a.imageLookupFormat,
+			ImageLookupOrg:           a.imageLookupOrg,
+			InstanceID:               a.instanceID,
+			InstanceMetadataOptions:  a.instanceMetadataOptions,
+			InstanceType:             a.instanceType,
+			NetworkInterfaces:        a.networkInterfaces,
+			NonRootVolumes:           a.nonRootVolumes,
+			PlacementGroupName:       a.placementGroupName,
+			PlacementGroupPartition:  a.placementGroupPartition,
+			PrivateDNSName:           a.privateDNSName,
+			ProviderID:               a.providerID,
+			PublicIP:                 a.publicIP,
+			RootVolume:               a.rootVolume,
+			SecurityGroupOverrides:   a.securityGroupOverrides,
+			SpotMarketOptions:        a.spotMarketOptions,
+			SSHKeyName:               a.sshKeyName,
+			Subnet:                   a.subnet,
+			Tenancy:                  a.tenancy,
+			UncompressedUserData:     a.uncompressedUserData,
+		},
+		Status: capav1.AWSMachineStatus{
+			Addresses:      a.addresses,
+			Conditions:     a.conditions,
+			FailureMessage: a.failureMessage,
+			FailureReason:  a.failureReason,
+			InstanceState:  a.instanceState,
+			Interruptible:  a.interruptible,
+			Ready:          a.ready,
+		},
+	}
+
+	return awsMachine
+}
+
+// Object meta fields.
+
+// WithAnnotations sets the annotations for the AWSMachine builder.
+func (a AWSMachineBuilder) WithAnnotations(annotations map[string]string) AWSMachineBuilder {
+	a.annotations = annotations
+	return a
+}
+
+// WithLabels sets the labels for the AWSMachine builder.
+func (a AWSMachineBuilder) WithLabels(labels map[string]string) AWSMachineBuilder {
+	a.labels = labels
+	return a
+}
+
+// WithName sets the name for the AWSMachine builder.
+func (a AWSMachineBuilder) WithName(name string) AWSMachineBuilder {
+	a.name = name
+	return a
+}
+
+// WithNamespace sets the namespace for the AWSMachine builder.
+func (a AWSMachineBuilder) WithNamespace(namespace string) AWSMachineBuilder {
+	a.namespace = namespace
+	return a
+}
+
+// Spec fields.
+
+// WithAdditionalSecurityGroups sets the additionalSecurityGroups for the AWSMachine builder.
+func (a AWSMachineBuilder) WithAdditionalSecurityGroups(additionalSecurityGroups []capav1.AWSResourceReference) AWSMachineBuilder {
+	a.additionalSecurityGroups = additionalSecurityGroups
+	return a
+}
+
+// WithAdditionalTags sets the additionalTags for the AWSMachine builder.
+func (a AWSMachineBuilder) WithAdditionalTags(additionalTags capav1.Tags) AWSMachineBuilder {
+	a.additionalTags = additionalTags
+	return a
+}
+
+// WithAMI sets the AMI for the AWSMachine builder.
+func (a AWSMachineBuilder) WithAMI(ami capav1.AMIReference) AWSMachineBuilder {
+	a.ami = ami
+	return a
+}
+
+// WithCapacityReservationID sets the capacityReservationID for the AWSMachine builder.
+func (a AWSMachineBuilder) WithCapacityReservationID(capacityReservationID *string) AWSMachineBuilder {
+	a.capacityReservationID = capacityReservationID
+	return a
+}
+
+// WithCloudInit sets the cloudInit for the AWSMachine builder.
+func (a AWSMachineBuilder) WithCloudInit(cloudInit capav1.CloudInit) AWSMachineBuilder {
+	a.cloudInit = cloudInit
+	return a
+}
+
+// WithElasticIPPool sets the elasticIPPool for the AWSMachine builder.
+func (a AWSMachineBuilder) WithElasticIPPool(elasticIPPool *capav1.ElasticIPPool) AWSMachineBuilder {
+	a.elasticIPPool = elasticIPPool
+	return a
+}
+
+// WithIAMInstanceProfile sets the iamInstanceProfile for the AWSMachine builder.
+func (a AWSMachineBuilder) WithIAMInstanceProfile(iamInstanceProfile string) AWSMachineBuilder {
+	a.iamInstanceProfile = iamInstanceProfile
+	return a
+}
+
+// WithIgnition sets the ignition for the AWSMachine builder.
+func (a AWSMachineBuilder) WithIgnition(ignition *capav1.Ignition) AWSMachineBuilder {
+	a.ignition = ignition
+	return a
+}
+
+// WithImageLookupBaseOS sets the imageLookupBaseOS for the AWSMachine builder.
+func (a AWSMachineBuilder) WithImageLookupBaseOS(imageLookupBaseOS string) AWSMachineBuilder {
+	a.imageLookupBaseOS = imageLookupBaseOS
+	return a
+}
+
+// WithImageLookupFormat sets the imageLookupFormat for the AWSMachine builder.
+func (a AWSMachineBuilder) WithImageLookupFormat(imageLookupFormat string) AWSMachineBuilder {
+	a.imageLookupFormat = imageLookupFormat
+	return a
+}
+
+// WithImageLookupOrg sets the imageLookupOrg for the AWSMachine builder.
+func (a AWSMachineBuilder) WithImageLookupOrg(imageLookupOrg string) AWSMachineBuilder {
+	a.imageLookupOrg = imageLookupOrg
+	return a
+}
+
+// WithInstanceID sets the instanceID for the AWSMachine builder.
+func (a AWSMachineBuilder) WithInstanceID(instanceID *string) AWSMachineBuilder {
+	a.instanceID = instanceID
+	return a
+}
+
+// WithInstanceMetadataOptions sets the instanceMetadataOptions for the AWSMachine builder.
+func (a AWSMachineBuilder) WithInstanceMetadataOptions(instanceMetadataOptions *capav1.InstanceMetadataOptions) AWSMachineBuilder {
+	a.instanceMetadataOptions = instanceMetadataOptions
+	return a
+}
+
+// WithInstanceType sets the instanceType for the AWSMachine builder.
+func (a AWSMachineBuilder) WithInstanceType(instanceType string) AWSMachineBuilder {
+	a.instanceType = instanceType
+	return a
+}
+
+// WithNetworkInterfaces sets the networkInterfaces for the AWSMachine builder.
+func (a AWSMachineBuilder) WithNetworkInterfaces(networkInterfaces []string) AWSMachineBuilder {
+	a.networkInterfaces = networkInterfaces
+	return a
+}
+
+// WithNonRootVolumes sets the nonRootVolumes for the AWSMachine builder.
+func (a AWSMachineBuilder) WithNonRootVolumes(nonRootVolumes []capav1.Volume) AWSMachineBuilder {
+	a.nonRootVolumes = nonRootVolumes
+	return a
+}
+
+// WithPlacementGroupName sets the placementGroupName for the AWSMachine builder.
+func (a AWSMachineBuilder) WithPlacementGroupName(placementGroupName string) AWSMachineBuilder {
+	a.placementGroupName = placementGroupName
+	return a
+}
+
+// WithPlacementGroupPartition sets the placementGroupPartition for the AWSMachine builder.
+func (a AWSMachineBuilder) WithPlacementGroupPartition(placementGroupPartition int64) AWSMachineBuilder {
+	a.placementGroupPartition = placementGroupPartition
+	return a
+}
+
+// WithPrivateDNSName sets the privateDNSName for the AWSMachine builder.
+func (a AWSMachineBuilder) WithPrivateDNSName(privateDNSName *capav1.PrivateDNSName) AWSMachineBuilder {
+	a.privateDNSName = privateDNSName
+	return a
+}
+
+// WithProviderID sets the providerID for the AWSMachine builder.
+func (a AWSMachineBuilder) WithProviderID(providerID *string) AWSMachineBuilder {
+	a.providerID = providerID
+	return a
+}
+
+// WithPublicIP sets the publicIP for the AWSMachine builder.
+func (a AWSMachineBuilder) WithPublicIP(publicIP *bool) AWSMachineBuilder {
+	a.publicIP = publicIP
+	return a
+}
+
+// WithRootVolume sets the rootVolume for the AWSMachine builder.
+func (a AWSMachineBuilder) WithRootVolume(rootVolume *capav1.Volume) AWSMachineBuilder {
+	a.rootVolume = rootVolume
+	return a
+}
+
+// WithSecurityGroupOverrides sets the securityGroupOverrides for the AWSMachine builder.
+func (a AWSMachineBuilder) WithSecurityGroupOverrides(securityGroupOverrides map[capav1.SecurityGroupRole]string) AWSMachineBuilder {
+	a.securityGroupOverrides = securityGroupOverrides
+	return a
+}
+
+// WithSpotMarketOptions sets the spotMarketOptions for the AWSMachine builder.
+func (a AWSMachineBuilder) WithSpotMarketOptions(spotMarketOptions *capav1.SpotMarketOptions) AWSMachineBuilder {
+	a.spotMarketOptions = spotMarketOptions
+	return a
+}
+
+// WithSSHKeyName sets the sshKeyName for the AWSMachine builder.
+func (a AWSMachineBuilder) WithSSHKeyName(sshKeyName *string) AWSMachineBuilder {
+	a.sshKeyName = sshKeyName
+	return a
+}
+
+// WithSubnet sets the subnet for the AWSMachine builder.
+func (a AWSMachineBuilder) WithSubnet(subnet *capav1.AWSResourceReference) AWSMachineBuilder {
+	a.subnet = subnet
+	return a
+}
+
+// WithTenancy sets the tenancy for the AWSMachine builder.
+func (a AWSMachineBuilder) WithTenancy(tenancy string) AWSMachineBuilder {
+	a.tenancy = tenancy
+	return a
+}
+
+// WithUncompressedUserData sets the uncompressedUserData for the AWSMachine builder.
+func (a AWSMachineBuilder) WithUncompressedUserData(uncompressedUserData *bool) AWSMachineBuilder {
+	a.uncompressedUserData = uncompressedUserData
+	return a
+}
+
+// Status fields.
+
+// WithAddresses sets the addresses for the AWSMachine builder.
+func (a AWSMachineBuilder) WithAddresses(addresses []clusterv1.MachineAddress) AWSMachineBuilder {
+	a.addresses = addresses
+	return a
+}
+
+// WithConditions sets the conditions for the AWSMachine builder.
+func (a AWSMachineBuilder) WithConditions(conditions clusterv1.Conditions) AWSMachineBuilder {
+	a.conditions = conditions
+	return a
+}
+
+// WithFailureMessage sets the failureMessage for the AWSMachine builder.
+func (a AWSMachineBuilder) WithFailureMessage(failureMessage *string) AWSMachineBuilder {
+	a.failureMessage = failureMessage
+	return a
+}
+
+// WithFailureReason sets the failureReason for the AWSMachine builder.
+func (a AWSMachineBuilder) WithFailureReason(failureReason *errors.MachineStatusError) AWSMachineBuilder {
+	a.failureReason = failureReason
+	return a
+}
+
+// WithInstanceState sets the instanceState for the AWSMachine builder.
+func (a AWSMachineBuilder) WithInstanceState(instanceState *capav1.InstanceState) AWSMachineBuilder {
+	a.instanceState = instanceState
+	return a
+}
+
+// WithInterruptible sets the interruptible for the AWSMachine builder.
+func (a AWSMachineBuilder) WithInterruptible(interruptible bool) AWSMachineBuilder {
+	a.interruptible = interruptible
+	return a
+}
+
+// WithReady sets the ready for the AWSMachine builder.
+func (a AWSMachineBuilder) WithReady(ready bool) AWSMachineBuilder {
+	a.ready = ready
+	return a
+}

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2/awsmachinetemplate.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2/awsmachinetemplate.go
@@ -1,0 +1,353 @@
+/*
+Copyright 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	capav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+)
+
+// AWSMachineTemplate creates a new AWSMachineTemplate builder.
+func AWSMachineTemplate() AWSMachineTemplateBuilder {
+	return AWSMachineTemplateBuilder{}
+}
+
+// AWSMachineTemplateBuilder is used to build out an AWSMachineTemplate object.
+type AWSMachineTemplateBuilder struct {
+	// Object meta fields.
+	annotations       map[string]string
+	creationTimestamp metav1.Time
+	deletionTimestamp *metav1.Time
+	generateName      string
+	labels            map[string]string
+	name              string
+	namespace         string
+
+	// Spec fields.
+	additionalSecurityGroups []capav1.AWSResourceReference
+	additionalTags           capav1.Tags
+	ami                      capav1.AMIReference
+	capacityReservationID    *string
+	cloudInit                capav1.CloudInit
+	elasticIPPool            *capav1.ElasticIPPool
+	iamInstanceProfile       string
+	ignition                 *capav1.Ignition
+	imageLookupBaseOS        string
+	imageLookupFormat        string
+	imageLookupOrg           string
+	instanceID               *string
+	instanceMetadataOptions  *capav1.InstanceMetadataOptions
+	instanceType             string
+	networkInterfaces        []string
+	nonRootVolumes           []capav1.Volume
+	placementGroupName       string
+	placementGroupPartition  int64
+	privateDNSName           *capav1.PrivateDNSName
+	providerID               *string
+	publicIP                 *bool
+	rootVolume               *capav1.Volume
+	securityGroupOverrides   map[capav1.SecurityGroupRole]string
+	spotMarketOptions        *capav1.SpotMarketOptions
+	sshKeyName               *string
+	subnet                   *capav1.AWSResourceReference
+	tenancy                  string
+	uncompressedUserData     *bool
+
+	// Status fields.
+	capacity corev1.ResourceList
+}
+
+// Build builds a new AWSMachineTemplate based on the configuration provided.
+func (a AWSMachineTemplateBuilder) Build() *capav1.AWSMachineTemplate {
+	awsMachineTemplate := &capav1.AWSMachineTemplate{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "infrastructure.cluster.x-k8s.io/v1beta2",
+			Kind:       "AWSMachineTemplate",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations:       a.annotations,
+			CreationTimestamp: a.creationTimestamp,
+			DeletionTimestamp: a.deletionTimestamp,
+			GenerateName:      a.generateName,
+			Labels:            a.labels,
+			Name:              a.name,
+			Namespace:         a.namespace,
+		},
+		Spec: capav1.AWSMachineTemplateSpec{
+			Template: capav1.AWSMachineTemplateResource{
+				Spec: capav1.AWSMachineSpec{
+					AdditionalSecurityGroups: a.additionalSecurityGroups,
+					AdditionalTags:           a.additionalTags,
+					AMI:                      a.ami,
+					CapacityReservationID:    a.capacityReservationID,
+					CloudInit:                a.cloudInit,
+					ElasticIPPool:            a.elasticIPPool,
+					IAMInstanceProfile:       a.iamInstanceProfile,
+					Ignition:                 a.ignition,
+					ImageLookupBaseOS:        a.imageLookupBaseOS,
+					ImageLookupFormat:        a.imageLookupFormat,
+					ImageLookupOrg:           a.imageLookupOrg,
+					InstanceID:               a.instanceID,
+					InstanceMetadataOptions:  a.instanceMetadataOptions,
+					InstanceType:             a.instanceType,
+					NetworkInterfaces:        a.networkInterfaces,
+					NonRootVolumes:           a.nonRootVolumes,
+					PlacementGroupName:       a.placementGroupName,
+					PlacementGroupPartition:  a.placementGroupPartition,
+					PrivateDNSName:           a.privateDNSName,
+					ProviderID:               a.providerID,
+					PublicIP:                 a.publicIP,
+					RootVolume:               a.rootVolume,
+					SecurityGroupOverrides:   a.securityGroupOverrides,
+					SpotMarketOptions:        a.spotMarketOptions,
+					SSHKeyName:               a.sshKeyName,
+					Subnet:                   a.subnet,
+					Tenancy:                  a.tenancy,
+					UncompressedUserData:     a.uncompressedUserData,
+				},
+			},
+		},
+		Status: capav1.AWSMachineTemplateStatus{
+			Capacity: a.capacity,
+		},
+	}
+
+	return awsMachineTemplate
+}
+
+// Object meta fields.
+
+// WithAnnotations sets the annotations for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithAnnotations(annotations map[string]string) AWSMachineTemplateBuilder {
+	a.annotations = annotations
+	return a
+}
+
+// WithCreationTimestamp sets the creationTimestamp for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithCreationTimestamp(timestamp metav1.Time) AWSMachineTemplateBuilder {
+	a.creationTimestamp = timestamp
+	return a
+}
+
+// WithDeletionTimestamp sets the deletionTimestamp for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithDeletionTimestamp(timestamp *metav1.Time) AWSMachineTemplateBuilder {
+	a.deletionTimestamp = timestamp
+	return a
+}
+
+// WithGenerateName sets the generateName for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithGenerateName(generateName string) AWSMachineTemplateBuilder {
+	a.generateName = generateName
+	return a
+}
+
+// WithLabels sets the labels for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithLabels(labels map[string]string) AWSMachineTemplateBuilder {
+	a.labels = labels
+	return a
+}
+
+// WithName sets the name for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithName(name string) AWSMachineTemplateBuilder {
+	a.name = name
+	return a
+}
+
+// WithNamespace sets the namespace for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithNamespace(namespace string) AWSMachineTemplateBuilder {
+	a.namespace = namespace
+	return a
+}
+
+// Spec fields.
+
+// WithAdditionalSecurityGroups sets the additionalSecurityGroups for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithAdditionalSecurityGroups(groups []capav1.AWSResourceReference) AWSMachineTemplateBuilder {
+	a.additionalSecurityGroups = groups
+	return a
+}
+
+// WithAdditionalTags sets the additionalTags for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithAdditionalTags(tags capav1.Tags) AWSMachineTemplateBuilder {
+	a.additionalTags = tags
+	return a
+}
+
+// WithAMI sets the AMI for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithAMI(ami capav1.AMIReference) AWSMachineTemplateBuilder {
+	a.ami = ami
+	return a
+}
+
+// WithCapacityReservationID sets the capacityReservationID for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithCapacityReservationID(id string) AWSMachineTemplateBuilder {
+	a.capacityReservationID = &id
+	return a
+}
+
+// WithCloudInit sets the cloudInit for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithCloudInit(cloudInit capav1.CloudInit) AWSMachineTemplateBuilder {
+	a.cloudInit = cloudInit
+	return a
+}
+
+// WithElasticIPPool sets the elasticIPPool for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithElasticIPPool(pool *capav1.ElasticIPPool) AWSMachineTemplateBuilder {
+	a.elasticIPPool = pool
+	return a
+}
+
+// WithIAMInstanceProfile sets the iamInstanceProfile for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithIAMInstanceProfile(profile string) AWSMachineTemplateBuilder {
+	a.iamInstanceProfile = profile
+	return a
+}
+
+// WithIgnition sets the ignition for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithIgnition(ignition *capav1.Ignition) AWSMachineTemplateBuilder {
+	a.ignition = ignition
+	return a
+}
+
+// WithImageLookupBaseOS sets the imageLookupBaseOS for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithImageLookupBaseOS(baseOS string) AWSMachineTemplateBuilder {
+	a.imageLookupBaseOS = baseOS
+	return a
+}
+
+// WithImageLookupFormat sets the imageLookupFormat for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithImageLookupFormat(format string) AWSMachineTemplateBuilder {
+	a.imageLookupFormat = format
+	return a
+}
+
+// WithImageLookupOrg sets the imageLookupOrg for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithImageLookupOrg(org string) AWSMachineTemplateBuilder {
+	a.imageLookupOrg = org
+	return a
+}
+
+// WithInstanceID sets the instanceID for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithInstanceID(instanceID string) AWSMachineTemplateBuilder {
+	a.instanceID = &instanceID
+	return a
+}
+
+// WithInstanceMetadataOptions sets the instanceMetadataOptions for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithInstanceMetadataOptions(options *capav1.InstanceMetadataOptions) AWSMachineTemplateBuilder {
+	a.instanceMetadataOptions = options
+	return a
+}
+
+// WithInstanceType sets the instanceType for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithInstanceType(instanceType string) AWSMachineTemplateBuilder {
+	a.instanceType = instanceType
+	return a
+}
+
+// WithNetworkInterfaces sets the networkInterfaces for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithNetworkInterfaces(interfaces []string) AWSMachineTemplateBuilder {
+	a.networkInterfaces = interfaces
+	return a
+}
+
+// WithNonRootVolumes sets the nonRootVolumes for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithNonRootVolumes(volumes []capav1.Volume) AWSMachineTemplateBuilder {
+	a.nonRootVolumes = volumes
+	return a
+}
+
+// WithPlacementGroupName sets the placementGroupName for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithPlacementGroupName(name string) AWSMachineTemplateBuilder {
+	a.placementGroupName = name
+	return a
+}
+
+// WithPlacementGroupPartition sets the placementGroupPartition for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithPlacementGroupPartition(partition int64) AWSMachineTemplateBuilder {
+	a.placementGroupPartition = partition
+	return a
+}
+
+// WithPrivateDNSName sets the privateDNSName for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithPrivateDNSName(dnsName *capav1.PrivateDNSName) AWSMachineTemplateBuilder {
+	a.privateDNSName = dnsName
+	return a
+}
+
+// WithProviderID sets the providerID for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithProviderID(providerID string) AWSMachineTemplateBuilder {
+	a.providerID = &providerID
+	return a
+}
+
+// WithPublicIP sets the publicIP for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithPublicIP(publicIP bool) AWSMachineTemplateBuilder {
+	a.publicIP = &publicIP
+	return a
+}
+
+// WithRootVolume sets the rootVolume for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithRootVolume(volume *capav1.Volume) AWSMachineTemplateBuilder {
+	a.rootVolume = volume
+	return a
+}
+
+// WithSecurityGroupOverrides sets the securityGroupOverrides for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithSecurityGroupOverrides(overrides map[capav1.SecurityGroupRole]string) AWSMachineTemplateBuilder {
+	a.securityGroupOverrides = overrides
+	return a
+}
+
+// WithSpotMarketOptions sets the spotMarketOptions for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithSpotMarketOptions(options *capav1.SpotMarketOptions) AWSMachineTemplateBuilder {
+	a.spotMarketOptions = options
+	return a
+}
+
+// WithSSHKeyName sets the sshKeyName for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithSSHKeyName(keyName string) AWSMachineTemplateBuilder {
+	a.sshKeyName = &keyName
+	return a
+}
+
+// WithSubnet sets the subnet for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithSubnet(subnet *capav1.AWSResourceReference) AWSMachineTemplateBuilder {
+	a.subnet = subnet
+	return a
+}
+
+// WithTenancy sets the tenancy for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithTenancy(tenancy string) AWSMachineTemplateBuilder {
+	a.tenancy = tenancy
+	return a
+}
+
+// WithUncompressedUserData sets the uncompressedUserData for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithUncompressedUserData(uncompressed bool) AWSMachineTemplateBuilder {
+	a.uncompressedUserData = &uncompressed
+	return a
+}
+
+// Status fields.
+
+// WithCapacity sets the capacity for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithCapacity(capacity corev1.ResourceList) AWSMachineTemplateBuilder {
+	a.capacity = capacity
+	return a
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -928,7 +928,7 @@ github.com/openshift/client-go/config/listers/config/v1
 github.com/openshift/client-go/config/listers/config/v1alpha1
 github.com/openshift/client-go/operator/applyconfigurations/internal
 github.com/openshift/client-go/operator/applyconfigurations/operator/v1
-# github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20241007145816-7038c320d36c
+# github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20241021095320-149bd4ea9cf3
 ## explicit; go 1.22.1
 github.com/openshift/cluster-api-actuator-pkg/testutils
 github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -932,6 +932,8 @@ github.com/openshift/client-go/operator/applyconfigurations/operator/v1
 ## explicit; go 1.22.1
 github.com/openshift/cluster-api-actuator-pkg/testutils
 github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder
+github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/cluster-api/core/v1beta1
+github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2
 github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/config/v1
 github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/core/v1
 github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1beta1


### PR DESCRIPTION
Second part (following up from the first https://github.com/openshift/cluster-capi-operator/pull/215) of the negative unit testing efforts for the conversion packages.
This is for the capi2mapi pkg.