### PR TITLE
OCPCLOUD-2792: corecluster: set controller level conditions + tests

### DIFF
--- a/pkg/controllers/capiinstaller/capi_installer_controller.go
+++ b/pkg/controllers/capiinstaller/capi_installer_controller.go
@@ -285,7 +285,7 @@ func (r *CapiInstallerController) setAvailableCondition(ctx context.Context, log
 
 	log.V(2).Info("CAPI Installer Controller is Available")
 
-	if err := r.SyncStatus(ctx, co, conds); err != nil {
+	if err := r.SyncStatus(ctx, controllerName, co, conds); err != nil {
 		return fmt.Errorf("failed to sync status: %w", err)
 	}
 
@@ -310,7 +310,7 @@ func (r *CapiInstallerController) setDegradedCondition(ctx context.Context, log 
 
 	log.Info("CAPI Installer Controller is Degraded")
 
-	if err := r.SyncStatus(ctx, co, conds); err != nil {
+	if err := r.SyncStatus(ctx, controllerName, co, conds); err != nil {
 		return fmt.Errorf("failed to sync status: %w", err)
 	}
 

--- a/pkg/controllers/clusteroperator/clusteroperator_controller.go
+++ b/pkg/controllers/clusteroperator/clusteroperator_controller.go
@@ -54,6 +54,11 @@ func (r *ClusterOperatorController) Reconcile(ctx context.Context, req ctrl.Requ
 	} else {
 		// TODO: wrap this into status aggregation logic to get these conditions conform,
 		// to the meaningful aggregation of all the other controllers ones.
+		//
+		// TODO: set a time period where if one of the controllers conditions has been degraded=true (reduced QoS)
+		// for an extended period of time (eg. 30mins, degrade top level) we set the overall operator degraded=true.
+		// For any controller available=false condition instead (e.g. when the CAPI components are failing to run),
+		// we should immediately set the overall operator available=false immediately.
 		if err := r.ClusterOperatorStatusClient.SetStatusAvailable(ctx, ""); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to set conditions for %q ClusterObject: %w", controllers.ClusterOperatorName, err)
 		}

--- a/pkg/controllers/corecluster/corecluster_controller.go
+++ b/pkg/controllers/corecluster/corecluster_controller.go
@@ -46,6 +46,12 @@ const (
 	capiInfraClusterAPIVersionV1Beta1 = "infrastructure.cluster.x-k8s.io/v1beta1"
 	capiInfraClusterAPIVersionV1Beta2 = "infrastructure.cluster.x-k8s.io/v1beta2"
 	clusterOperatorName               = "cluster-api"
+
+	// CoreClusterControllerAvailableCondition is the condition type that indicates the CoreCluster controller is available.
+	CoreClusterControllerAvailableCondition = "CoreClusterControllerAvailable"
+
+	// CoreClusterControllerDegradedCondition is the condition type that indicates the CoreCluster controller is degraded.
+	CoreClusterControllerDegradedCondition = "CoreClusterControllerDegraded"
 )
 
 var (
@@ -53,6 +59,9 @@ var (
 	errUnsupportedPlatformType                     = errors.New("unsupported platform type")
 	errOpenshiftInfraShouldNotBeNil                = errors.New("infrastructure object should not be nil")
 	errOpenshiftInfrastructureNameShouldNotBeEmpty = errors.New("infrastructure object's infrastructureName should not be empty")
+
+	//nolint:gochecknoglobals
+	expectedConditionTypes = []string{CoreClusterControllerAvailableCondition, CoreClusterControllerDegradedCondition}
 )
 
 // CoreClusterController reconciles a Cluster object.
@@ -81,6 +90,8 @@ func (r *CoreClusterController) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 // Reconcile reconciles the core cluster object for the openshift-cluster-api namespace.
+//
+//nolint:funlen
 func (r *CoreClusterController) Reconcile(ctx context.Context, req reconcile.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx).WithName(controllerName)
 	logger.Info("Reconciling core cluster")
@@ -88,25 +99,25 @@ func (r *CoreClusterController) Reconcile(ctx context.Context, req reconcile.Req
 
 	var err error
 
-	conditions := &[]configv1.ClusterOperatorStatusCondition{}
+	co, err := r.GetOrCreateClusterOperator(ctx)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get or create cluster operator: %w", err)
+	}
 
-	// We optimistically set Degraded=false at the beginning.
-	operatorstatus.SetCondition(conditions, operatorstatus.CoreClusterControllerDegradedCondition, configv1.ConditionFalse,
-		operatorstatus.ReasonAsExpected, "controller works as expected")
-
-	// We optimistically set Available=true at the beginning.
-	operatorstatus.SetCondition(conditions, operatorstatus.CoreClusterControllerAvailableCondition, configv1.ConditionTrue,
-		operatorstatus.ReasonAsExpected, "controller is available")
+	// Populate conditions from the existing cluster operator status.
+	conditions := operatorstatus.FilterOwnedConditions(co.Status.Conditions, expectedConditionTypes)
 
 	defer func() {
 		// This function runs before every return, to ensure the controller conditions
-		// for that codepath are correctly synced to the ClusterOperator status.
-		if syncErr := r.syncControllerConditions(ctx, conditions); syncErr != nil {
+		// for that codepath are correctly synced to the cluster operator status.
+		if syncErr := r.SyncControllerConditions(ctx, co, controllerName, conditions, expectedConditionTypes); syncErr != nil {
 			if err != nil {
 				// The sync of the controller conditions failed but there is also a non nil reconcile error.
 				// Log the sync error and pass down the reconciler one.
 				logger.Error(syncErr, "failed to sync cluster operator status")
 			} else {
+				// If there is no reconcile error, but there is a sync error, then we want to propagate the
+				// sync error to be returned by the Reconcile function, so that it will cause an immediate requeue/retry.
 				err = syncErr
 			}
 		}
@@ -114,7 +125,7 @@ func (r *CoreClusterController) Reconcile(ctx context.Context, req reconcile.Req
 
 	ocpInfrastructureName, err := getOCPInfrastructureName(r.Infra)
 	if err != nil {
-		operatorstatus.SetCondition(conditions, operatorstatus.CoreClusterControllerDegradedCondition, configv1.ConditionTrue,
+		operatorstatus.SetCondition(conditions, CoreClusterControllerDegradedCondition, configv1.ConditionTrue,
 			operatorstatus.ReasonSyncFailed, fmt.Sprintf("controller is degraded: %s", err.Error()))
 
 		return ctrl.Result{}, fmt.Errorf("failed to obtain infrastructure name: %w", err)
@@ -122,7 +133,7 @@ func (r *CoreClusterController) Reconcile(ctx context.Context, req reconcile.Req
 
 	cluster, err := r.ensureCoreCluster(ctx, client.ObjectKey{Namespace: r.ManagedNamespace, Name: ocpInfrastructureName}, logger)
 	if err != nil {
-		operatorstatus.SetCondition(conditions, operatorstatus.CoreClusterControllerDegradedCondition, configv1.ConditionTrue,
+		operatorstatus.SetCondition(conditions, CoreClusterControllerDegradedCondition, configv1.ConditionTrue,
 			operatorstatus.ReasonSyncFailed, fmt.Sprintf("controller is degraded: %s", err.Error()))
 
 		return ctrl.Result{}, fmt.Errorf("failed to ensure core cluster: %w", err)
@@ -133,11 +144,17 @@ func (r *CoreClusterController) Reconcile(ctx context.Context, req reconcile.Req
 	}
 
 	if err := r.ensureCoreClusterControlPlaneInitializedCondition(ctx, cluster); err != nil {
-		operatorstatus.SetCondition(conditions, operatorstatus.CoreClusterControllerDegradedCondition, configv1.ConditionTrue,
+		operatorstatus.SetCondition(conditions, CoreClusterControllerDegradedCondition, configv1.ConditionTrue,
 			operatorstatus.ReasonSyncFailed, fmt.Sprintf("controller is degraded: %s", err.Error()))
 
 		return ctrl.Result{}, fmt.Errorf("failed to ensure core cluster has the ControlPlaneInitializedCondition: %w", err)
 	}
+
+	operatorstatus.SetCondition(conditions, CoreClusterControllerDegradedCondition, configv1.ConditionFalse,
+		operatorstatus.ReasonAsExpected, "controller works as expected")
+
+	operatorstatus.SetCondition(conditions, CoreClusterControllerAvailableCondition, configv1.ConditionTrue,
+		operatorstatus.ReasonAsExpected, "controller is available")
 
 	return ctrl.Result{}, err
 }
@@ -266,18 +283,4 @@ func getOCPInfrastructureName(infra *configv1.Infrastructure) (string, error) {
 	}
 
 	return infra.Status.InfrastructureName, nil
-}
-
-// syncControllerConditions sets the CoreClusterController conditions.
-func (r *CoreClusterController) syncControllerConditions(ctx context.Context, conds *[]configv1.ClusterOperatorStatusCondition) error {
-	co, err := r.GetOrCreateClusterOperator(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get cluster operator: %w", err)
-	}
-
-	if err := r.SyncStatus(ctx, controllerName, co, *conds); err != nil {
-		return fmt.Errorf("failed to sync cluster operator status: %w", err)
-	}
-
-	return nil
 }

--- a/pkg/controllers/corecluster/corecluster_controller.go
+++ b/pkg/controllers/corecluster/corecluster_controller.go
@@ -275,7 +275,7 @@ func (r *CoreClusterController) syncControllerConditions(ctx context.Context, co
 		return fmt.Errorf("failed to get cluster operator: %w", err)
 	}
 
-	if err := r.SyncStatus(ctx, co, *conds); err != nil {
+	if err := r.SyncStatus(ctx, controllerName, co, *conds); err != nil {
 		return fmt.Errorf("failed to sync cluster operator status: %w", err)
 	}
 

--- a/pkg/controllers/corecluster/corecluster_controller_test.go
+++ b/pkg/controllers/corecluster/corecluster_controller_test.go
@@ -21,7 +21,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	capav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -156,11 +155,7 @@ var _ = Describe("Reconcile Core cluster", func() {
 					Eventually(komega.Object(configv1resourcebuilder.ClusterOperator().WithName(controllers.ClusterOperatorName).Build())).Should(
 						HaveField("Status.Conditions", SatisfyAll(
 							ContainElement(And(
-								HaveField("Type", BeEquivalentTo(operatorstatus.CoreClusterControllerAvailableCondition)),
-								HaveField("Status", BeEquivalentTo(configv1.ConditionTrue)),
-							)),
-							ContainElement(And(
-								HaveField("Type", BeEquivalentTo(operatorstatus.CoreClusterControllerDegradedCondition)),
+								HaveField("Type", BeEquivalentTo(CoreClusterControllerDegradedCondition)),
 								HaveField("Status", BeEquivalentTo(configv1.ConditionTrue)),
 							)),
 						)),
@@ -193,11 +188,11 @@ var _ = Describe("Reconcile Core cluster", func() {
 					Eventually(komega.Object(configv1resourcebuilder.ClusterOperator().WithName(controllers.ClusterOperatorName).Build())).Should(
 						HaveField("Status.Conditions", SatisfyAll(
 							ContainElement(And(
-								HaveField("Type", BeEquivalentTo(operatorstatus.CoreClusterControllerAvailableCondition)),
+								HaveField("Type", BeEquivalentTo(CoreClusterControllerAvailableCondition)),
 								HaveField("Status", BeEquivalentTo(configv1.ConditionTrue)),
 							)),
 							ContainElement(And(
-								HaveField("Type", BeEquivalentTo(operatorstatus.CoreClusterControllerDegradedCondition)),
+								HaveField("Type", BeEquivalentTo(CoreClusterControllerDegradedCondition)),
 								HaveField("Status", BeEquivalentTo(configv1.ConditionFalse)),
 							)),
 						)),
@@ -245,11 +240,11 @@ var _ = Describe("Reconcile Core cluster", func() {
 					Eventually(komega.Object(configv1resourcebuilder.ClusterOperator().WithName(controllers.ClusterOperatorName).Build())).Should(
 						HaveField("Status.Conditions", SatisfyAll(
 							ContainElement(And(
-								HaveField("Type", BeEquivalentTo(operatorstatus.CoreClusterControllerAvailableCondition)),
+								HaveField("Type", BeEquivalentTo(CoreClusterControllerAvailableCondition)),
 								HaveField("Status", BeEquivalentTo(configv1.ConditionTrue)),
 							)),
 							ContainElement(And(
-								HaveField("Type", BeEquivalentTo(operatorstatus.CoreClusterControllerDegradedCondition)),
+								HaveField("Type", BeEquivalentTo(CoreClusterControllerDegradedCondition)),
 								HaveField("Status", BeEquivalentTo(configv1.ConditionFalse)),
 							)),
 						)),
@@ -257,30 +252,6 @@ var _ = Describe("Reconcile Core cluster", func() {
 				})
 			})
 
-		})
-
-		Context("When there is an existing core cluster", func() {
-			BeforeEach(func() {
-				By("Creating a being-deleted testing core cluster object")
-				now := v1.Now()
-				coreCluster = capibuilder.Cluster().WithNamespace(testNamespaceName).WithName(testInfraName).WithDeletionTimestamp(&now).Build()
-				Eventually(cl.Create(ctx, coreCluster)).Should(Succeed())
-			})
-
-			It("should update the ClusterOperator status conditions with controller specific ones to reflect a normal state", func() {
-				Eventually(komega.Object(configv1resourcebuilder.ClusterOperator().WithName(controllers.ClusterOperatorName).Build())).Should(
-					HaveField("Status.Conditions", SatisfyAll(
-						ContainElement(And(
-							HaveField("Type", BeEquivalentTo(operatorstatus.CoreClusterControllerAvailableCondition)),
-							HaveField("Status", BeEquivalentTo(configv1.ConditionTrue)),
-						)),
-						ContainElement(And(
-							HaveField("Type", BeEquivalentTo(operatorstatus.CoreClusterControllerDegradedCondition)),
-							HaveField("Status", BeEquivalentTo(configv1.ConditionFalse)),
-						)),
-					)),
-				)
-			})
 		})
 	})
 

--- a/pkg/controllers/infracluster/infracluster_controller.go
+++ b/pkg/controllers/infracluster/infracluster_controller.go
@@ -245,7 +245,7 @@ func (r *InfraClusterController) setAvailableCondition(ctx context.Context, log 
 
 	log.V(2).Info("InfraCluster Controller is Available")
 
-	if err := r.SyncStatus(ctx, co, conds); err != nil {
+	if err := r.SyncStatus(ctx, controllerName, co, conds); err != nil {
 		return fmt.Errorf("failed to sync status: %w", err)
 	}
 

--- a/pkg/controllers/secretsync/secret_sync_controller.go
+++ b/pkg/controllers/secretsync/secret_sync_controller.go
@@ -203,7 +203,7 @@ func (r *UserDataSecretController) setAvailableCondition(ctx context.Context, lo
 
 	log.Info("user Data Secret Controller is available")
 
-	if err := r.SyncStatus(ctx, co, conds); err != nil {
+	if err := r.SyncStatus(ctx, controllerName, co, conds); err != nil {
 		return fmt.Errorf("failed to sync status: %w", err)
 	}
 
@@ -227,7 +227,7 @@ func (r *UserDataSecretController) setDegradedCondition(ctx context.Context, log
 
 	log.Info("user Data Secret Controller is degraded")
 
-	if err := r.SyncStatus(ctx, co, conds); err != nil {
+	if err := r.SyncStatus(ctx, controllerName, co, conds); err != nil {
 		return fmt.Errorf("failed to sync status: %w", err)
 	}
 

--- a/pkg/operatorstatus/operator_status.go
+++ b/pkg/operatorstatus/operator_status.go
@@ -46,6 +46,12 @@ const (
 
 	// ReasonSyncFailed is the reason for the condition when the operator failed to sync resources.
 	ReasonSyncFailed = "SyncingFailed"
+
+	// CoreClusterControllerAvailableCondition is the condition type that indicates the CoreCluster controller is available.
+	CoreClusterControllerAvailableCondition = "CoreClusterControllerAvailable"
+
+	// CoreClusterControllerDegradedCondition is the condition type that indicates the CoreCluster controller is degraded.
+	CoreClusterControllerDegradedCondition = "CoreClusterControllerDegraded"
 )
 
 // ClusterOperatorStatusClient is a client for managing the status of the ClusterOperator object.
@@ -196,6 +202,26 @@ func NewClusterOperatorStatusCondition(conditionType configv1.ClusterStatusCondi
 		Reason:             reason,
 		Message:            message,
 	}
+}
+
+// SetCondition updates or appends a condition to the conditions slice.
+// If the condition doesn't exist, it will be appended as a new entry,
+// otherwise if a condition of the same type already exists, it will be updated.
+// It also sets the condition LastTransitionTime to now().
+func SetCondition(conditions *[]configv1.ClusterOperatorStatusCondition, conditionType configv1.ClusterStatusConditionType,
+	conditionStatus configv1.ConditionStatus, reason string, message string) {
+	newCond := NewClusterOperatorStatusCondition(conditionType, conditionStatus, reason, message)
+
+	// Try to find and update existing condition.
+	for i := range *conditions {
+		if (*conditions)[i].Type == newCond.Type {
+			(*conditions)[i] = newCond
+			return
+		}
+	}
+
+	// If we get here, condition wasn't found, so append it.
+	*conditions = append(*conditions, newCond)
 }
 
 func printOperandVersions(versions []configv1.OperandVersion) string {

--- a/pkg/operatorstatus/operator_status.go
+++ b/pkg/operatorstatus/operator_status.go
@@ -48,12 +48,6 @@ const (
 
 	// ReasonSyncFailed is the reason for the condition when the operator failed to sync resources.
 	ReasonSyncFailed = "SyncingFailed"
-
-	// CoreClusterControllerAvailableCondition is the condition type that indicates the CoreCluster controller is available.
-	CoreClusterControllerAvailableCondition = "CoreClusterControllerAvailable"
-
-	// CoreClusterControllerDegradedCondition is the condition type that indicates the CoreCluster controller is degraded.
-	CoreClusterControllerDegradedCondition = "CoreClusterControllerDegraded"
 )
 
 // ClusterOperatorStatusClient is a client for managing the status of the ClusterOperator object.
@@ -117,8 +111,7 @@ func (r *ClusterOperatorStatusClient) SetStatusDegraded(ctx context.Context, rec
 	}
 
 	conds := []configv1.ClusterOperatorStatusCondition{
-		NewClusterOperatorStatusCondition(configv1.OperatorDegraded, configv1.ConditionTrue,
-			ReasonSyncFailed, message),
+		NewClusterOperatorStatusCondition(configv1.OperatorDegraded, configv1.ConditionTrue, ReasonSyncFailed, message),
 		NewClusterOperatorStatusCondition(configv1.OperatorUpgradeable, configv1.ConditionFalse, ReasonAsExpected, ""),
 	}
 
@@ -165,7 +158,42 @@ func (r *ClusterOperatorStatusClient) GetOrCreateClusterOperator(ctx context.Con
 	return co, nil
 }
 
-// SyncStatus applies the new condition to the ClusterOperator object.
+// SyncControllerConditions syncs the controller conditions to the ClusterOperator object status.
+func (r *ClusterOperatorStatusClient) SyncControllerConditions(ctx context.Context, co *configv1.ClusterOperator, controllerName string, conditions *[]configv1.ClusterOperatorStatusCondition, expectedConditionTypes []string) error {
+	// Mark the conditions not present as Unknown.
+	for _, v := range getMissingConditionTypes(conditions, expectedConditionTypes) {
+		co.Status.Conditions = append(co.Status.Conditions, NewClusterOperatorStatusCondition(configv1.ClusterStatusConditionType(v), configv1.ConditionUnknown, "Unknown", ""))
+	}
+
+	if err := r.SyncStatus(ctx, controllerName, co, *conditions); err != nil {
+		return fmt.Errorf("failed to sync cluster operator status: %w", err)
+	}
+
+	return nil
+}
+
+func getMissingConditionTypes(conditions *[]configv1.ClusterOperatorStatusCondition, expectedConditionTypes []string) []string {
+	missing := []string{}
+
+	for _, e := range expectedConditionTypes {
+		found := false
+
+		for _, c := range *conditions {
+			if c.Type == configv1.ClusterStatusConditionType(e) {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			missing = append(missing, e)
+		}
+	}
+
+	return missing
+}
+
+// SyncStatus syncs the updated status to the ClusterOperator object.
 func (r *ClusterOperatorStatusClient) SyncStatus(ctx context.Context, fieldOwner string, co *configv1.ClusterOperator, conds []configv1.ClusterOperatorStatusCondition) error {
 	// Convert conditions to applyConfig ones.
 	conditionsAc := make([]*configv1applyconfigs.ClusterOperatorStatusConditionApplyConfiguration, len(conds))
@@ -248,7 +276,7 @@ func NewClusterOperatorStatusCondition(conditionType configv1.ClusterStatusCondi
 // SetCondition updates or appends a condition to the conditions slice.
 // If the condition doesn't exist, it will be appended as a new entry,
 // otherwise if a condition of the same type already exists, it will be updated.
-// It also sets the condition LastTransitionTime to now().
+// It also handles the condition LastTransitionTime.
 func SetCondition(conditions *[]configv1.ClusterOperatorStatusCondition, conditionType configv1.ClusterStatusConditionType,
 	conditionStatus configv1.ConditionStatus, reason string, message string) {
 	newCond := NewClusterOperatorStatusCondition(conditionType, conditionStatus, reason, message)
@@ -256,7 +284,16 @@ func SetCondition(conditions *[]configv1.ClusterOperatorStatusCondition, conditi
 	// Try to find and update existing condition.
 	for i := range *conditions {
 		if (*conditions)[i].Type == newCond.Type {
+			// The condition already exists.
+			if (*conditions)[i].Status == newCond.Status {
+				// The condition status hasn't changed, retain the previous lastTransitionTime.
+				newCond.LastTransitionTime = (*conditions)[i].LastTransitionTime
+			}
+
+			// Override the existing condition with the new one.
 			(*conditions)[i] = newCond
+
+			// Return early as we found and updated the condition in the slice.
 			return
 		}
 	}
@@ -294,4 +331,19 @@ func clusterObjectNeedsUpdating(co *configv1.ClusterOperator, conds []configv1.C
 	}
 
 	return co, shouldUpdate
+}
+
+// FilterOwnedConditions returns filters the list of provided conditions based on whether they have an expected condition type.
+func FilterOwnedConditions(conditions []configv1.ClusterOperatorStatusCondition, expectedConditionTypes []string) *[]configv1.ClusterOperatorStatusCondition {
+	filtered := []configv1.ClusterOperatorStatusCondition{}
+
+	for _, e := range expectedConditionTypes {
+		for _, c := range conditions {
+			if c.Type == configv1.ClusterStatusConditionType(e) {
+				filtered = append(filtered, c)
+			}
+		}
+	}
+
+	return &filtered
 }


### PR DESCRIPTION
This PR is part of a wider effort to try and rework the controller/operator level condition setting and aggregation for the cluster-capi-operator (see: https://issues.redhat.com/browse/OCPCLOUD-2792)

This PR specifically, builds on top of #254 and:
- defines controller level conditions for the CoreCluster controller, setting them accordingly
- tests that the conditions have been set under different scenarios

More PRs will follow for each controller once the approach proposed in this one is agreed upon.