### PR TITLE
OCPBUGS-29815: fix: always update clusteroperator status versions when differing

### DIFF
--- a/pkg/controllers/unsupported/suite_test.go
+++ b/pkg/controllers/unsupported/suite_test.go
@@ -22,14 +22,13 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/openshift/cluster-capi-operator/pkg/controllers"
 	"github.com/openshift/cluster-capi-operator/pkg/test"
 )
 
@@ -37,6 +36,7 @@ var (
 	testEnv *envtest.Environment
 	cfg     *rest.Config
 	cl      client.Client
+	ctx     = context.Background()
 )
 
 func TestAPIs(t *testing.T) {
@@ -55,9 +55,8 @@ var _ = BeforeSuite(func() {
 	Expect(cfg).NotTo(BeNil())
 	Expect(cl).NotTo(BeNil())
 
-	managedNamespace := &corev1.Namespace{}
-	managedNamespace.SetName(controllers.DefaultManagedNamespace)
-	Expect(cl.Create(context.Background(), managedNamespace)).To(Succeed())
+	komega.SetClient(cl)
+	komega.SetContext(ctx)
 })
 
 var _ = AfterSuite(func() {

--- a/pkg/controllers/unsupported/unsupported_controller_test.go
+++ b/pkg/controllers/unsupported/unsupported_controller_test.go
@@ -24,37 +24,48 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-api-actuator-pkg/testutils"
+	configv1resourcebuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/config/v1"
+	corev1resourcebuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/core/v1"
+	"github.com/openshift/cluster-capi-operator/pkg/controllers"
 	"github.com/openshift/cluster-capi-operator/pkg/operatorstatus"
-	"github.com/openshift/cluster-capi-operator/pkg/test"
 )
 
 var _ = Describe("CAPI unsupported controller", func() {
 	ctx := context.Background()
+	desiredOperatorReleaseVersion := "this-is-the-desired-release-version"
 	var r *UnsupportedController
 	var capiClusterOperator *configv1.ClusterOperator
-	capiClusterOperatorKey := client.ObjectKey{Name: "cluster-api"}
+	var testNamespaceName string
 
 	BeforeEach(func() {
 		r = &UnsupportedController{
 			ClusterOperatorStatusClient: operatorstatus.ClusterOperatorStatusClient{
-				Client: cl,
+				Client:         cl,
+				ReleaseVersion: desiredOperatorReleaseVersion,
 			},
 		}
 
+		By("Creating the cluster-api ClusterOperator")
 		capiClusterOperator = &configv1.ClusterOperator{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "cluster-api",
 			},
 		}
-
 		Expect(cl.Create(ctx, capiClusterOperator)).To(Succeed(), "should be able to create the 'cluster-api' ClusterOperator object")
+
+		By("Creating the testing namespace")
+		namespace := corev1resourcebuilder.Namespace().WithGenerateName("test-capi-corecluster-").Build()
+		Expect(cl.Create(ctx, namespace)).To(Succeed())
+		testNamespaceName = namespace.Name
 	})
 
 	AfterEach(func() {
-		Expect(test.CleanupAndWait(ctx, cl, &configv1.ClusterOperator{})).To(Succeed())
+		testutils.CleanupResources(Default, ctx, testEnv.Config, cl, testNamespaceName, &configv1.ClusterOperator{})
 	})
 
 	It("should update cluster-api ClusterOperator status with an 'unsupported' message", func() {
@@ -63,19 +74,56 @@ var _ = Describe("CAPI unsupported controller", func() {
 				Name: capiClusterOperator.Name,
 			},
 		})
-
 		Expect(err).ToNot(HaveOccurred(), "should be able to reconcile the cluster-api ClusterOperator without erroring")
 
-		Eventually(func() (*configv1.ClusterOperator, error) {
-			err := cl.Get(ctx, capiClusterOperatorKey, capiClusterOperator)
-			return capiClusterOperator, err
-		}).Should(HaveField("Status.Conditions",
+		co := komega.Object(configv1resourcebuilder.ClusterOperator().WithName(controllers.ClusterOperatorName).Build())
+		Eventually(co).Should(HaveField("Status.Conditions",
 			SatisfyAll(
 				ContainElement(And(HaveField("Type", Equal(configv1.OperatorAvailable)), HaveField("Status", Equal(configv1.ConditionTrue)), HaveField("Message", Equal(capiUnsupportedPlatformMsg)))),
 				ContainElement(And(HaveField("Type", Equal(configv1.OperatorProgressing)), HaveField("Status", Equal(configv1.ConditionFalse)))),
 				ContainElement(And(HaveField("Type", Equal(configv1.OperatorDegraded)), HaveField("Status", Equal(configv1.ConditionFalse)))),
+				ContainElement(And(HaveField("Type", Equal(configv1.OperatorUpgradeable)), HaveField("Status", Equal(configv1.ConditionTrue)))),
 			),
 		), "should match the expected ClusterOperator status conditions")
+
 	})
 
+	It("should update the ClusterOperator status version to the desired one", func() {
+		_, err := r.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name: capiClusterOperator.Name,
+			},
+		})
+		Expect(err).ToNot(HaveOccurred(), "should be able to reconcile the cluster-api ClusterOperator without erroring")
+
+		co := komega.Object(configv1resourcebuilder.ClusterOperator().WithName(controllers.ClusterOperatorName).Build())
+		Eventually(co).Should(
+			HaveField("Status.Versions", ContainElement(SatisfyAll(
+				HaveField("Name", Equal("operator")),
+				HaveField("Version", Equal(desiredOperatorReleaseVersion)),
+			))),
+		)
+	})
+
+	It("should update the ClusterOperator status version to the desired one when an incorrect one is present", func() {
+		By("setting the ClusterOperator status version to an incorrect one")
+		patchBase := client.MergeFrom(capiClusterOperator.DeepCopy())
+		capiClusterOperator.Status.Versions = []configv1.OperandVersion{{Name: "operator", Version: "incorrect"}}
+		Expect(cl.Status().Patch(ctx, capiClusterOperator, patchBase)).To(Succeed())
+
+		_, err := r.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name: capiClusterOperator.Name,
+			},
+		})
+		Expect(err).ToNot(HaveOccurred(), "should be able to reconcile the cluster-api ClusterOperator without erroring")
+
+		co := komega.Object(configv1resourcebuilder.ClusterOperator().WithName(controllers.ClusterOperatorName).Build())
+		Eventually(co).Should(
+			HaveField("Status.Versions", ContainElement(SatisfyAll(
+				HaveField("Name", Equal("operator")),
+				HaveField("Version", Equal(desiredOperatorReleaseVersion)),
+			))),
+		)
+	})
 })


