### PR TITLE
Don't disable CAPI defaulting and validating webhooks

### DIFF
--- a/manifests-gen/customizations.go
+++ b/manifests-gen/customizations.go
@@ -62,15 +62,9 @@ func processObjects(objs []unstructured.Unstructured, providerName string) map[r
 			setNoUpgradeAnnotations(obj)
 			providerConfigMapObjs = append(providerConfigMapObjs, obj)
 		case "MutatingWebhookConfiguration":
-			// Explicitly remove defaulting webhooks for the cluster-api provider.
-			// We don't need CAPI to set any default to the cluster object because
-			// we have a custom controller for reconciling it.
-			// For more information: https://issues.redhat.com/browse/OCPCLOUD-1506
-			removeClusterDefaultingWebhooks(&obj)
 			replaceCertManagerAnnotations(&obj)
 			providerConfigMapObjs = append(providerConfigMapObjs, obj)
 		case "ValidatingWebhookConfiguration":
-			removeClusterValidatingWebhooks(&obj)
 			replaceCertManagerAnnotations(&obj)
 			providerConfigMapObjs = append(providerConfigMapObjs, obj)
 		case "CustomResourceDefinition":

--- a/manifests-gen/providercustomizations.go
+++ b/manifests-gen/providercustomizations.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"regexp"
-
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -103,65 +100,5 @@ func powerVSCustomizations(obj *unstructured.Unstructured) {
 		if err := scheme.Convert(deployment, obj, nil); err != nil {
 			panic(err)
 		}
-	}
-}
-
-func removeClusterDefaultingWebhooks(obj *unstructured.Unstructured) {
-	var providerWebhooks = regexp.MustCompile(`^default\.[a-z]+cluster[a-z]*\.infrastructure\.cluster\.x-k8s\.io$`)
-
-	mutatingWebhookConfiguration := &admissionregistrationv1.MutatingWebhookConfiguration{}
-	if err := scheme.Convert(obj, mutatingWebhookConfiguration, nil); err != nil {
-		panic(err)
-	}
-
-	webhooks := []admissionregistrationv1.MutatingWebhook{}
-	for _, webhook := range mutatingWebhookConfiguration.Webhooks {
-		// We don't need these specific webhooks.
-		if webhook.Name == "default.cluster.cluster.x-k8s.io" || webhook.Name == "default.clusterclass.cluster.x-k8s.io" || webhook.Name == "default.clusterresourceset.addons.cluster.x-k8s.io" {
-			continue
-		}
-
-		// We also don't need provider webhooks for clusters.
-		if providerWebhooks.MatchString(webhook.Name) {
-			continue
-		}
-
-		webhooks = append(webhooks, webhook)
-	}
-
-	mutatingWebhookConfiguration.Webhooks = webhooks
-
-	if err := scheme.Convert(mutatingWebhookConfiguration, obj, nil); err != nil {
-		panic(err)
-	}
-}
-
-func removeClusterValidatingWebhooks(obj *unstructured.Unstructured) {
-	var providerWebhooks = regexp.MustCompile(`^validation\.[a-z]+cluster[a-z]*\.infrastructure\.cluster\.x-k8s\.io$`)
-
-	validatingWebhookConfiguration := &admissionregistrationv1.ValidatingWebhookConfiguration{}
-	if err := scheme.Convert(obj, validatingWebhookConfiguration, nil); err != nil {
-		panic(err)
-	}
-
-	webhooks := []admissionregistrationv1.ValidatingWebhook{}
-	for _, webhook := range validatingWebhookConfiguration.Webhooks {
-		// We don't need these specific webhooks.
-		if webhook.Name == "validation.cluster.cluster.x-k8s.io" || webhook.Name == "validation.clusterclass.cluster.x-k8s.io" || webhook.Name == "default.clusterresourceset.addons.cluster.x-k8s.io" {
-			continue
-		}
-
-		// We also don't need provider webhooks for clusters.
-		if providerWebhooks.MatchString(webhook.Name) {
-			continue
-		}
-
-		webhooks = append(webhooks, webhook)
-	}
-
-	validatingWebhookConfiguration.Webhooks = webhooks
-
-	if err := scheme.Convert(validatingWebhookConfiguration, obj, nil); err != nil {
-		panic(err)
 	}
 }


### PR DESCRIPTION
These webhooks form part of CAPI's API contract. We must run them to
ensure we aren't breaking assumptions of the CAPI controllers.
