### PR TITLE
NO-JIRA: Add lifecyclehook script that updates manifests-gen

### DIFF
--- a/hack/rebasebot-hook-scripts/update-ocp-manifests-gen.sh
+++ b/hack/rebasebot-hook-scripts/update-ocp-manifests-gen.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This script is run by rebasebot during the rebase of the CAPI repositories.
 # This script must be added to rebasebot as a post-rebase hook, which will download it from this repository and execute it on the repository being rebased.
-# The repository being rebased must have a Make target under the openshift folder that performs the OCP manifests generation.
+# The repository being rebased must have a Make target under the openshift folder that performs the OCP manifests-gen tool update.
 
 set -e  # Exit immediately if a command exits with a non-zero status
 set -o pipefail  # Return the exit status of the last command in the pipe that failed
@@ -23,19 +23,10 @@ stage_and_commit(){
 }
 
 main(){
-    # $REBASEBOT_SOURCE is version tag in format v0.0.0
-    if [[ -z "$REBASEBOT_SOURCE" ]]; then
-        echo "The environment variable REBASEBOT_SOURCE is not set." >&2
-        exit 1
-    fi
-
-    # Remove the leading 'v' from REBASEBOT_SOURCE
-    export PROVIDER_VERSION="${REBASEBOT_SOURCE#v}"
-
     pushd openshift
-    make ocp-manifests
+    make update-manifests-gen
     popd
-    stage_and_commit "UPSTREAM: <drop>: Generate OpenShift manifests"
+    stage_and_commit "UPSTREAM: <drop>: Update manifests generator"
 }
 
 main


### PR DESCRIPTION
Adds lifecyclehook script that will run make update-manifests-gen in openshift folder in the rebased repository.

This is meant to run before running generate-ocp-manifests.sh hook to ensure manifests-gen is present and up-to-date.

I considered these two scripts being combined, but having the option to quickly disable one is preferred.