### PR DESCRIPTION
For manual testing of this fix, see: https://github.com/openshift/cluster-capi-operator/pull/248#issuecomment-2592344932

**Problem:**

Prior to this change, the operator's controller responsible for keeping the ClusterObject up to date had an issue when invoking r.SetStatusAvailable(...) with a non-empty availableConditionMsg string. Specifically:

- The condition NewClusterOperatorStatusCondition(configv1.OperatorAvailable, configv1.ConditionTrue, ReasonAsExpected, availableConditionMsg) would remain unchanged.
- This left the conds []configv1.ClusterOperatorStatusCondition unmodified compared to the current ClusterObject.Status.Conditions. 
- As a result, the ClusterObject.Status was not resynced.
 
This behavior caused a critical issue during cluster version upgrades:
- The operator failed to propagate changes to ClusterObject.Status.Versions, as the logic did not detect any updates requiring a resync.
- This prevented the cluster version upgrade process from progressing, effectively blocking the upgrade, since the Cluster Version Operator awaited the cluster-api operator to sync the new ClusterObject.Status.Versions.

**Solution:**

With this change, the criteria for resyncing the ClusterObject.Status have been updated. The resync logic now also triggers when only the desired operandVersions are modified, ensuring that:
- The ClusterObject.Status is correctly updated even if no other conditions change.
- Cluster version upgrades can proceed without unnecessary blockages.