### PR TITLE
OCPCLOUD-2787: Updates migration cmd to change metrics port

### DIFF
--- a/cmd/machine-api-migration/main.go
+++ b/cmd/machine-api-migration/main.go
@@ -79,10 +79,6 @@ func main() {
 		ResourceNamespace: "openshift-cluster-api",
 	}
 
-	capiManagerOptions := capiflags.ManagerOptions{
-		DiagnosticsAddress: ":8081",
-	}
-
 	healthAddr := flag.String(
 		"health-addr",
 		":9441",
@@ -108,6 +104,8 @@ func main() {
 	textLoggerConfig := textlogger.NewConfig()
 	textLoggerConfig.AddFlags(flag.CommandLine)
 	ctrl.SetLogger(textlogger.NewLogger(textLoggerConfig))
+
+	capiManagerOptions := capiflags.ManagerOptions{}
 
 	// Once all the flags are registered, switch to pflag
 	// to allow leader lection flags to be bound.

--- a/manifests/0000_30_cluster-api_11_deployment.yaml
+++ b/manifests/0000_30_cluster-api_11_deployment.yaml
@@ -31,12 +31,16 @@ spec:
         - ./cluster-capi-operator
         args:
           - --images-json=/etc/cluster-api-config-images/images.json
+          - --diagnostics-address=:8443
         env:
         - name: RELEASE_VERSION
           value: "0.0.1-snapshot"
         ports:
         - containerPort: 9443
           name: webhook-server
+          protocol: TCP
+        - containerPort: 8443
+          name: diagnostics
           protocol: TCP
         resources:
           requests:
@@ -53,9 +57,15 @@ spec:
         image: registry.ci.openshift.org/openshift:cluster-capi-operator
         command:
         - ./machine-api-migration
+        args:
+          - --diagnostics-address=:8442
         env:
         - name: RELEASE_VERSION
           value: "0.0.1-snapshot"
+        ports:
+        - containerPort: 8442
+          name: diagnostics
+          protocol: TCP
         resources:
           requests:
             cpu: 10m


### PR DESCRIPTION
This change:

Removes the defaulting in the code where we set DiagnosticsAddress. It was being overwritten by --diagnostics-address in capiflags.AddManagerOptions() and setting the default value to :8443.

Updates the deployment manifests to pass --diagnostics-address to the migration controller with a value of :8442, so we don't clash with the cluster-capi-operator container running in the pod.