### PR TITLE
Apply provider manifests with SSA

### DIFF
--- a/pkg/controllers/capiinstaller/watch_predicates.go
+++ b/pkg/controllers/capiinstaller/watch_predicates.go
@@ -32,11 +32,12 @@ func clusterOperatorPredicates() predicate.Funcs {
 		return ok && clusterOperator.GetName() == clusterOperatorName
 	}
 
+	// We only want to be reconciled on creation of the cluster operator,
+	// because we wait for it before reconciling. The Create event also fires
+	// when the manager is started, so this will additionally ensure we are
+	// called at least once at startup.
 	return predicate.Funcs{
-		CreateFunc:  func(e event.CreateEvent) bool { return isClusterOperator(e.Object) },
-		UpdateFunc:  func(e event.UpdateEvent) bool { return isClusterOperator(e.ObjectNew) },
-		GenericFunc: func(e event.GenericEvent) bool { return isClusterOperator(e.Object) },
-		DeleteFunc:  func(e event.DeleteEvent) bool { return isClusterOperator(e.Object) },
+		CreateFunc: func(e event.CreateEvent) bool { return isClusterOperator(e.Object) },
 	}
 }
 


### PR DESCRIPTION
This change uses Server-Side Apply to apply provider manifests in place of the logic from library-go, which uses an Update with custom kind-specific client-side merge logic. Using SSA here should be equivalent to how these manifests would be applied by any other client.

The merge logic from library-go should no longer be required as long as the manifests are not specifying any fields which will be overwritten by an existing controller.

In particular, there should be no conflict with service-ca setting `caBundle` in various places, as long as the specified manifests do not include a caBundle. However, note that due to a validation bug in older versions of k8s, some CRDs do still specify an empty caBundle in their CRDs. These would have to be removed for this to work.

The expected flow of reconciles between cluster-capi-operator and service-ca-operator becomes:
* cluster-capi-operator: apply initial manifests
* service-ca-operator: adds caBundle to CRDs and validating webhooks
* cluster-capi-operator: triggered by update to manifests it managed applies manifests again

The final update will produce no change as long as no managed fields have been updated, so there will be no further reconciles.

However, objects with the provider label were being reconciled too often due to insufficient filtering. This PR includes a second commit which addresses that.