### PR TITLE
OCPCLOUD-2642: manifests-gen: Allow overriding kustomize component path

### DIFF
--- a/manifests-gen/README.md
+++ b/manifests-gen/README.md
@@ -1,0 +1,19 @@
+manifests-gen
+=============
+
+This tool is used to generate manifests for Cluster API Providers suitable for use within OpenShift Container Platform.
+
+The tool makes the following assumptions, and uses relative paths based on those:
+
+    * The forked provider repository has directories `openshift` and `openshift/tools`
+    * `manifests-gen`'s working directory is `openshift/tools` (invoked via `openshift/Makefile`)
+
+Most often, the base Cluster API Provider YAML manifests will be stored in `config/default`.
+
+If there are any OpenShift-specific changes that do not warrant inclusion into this tool,
+the directory can be overriden with `--kustomize-dir`. Often, this should be `--kustomize-dir=openshift`
+and a `openshift/kustomization.yaml` file should be present that references `config/default` as the base.
+
+Changes that warrant making edits via this tool are things that apply to all or many resources.
+Changes that target a single resource, such as changing a single, specific `Deployment`'s
+container arguments should be applies as Kustomize patches local to the provider repo.

--- a/manifests-gen/main.go
+++ b/manifests-gen/main.go
@@ -19,6 +19,7 @@ import (
 var (
 	basePath        = flag.String("base-path", "", "path to the root of the provider's repository")
 	manifestsPath   = flag.String("manifests-path", "", "path to the desired directory where to output the generated manifests")
+	kustomizeDir    = flag.String("kustomize-dir", defaultKustomizeComponentsPath, "directory to search for kustomization.yaml file, relative to the base-path")
 	providerName    = flag.String("provider-name", "", "name of the provider")
 	providerType    = flag.String("provider-type", "", "type of the provider")
 	providerVersion = flag.String("provider-version", "", "version of the provider")

--- a/manifests-gen/providers.go
+++ b/manifests-gen/providers.go
@@ -21,11 +21,11 @@ import (
 )
 
 const (
-	powerVSProvider         = "powervs"
-	ibmCloudProvider        = "ibmcloud"
-	coreCAPIProvider        = "cluster-api"
-	metadataFilePath        = "./metadata.yaml"
-	kustomizeComponentsPath = "./config/default"
+	powerVSProvider                = "powervs"
+	ibmCloudProvider               = "ibmcloud"
+	coreCAPIProvider               = "cluster-api"
+	metadataFilePath               = "./metadata.yaml"
+	defaultKustomizeComponentsPath = "./config/default"
 	// customizedComponentsFilename is a name for file containing customized infrastructure components.
 	// This file helps with code review as it is always uncompressed unlike the components configMap.
 	customizedComponentsFilename = "infrastructure-components-openshift.yaml"
@@ -60,7 +60,9 @@ func (p *provider) loadComponents() error {
 	}
 
 	// Compile assets using kustomize.
-	rawComponents, err := fetchAndCompileComponents(path.Join(projDir, kustomizeComponentsPath))
+	kustomizeComponentsPath := path.Join(projDir, *kustomizeDir)
+	fmt.Printf("> Generating OpenShift manifests based on kustomize.yaml from %q\n", kustomizeComponentsPath)
+	rawComponents, err := fetchAndCompileComponents(kustomizeComponentsPath)
 	if err != nil {
 		return fmt.Errorf("error fetching and compiling assets using kustomize: %w", err)
 	}


### PR DESCRIPTION
This PR adds the ability to locally override the path for Kustomize components within a CAPI provider repository.

This is required for https://github.com/openshift/cluster-api-provider-azure/pull/322 so that the Azure Service Operator's Deployment arguments can be overridden to ignore handling CRDs. 

Adding that modification directly in the Go code here would create a tighter coupling between this repository and the CAPZ one, and would be less flexible for future scenarios.

Also added a README file to explain some assumptions in the code base and document overriding the Kustomize component path.