### PR TITLE
OCPCLOUD-2646: MachineSetSync controller: tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/onsi/gomega v1.35.1
 	github.com/openshift/api v0.0.0-20241009131553-a1523024209f
 	github.com/openshift/client-go v0.0.0-20241001162912-da6d55e4611f
-	github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20241024095219-086923b9d3fd
+	github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20241029130438-302aefe5af06
 	github.com/openshift/cluster-control-plane-machine-set-operator v0.0.0-20241008085214-8d85b2cb2c1d
 	github.com/openshift/library-go v0.0.0-20240919205913-c96b82b3762b
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -423,8 +423,8 @@ github.com/openshift/api v0.0.0-20241009131553-a1523024209f h1:nxQl2ZH5Lr7KzM1zH
 github.com/openshift/api v0.0.0-20241009131553-a1523024209f/go.mod h1:Shkl4HanLwDiiBzakv+con/aMGnVE2MAGvoKp5oyYUo=
 github.com/openshift/client-go v0.0.0-20241001162912-da6d55e4611f h1:FRc0bVNWprihWS0GqQWzb3dY4dkCwpOP3mDw5NwSoR4=
 github.com/openshift/client-go v0.0.0-20241001162912-da6d55e4611f/go.mod h1:KiZi2mJRH1TOJ3FtBDYS6YvUL30s/iIXaGSUrSa36mo=
-github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20241024095219-086923b9d3fd h1:uJuMyhb2hTo2zy9zZAuqarSi+zcMPaFl9xmmeuaN0g8=
-github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20241024095219-086923b9d3fd/go.mod h1:Ns6d57JhMddy6w5c61HHWQ4jqF8Pvrv8mgs2gxg5jKU=
+github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20241029130438-302aefe5af06 h1:fOW9q/XdyeDivivOhvTWHeJXIPXpx4wvQrHhNv4iXlo=
+github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20241029130438-302aefe5af06/go.mod h1:Ns6d57JhMddy6w5c61HHWQ4jqF8Pvrv8mgs2gxg5jKU=
 github.com/openshift/cluster-control-plane-machine-set-operator v0.0.0-20241008085214-8d85b2cb2c1d h1:X4NkXsGOvS5pRBYaaLfLoUVMYbXl00I07dJFnNdxbq0=
 github.com/openshift/cluster-control-plane-machine-set-operator v0.0.0-20241008085214-8d85b2cb2c1d/go.mod h1:u+45mmWUg2ld7nsPDXzntjMsxannCV0CVmcUj9tIDvU=
 github.com/openshift/library-go v0.0.0-20240919205913-c96b82b3762b h1:y2DduJug7UZqTu0QTkRPAu73nskuUbFA66fmgxVf/fI=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -930,7 +930,7 @@ github.com/openshift/client-go/machine/applyconfigurations/internal
 github.com/openshift/client-go/machine/applyconfigurations/machine/v1beta1
 github.com/openshift/client-go/operator/applyconfigurations/internal
 github.com/openshift/client-go/operator/applyconfigurations/operator/v1
-# github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20241024095219-086923b9d3fd
+# github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20241029130438-302aefe5af06
 ## explicit; go 1.22.1
 github.com/openshift/cluster-api-actuator-pkg/testutils
 github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder


### PR DESCRIPTION
This PR adds tests outside of the happy path for the MachineSetSync controller going in the direction from capi -> mapi 

#221 should merge before this.