### PR TITLE
OCPCLOUD-2718: Add default VolumeSize for MAPI to CAPI conversion

### DIFF
--- a/pkg/conversion/mapi2capi/aws.go
+++ b/pkg/conversion/mapi2capi/aws.go
@@ -475,12 +475,6 @@ func blockDeviceMappingSpecToVolume(fldPath *field.Path, bdm mapiv1.BlockDeviceM
 
 	capiKMSKey := convertKMSKeyToCAPI(bdm.EBS.KMSKey)
 
-	if bdm.EBS.VolumeSize == nil {
-		// The volume size is required in CAPA, we will have to return an error, until we can come up with an appropriate way to handle this.
-		// TODO(OCPCLOUD-2718): Either find a way to handle the required value, or, force users to set the value.
-		errs = append(errs, field.Required(fldPath.Child("ebs", "volumeSize"), "volumeSize is required, but is missing"))
-	}
-
 	if rootVolume && !ptr.Deref(bdm.EBS.DeleteOnTermination, true) {
 		warnings = append(warnings, field.Invalid(fldPath.Child("ebs", "deleteOnTermination"), bdm.EBS.DeleteOnTermination, "root volume must be deleted on termination, ignoring invalid value false").Error())
 	} else if !rootVolume && !ptr.Deref(bdm.EBS.DeleteOnTermination, true) {
@@ -494,7 +488,7 @@ func blockDeviceMappingSpecToVolume(fldPath *field.Path, bdm mapiv1.BlockDeviceM
 
 	return capav1.Volume{
 		DeviceName:    ptr.Deref(bdm.DeviceName, ""),
-		Size:          *bdm.EBS.VolumeSize,
+		Size:          ptr.Deref(bdm.EBS.VolumeSize, 120), // The installer uses 120GiB by default as of 4.19.
 		Type:          capav1.VolumeType(ptr.Deref(bdm.EBS.VolumeType, "")),
 		IOPS:          ptr.Deref(bdm.EBS.Iops, 0),
 		Encrypted:     bdm.EBS.Encrypted,

--- a/pkg/conversion/mapi2capi/aws_fuzz_test.go
+++ b/pkg/conversion/mapi2capi/aws_fuzz_test.go
@@ -145,6 +145,7 @@ func awsProviderSpecFuzzerFuncs(codecs runtimeserializer.CodecFactory) []interfa
 			c.FuzzNoCustom(ebs)
 
 			// Fuzz required fields so that they are not empty.
+			// Setting volumeSize to a random int64 value.
 			if ebs.VolumeSize == nil {
 				ebs.VolumeSize = ptr.To(c.Int63())
 			}

--- a/pkg/conversion/mapi2capi/aws_test.go
+++ b/pkg/conversion/mapi2capi/aws_test.go
@@ -207,10 +207,8 @@ var _ = Describe("mapi2capi AWS conversion", func() {
 					EBS: &mapiv1.EBSBlockDeviceSpec{},
 				}}),
 			),
-			infra: infra,
-			expectedErrors: []string{
-				"spec.providerSpec.value.blockDevices[0].ebs.volumeSize: Required value: volumeSize is required, but is missing",
-			},
+			infra:            infra,
+			expectedErrors:   []string{}, // No error is expected anymore, because volumeSize is now set to a default amount if nil.
 			expectedWarnings: []string{},
 		}),
 		Entry("With non-root Volume not deleted on termination", awsMAPI2CAPIConversionInput{


### PR DESCRIPTION
Hello! This is a draft PR to get feedback for the default VolumeSize for the MAPI to CAPI conversion for AWS. Thanks!