### PR TITLE
OCPBUGS-53057: Fix misspelled CAPI IBMPowerVSCluster kind name in corecluster generation logic

### DIFF
--- a/pkg/controllers/corecluster/corecluster_controller.go
+++ b/pkg/controllers/corecluster/corecluster_controller.go
@@ -220,9 +220,12 @@ func mapOCPPlatformToInfraClusterKindAndVersion(platform configv1.PlatformType) 
 	switch platform {
 	case configv1.AWSPlatformType:
 		return fmt.Sprintf("%sCluster", platform), capiInfraClusterAPIVersionV1Beta2, nil
-	case configv1.AzurePlatformType, configv1.GCPPlatformType, configv1.PowerVSPlatformType,
+	case configv1.AzurePlatformType, configv1.GCPPlatformType,
 		configv1.VSpherePlatformType, configv1.OpenStackPlatformType, configv1.BareMetalPlatformType:
 		return fmt.Sprintf("%sCluster", platform), capiInfraClusterAPIVersionV1Beta1, nil
+	// The CAPI corresponding CRD name is IBMPowerVSCluster https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/api/v1beta2/ibmpowervscluster_types.go#L247
+	case configv1.PowerVSPlatformType:
+		return "ibmpowervscluster", capiInfraClusterAPIVersionV1Beta1, nil
 	default:
 		return "", "", fmt.Errorf("%w: %q", errUnsupportedPlatformType, platform)
 	}


### PR DESCRIPTION
Fixed an issue where PowerVSPlatformType was using incorrect CAPI CRD name. Now, it correctly returns `ibmpowervscluster` as per the [Cluster API Provider for IBM Cloud](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/api/v1beta2/ibmpowervscluster_types.go#L247).