### PR TITLE
OCPCLOUD-2642: Reference ASO image for installation

### DIFF
--- a/manifests/image-references
+++ b/manifests/image-references
@@ -26,6 +26,10 @@ spec:
     from:
       kind: DockerImage
       name: registry.ci.openshift.org/openshift:azure-cluster-api-controllers
+  - name: azure-service-operator
+    from:
+      kind: DockerImage
+      name: registry.ci.openshift.org/openshift:azure-service-operator
   - name: gcp-cluster-api-controllers
     from:
       kind: DockerImage


### PR DESCRIPTION
Draft until https://github.com/openshift/release/pull/55371 merges and the image is actually built.