### PR TITLE
[release-4.17] OCPBUGS-48493: fix: always update clusteroperator status versions when differing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ operator:
 	go build -o bin/cluster-capi-operator cmd/cluster-capi-operator/main.go
 
 unit:
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path --bin-dir $(PROJECT_DIR)/bin --remote-bucket openshift-kubebuilder-tools --use-deprecated-gcs)" ./hack/test.sh "./pkg/... ./assets/..." 5m
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path --bin-dir $(PROJECT_DIR)/bin --remote-bucket openshift-kubebuilder-tools --use-deprecated-gcs)" ./hack/test.sh "./pkg/... ./manifests-gen/..." 5m
 
 .PHONY: e2e
 e2e:

--- a/pkg/controllers/cluster/core_test.go
+++ b/pkg/controllers/cluster/core_test.go
@@ -23,40 +23,54 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-api-actuator-pkg/testutils"
+	configv1resourcebuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/config/v1"
+	corev1resourcebuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/core/v1"
 	"github.com/openshift/cluster-capi-operator/pkg/controllers"
 	"github.com/openshift/cluster-capi-operator/pkg/operatorstatus"
-	"github.com/openshift/cluster-capi-operator/pkg/test"
 )
 
 var _ = Describe("Reconcile Core cluster", func() {
-	var r *CoreClusterReconciler
 	var coreCluster *clusterv1.Cluster
+	var capiClusterOperator *configv1.ClusterOperator
+	var testNamespaceName string
+	desiredOperatorReleaseVersion := "this-is-the-desired-release-version"
 
 	BeforeEach(func() {
-		r = &CoreClusterReconciler{
-			ClusterOperatorStatusClient: operatorstatus.ClusterOperatorStatusClient{
-				Client: cl,
+		By("Creating the cluster-api ClusterOperator")
+		capiClusterOperator = &configv1.ClusterOperator{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: controllers.ClusterOperatorName,
 			},
-			Cluster: &clusterv1.Cluster{},
 		}
+		Expect(cl.Create(ctx, capiClusterOperator)).To(Succeed(), "should be able to create the 'cluster-api' ClusterOperator object")
 
+		By("Creating the testing namespace")
+		namespace := corev1resourcebuilder.Namespace().WithGenerateName("test-capi-corecluster-").Build()
+		Expect(cl.Create(ctx, namespace)).To(Succeed())
+		testNamespaceName = namespace.Name
+
+		By("Creating the core cluster object")
 		coreCluster = &clusterv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-name",
-				Namespace: controllers.DefaultManagedNamespace,
+				Namespace: testNamespaceName,
 			},
 		}
-
 		Expect(cl.Create(ctx, coreCluster)).To(Succeed())
-	})
 
-	AfterEach(func() {
-		Expect(test.CleanupAndWait(ctx, cl, coreCluster)).To(Succeed())
-	})
-
-	It("should update core cluster status", func() {
+		By("Starting the controller")
+		r := &CoreClusterReconciler{
+			ClusterOperatorStatusClient: operatorstatus.ClusterOperatorStatusClient{
+				Client:         cl,
+				ReleaseVersion: desiredOperatorReleaseVersion,
+			},
+			Cluster: &clusterv1.Cluster{},
+		}
 		_, err := r.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: coreCluster.Namespace,
@@ -64,7 +78,13 @@ var _ = Describe("Reconcile Core cluster", func() {
 			},
 		})
 		Expect(err).ToNot(HaveOccurred())
+	})
 
