### PR TITLE
Remove duplicated vnet delete permission

### DIFF
--- a/manifests/0000_30_cluster-api_01_credentials-request.yaml
+++ b/manifests/0000_30_cluster-api_01_credentials-request.yaml
@@ -130,7 +130,6 @@ spec:
     - Microsoft.Network/routeTables/read
     - Microsoft.Network/routeTables/write
     - Microsoft.Network/virtualNetworks/delete
-    - Microsoft.Network/virtualNetworks/delete
     - Microsoft.Network/virtualNetworks/read
     - Microsoft.Network/virtualNetworks/subnets/delete
     - Microsoft.Network/virtualNetworks/subnets/read


### PR DESCRIPTION
The `Microsoft.Network/virtualNetwork/delete` permission is listed twice in the credentials request.  