+	AfterEach(func() {
+		testutils.CleanupResources(Default, ctx, testEnv.Config, cl, testNamespaceName, &configv1.ClusterOperator{}, &clusterv1.Cluster{})
+	})
+
+	It("should update core cluster status", func() {
 		Expect(cl.Get(ctx, client.ObjectKey{
 			Name:      coreCluster.Name,
 			Namespace: coreCluster.Namespace,
@@ -73,5 +93,27 @@ var _ = Describe("Reconcile Core cluster", func() {
 		Expect(coreCluster.Status.Conditions).ToNot(BeEmpty())
 		Expect(coreCluster.Status.Conditions[0].Type).To(Equal(clusterv1.ControlPlaneInitializedCondition))
 		Expect(coreCluster.Status.Conditions[0].Status).To(Equal(corev1.ConditionTrue))
+	})
+
+	It("should update the ClusterOperator status to be available, upgradeable, non-progressing, non-degraded", func() {
+		co := komega.Object(configv1resourcebuilder.ClusterOperator().WithName(controllers.ClusterOperatorName).Build())
+		Eventually(co).Should(
+			HaveField("Status.Conditions", SatisfyAll(
+				ContainElement(And(HaveField("Type", Equal(configv1.OperatorAvailable)), HaveField("Status", Equal(configv1.ConditionTrue)))),
+				ContainElement(And(HaveField("Type", Equal(configv1.OperatorProgressing)), HaveField("Status", Equal(configv1.ConditionFalse)))),
+				ContainElement(And(HaveField("Type", Equal(configv1.OperatorDegraded)), HaveField("Status", Equal(configv1.ConditionFalse)))),
+				ContainElement(And(HaveField("Type", Equal(configv1.OperatorUpgradeable)), HaveField("Status", Equal(configv1.ConditionTrue)))),
+			)),
+		)
+	})
+
+	It("should update the ClusterOperator status version to the desired one", func() {
+		co := komega.Object(configv1resourcebuilder.ClusterOperator().WithName(controllers.ClusterOperatorName).Build())
+		Eventually(co).Should(
+			HaveField("Status.Versions", ContainElement(SatisfyAll(
+				HaveField("Name", Equal("operator")),
+				HaveField("Version", Equal(desiredOperatorReleaseVersion)),
+			))),
+		)
 	})
 })

--- a/pkg/controllers/cluster/suite_test.go
+++ b/pkg/controllers/cluster/suite_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/openshift/cluster-capi-operator/pkg/controllers"
@@ -56,6 +57,9 @@ var _ = BeforeSuite(func() {
 	managedNamespace := &corev1.Namespace{}
 	managedNamespace.SetName(controllers.DefaultManagedNamespace)
 	Expect(cl.Create(context.Background(), managedNamespace)).To(Succeed())
+
+	komega.SetClient(cl)
+	komega.SetContext(ctx)
 })
 
 var _ = AfterSuite(func() {

--- a/pkg/controllers/unsupported/suite_test.go
+++ b/pkg/controllers/unsupported/suite_test.go
@@ -22,14 +22,13 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/openshift/cluster-capi-operator/pkg/controllers"
 	"github.com/openshift/cluster-capi-operator/pkg/test"
 )
 
@@ -37,6 +36,7 @@ var (
 	testEnv *envtest.Environment
 	cfg     *rest.Config
 	cl      client.Client
+	ctx     = context.Background()
 )
 
 func TestAPIs(t *testing.T) {
@@ -55,9 +55,8 @@ var _ = BeforeSuite(func() {
 	Expect(cfg).NotTo(BeNil())
 	Expect(cl).NotTo(BeNil())
 
-	managedNamespace := &corev1.Namespace{}
-	managedNamespace.SetName(controllers.DefaultManagedNamespace)
-	Expect(cl.Create(context.Background(), managedNamespace)).To(Succeed())
+	komega.SetClient(cl)
+	komega.SetContext(ctx)
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
Manual backport of https://github.com/openshift/cluster-capi-operator/pull/249

---

**Problem:**
Prior to this change, the operator's controller responsible for keeping the ClusterObject up to date had an issue when invoking r.SetStatusAvailable(...) with a non-empty availableConditionMsg string. Specifically:

The condition NewClusterOperatorStatusCondition(configv1.OperatorAvailable, configv1.ConditionTrue, ReasonAsExpected, availableConditionMsg) would remain unchanged. This left the conds []configv1.ClusterOperatorStatusCondition unmodified compared to the current ClusterObject.Status.Conditions. As a result, the ClusterObject.Status was not resynced. This behavior caused a critical issue during cluster version upgrades:

The operator failed to propagate changes to ClusterObject.Status.Versions, as the logic did not detect any updates requiring a resync. This prevented the cluster version upgrade process from progressing, effectively blocking the upgrade, since the Cluster Version Operator awaited the cluster-api operator to sync the new ClusterObject.Status.Versions.

**Solution:**
With this change, the criteria for resyncing the ClusterObject.Status have been updated. The resync logic now also triggers when only the desired operandVersions are modified, ensuring that:

The ClusterObject.Status is correctly updated even if no other conditions change. Cluster version upgrades can proceed without unnecessary blockages.