### PR TITLE
OCPCLOUD-2564: add migration controllers

### DIFF
--- a/cmd/machine-api-migration/main.go
+++ b/cmd/machine-api-migration/main.go
@@ -26,6 +26,8 @@ import (
 	configv1client "github.com/openshift/client-go/config/clientset/versioned"
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
 	"github.com/openshift/cluster-capi-operator/pkg/controllers"
+	"github.com/openshift/cluster-capi-operator/pkg/controllers/machinemigration"
+	"github.com/openshift/cluster-capi-operator/pkg/controllers/machinesetmigration"
 	"github.com/openshift/cluster-capi-operator/pkg/controllers/machinesetsync"
 	"github.com/openshift/cluster-capi-operator/pkg/controllers/machinesync"
 	"github.com/openshift/cluster-capi-operator/pkg/util"
@@ -240,6 +242,26 @@ func main() {
 
 	if err := machineSetSyncReconciler.SetupWithManager(mgr); err != nil {
 		klog.Error(err, "failed to set up machineset sync reconciler with manager")
+		os.Exit(1)
+	}
+
+	machineMigrationReconciler := machinemigration.MachineMigrationReconciler{
+		MAPINamespace: *mapiManagedNamespace,
+		CAPINamespace: *capiManagedNamespace,
+	}
+
+	if err := machineMigrationReconciler.SetupWithManager(mgr); err != nil {
+		klog.Error(err, "failed to set up machine migration reconciler with manager")
+		os.Exit(1)
+	}
+
+	machineSetMigrationReconciler := machinesetmigration.MachineSetMigrationReconciler{
+		MAPINamespace: *mapiManagedNamespace,
+		CAPINamespace: *capiManagedNamespace,
+	}
+
+	if err := machineSetMigrationReconciler.SetupWithManager(mgr); err != nil {
+		klog.Error(err, "failed to set up machineset migration reconciler with manager")
 		os.Exit(1)
 	}
 

--- a/pkg/controllers/machinemigration/machine_migration_controller.go
+++ b/pkg/controllers/machinemigration/machine_migration_controller.go
@@ -1,0 +1,397 @@
+/*
+Copyright 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machinemigration
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	capiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/annotations"
+	conditionsv1beta2 "sigs.k8s.io/cluster-api/util/conditions/v1beta2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	machinev1applyconfigs "github.com/openshift/client-go/machine/applyconfigurations/machine/v1beta1"
+	consts "github.com/openshift/cluster-capi-operator/pkg/controllers"
+	"github.com/openshift/cluster-capi-operator/pkg/util"
+)
+
+const controllerName = "MachineMigrationController"
+
+// MachineMigrationReconciler reconciles Machine resources for migration.
+type MachineMigrationReconciler struct {
+	client.Client
+	Scheme        *runtime.Scheme
+	Recorder      record.EventRecorder
+	CAPINamespace string
+	MAPINamespace string
+}
+
+// SetupWithManager sets up the MachineMigration controller.
+func (r *MachineMigrationReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// Allow the namespaces to be set externally for test purposes, when not set,
+	// default to the production namespaces.
+	if r.CAPINamespace == "" {
+		r.CAPINamespace = consts.DefaultManagedNamespace
+	}
+
+	if r.MAPINamespace == "" {
+		r.MAPINamespace = consts.DefaultMAPIManagedNamespace
+	}
+
+	if err := ctrl.NewControllerManagedBy(mgr).
+		Named(controllerName).
+		For(&machinev1beta1.Machine{}, builder.WithPredicates(util.FilterNamespace(r.MAPINamespace))).
+		Complete(r); err != nil {
+		return fmt.Errorf("failed to create controller: %w", err)
+	}
+
+	r.Client = mgr.GetClient()
+	r.Scheme = mgr.GetScheme()
+	r.Recorder = mgr.GetEventRecorderFor(controllerName)
+
+	return nil
+}
+
+// Reconcile performs the reconciliation for a Machine.
+//
+//nolint:funlen
+func (r *MachineMigrationReconciler) Reconcile(ctx context.Context, req reconcile.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues("namespace", req.Namespace, "name", req.Name)
+	ctx = logr.NewContext(ctx, logger)
+
+	logger.V(1).Info("Reconciling machine")
+	defer logger.V(1).Info("Finished reconciling machine")
+
+	mapiMachine := &machinev1beta1.Machine{}
+	if err := r.Get(ctx, client.ObjectKey{Namespace: req.Namespace, Name: req.Name}, mapiMachine); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get MAPI machine: %w", err)
+	}
+
+	if mapiMachine.Spec.AuthoritativeAPI == mapiMachine.Status.AuthoritativeAPI {
+		// No migration is being requested for this resource, nothing to do.
+		return ctrl.Result{}, nil
+	}
+
+	// If authoritativeAPI status is empty, it means it is the first time we see this resource.
+	// Set the status.authoritativeAPI to match the spec.authoritativeAPI.
+	if mapiMachine.Status.AuthoritativeAPI == "" {
+		if err := r.applyStatusAuthoritativeAPIWithPatch(ctx, mapiMachine, mapiMachine.Spec.AuthoritativeAPI); err != nil {
+			return ctrl.Result{}, fmt.Errorf("unable to apply authoritativeAPI to status with patch: %w", err)
+		}
+
+		// Wait for the patching to take effect.
+		return ctrl.Result{}, nil
+	}
+
+	// Check if the Synchronized condition is set to True.
+	// If it is not, this indicates an unmigratable resource and therefore should take no action.
+	if cond, err := util.GetConditionStatus(mapiMachine, string(consts.SynchronizedCondition)); err != nil {
+		return ctrl.Result{}, fmt.Errorf("unable to get synchronizedCondition for %s/%s: %w", mapiMachine.Namespace, mapiMachine.Name, err)
+	} else if cond != corev1.ConditionTrue {
+		logger.Info("Machine not synchronized with latest authoritative generation, will retry later")
+
+		return ctrl.Result{}, nil
+	}
+
+	// Make sure the authoritativeAPI resource status is set to migrating.
+	if mapiMachine.Status.AuthoritativeAPI != machinev1beta1.MachineAuthorityMigrating {
+		logger.Info("Detected migration request for machine")
+
+		if err := r.applyStatusAuthoritativeAPIWithPatch(ctx, mapiMachine, machinev1beta1.MachineAuthorityMigrating); err != nil {
+			return ctrl.Result{}, fmt.Errorf("unable to set authoritativeAPI %q to status: %w", machinev1beta1.MachineAuthorityMigrating, err)
+		}
+
+		logger.Info("Acknowledged migration request for machine")
+
+		// Wait for the change to propagate.
+		return ctrl.Result{}, nil
+	}
+
+	// Request pausing on the authoritative resource.
+	if updated, err := r.requestOldAuthoritativeResourcePaused(ctx, mapiMachine); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to request pause on authoritative machine: %w", err)
+	} else if updated {
+		logger.Info("Requested pausing for authoritative machine")
+
+		// Wait for the change to propagate.
+		// Since there is not a watch for CAPI infra machines here
+		// we will not get an event for the CAPI infra machine's paused condition change,
+		// as such, manually requeue.
+		return ctrl.Result{RequeueAfter: time.Second}, nil
+	}
+
+	// Check that the authoritative resource is paused.
+	if paused, err := r.isOldAuthoritativeResourcePaused(ctx, mapiMachine); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to check paused on authoritative machine: %w", err)
+	} else if !paused {
+		// The Authoritative API resource is not paused yet, requeue to check later.
+		logger.Info("Authoritative machine is not paused yet, will retry later")
+
+		return ctrl.Result{}, nil
+	}
+
+	// Check if the synchronizedGeneration matches the old authoritativeAPI's resource current generation.
+	if isSynchronizedGenMatchingOldAuthority, err := r.isSynchronizedGenerationMatchingOldAuthoritativeAPIGeneration(ctx, mapiMachine); err != nil {
+		return ctrl.Result{}, fmt.Errorf("unable to check synchronizedGeneration matches old authority: %w", err)
+	} else if !isSynchronizedGenMatchingOldAuthority {
+		// The to-be Authoritative API resource is not fully synced up yet, requeue to check later.
+		logger.Info("Authoritative machine and its copy are not synchronized yet, will retry later")
+
+		return ctrl.Result{}, nil
+	}
+
+	// Set the actual AuthoritativeAPI to the desired one, reset the synchronized generation and condition.
+	if err := r.setNewAuthoritativeAPIAndResetSynchronized(ctx, mapiMachine, mapiMachine.Spec.AuthoritativeAPI); err != nil {
+		return ctrl.Result{}, fmt.Errorf("unable to apply authoritativeAPI to status with patch: %w", err)
+	}
+
+	// Make sure the new authoritative resource has been requested to unpause.
+	if err := r.ensureUnpauseRequestedOnNewAuthoritativeResource(ctx, mapiMachine); err != nil {
+		return ctrl.Result{}, fmt.Errorf("unable to ensure the new AuthoritativeAPI has been un-paused: %w", err)
+	}
+
+	logger.Info("Machine authority switch has now been completed and the resource unpaused")
+	logger.Info("Machine migrated successfully")
+
+	return ctrl.Result{}, nil
+}
+
+// isOldAuthoritativeResourcePaused checks whether the old authoritative resource is paused.
+func (r *MachineMigrationReconciler) isOldAuthoritativeResourcePaused(ctx context.Context, m *machinev1beta1.Machine) (bool, error) {
+	if m.Spec.AuthoritativeAPI == machinev1beta1.MachineAuthorityClusterAPI {
+		cond, err := util.GetConditionStatus(m, "Paused")
+		if err != nil {
+			return false, fmt.Errorf("unable to get paused condition for %s/%s: %w", m.Namespace, m.Name, err)
+		}
+
+		return cond == corev1.ConditionTrue, nil
+	}
+
+	// For MachineAuthorityMachineAPI, check the corresponding CAPI resource.
+	capiMachine := &capiv1beta1.Machine{}
+	if err := r.Get(ctx, client.ObjectKey{Namespace: r.CAPINamespace, Name: m.Name}, capiMachine); err != nil {
+		return false, fmt.Errorf("failed to get Cluster API machine: %w", err)
+	}
+
+	machinePausedCondition := conditionsv1beta2.Get(capiMachine, capiv1beta1.PausedV1Beta2Condition)
+	if machinePausedCondition == nil {
+		return false, nil
+	}
+
+	infraMachineRef := capiMachine.Spec.InfrastructureRef
+
+	infraMachine, err := util.GetReferencedObject(ctx, r.Client, r.Scheme, infraMachineRef)
+	if err != nil {
+		return false, fmt.Errorf("failed to get Cluster API infra machine: %w", err)
+	}
+
+	infraMachinePausedConditionStatus, err := util.GetConditionStatus(infraMachine, capiv1beta1.PausedV1Beta2Condition)
+	if err != nil {
+		return false, fmt.Errorf("unable to get paused condition for %s/%s: %w", infraMachine.GetNamespace(), infraMachine.GetName(), err)
+	}
+
+	return (machinePausedCondition.Status == metav1.ConditionTrue) && (infraMachinePausedConditionStatus == corev1.ConditionTrue), nil
+}
+
+func (r *MachineMigrationReconciler) ensureUnpauseRequestedOnNewAuthoritativeResource(ctx context.Context, mapiMachine *machinev1beta1.Machine) error {
+	// Request that the new authoritative resource reconciliation is un-paused.
+	//nolint:wsl
+	switch mapiMachine.Spec.AuthoritativeAPI {
+	case machinev1beta1.MachineAuthorityClusterAPI:
+		// For requesting unpausing of a CAPI resource, remove the paused annotation on it.
+		// So check if the ClusterAPI resource has the paused annotation and if so remove it.
+		capiMachine := &capiv1beta1.Machine{}
+		if err := r.Get(ctx, client.ObjectKey{Namespace: r.CAPINamespace, Name: mapiMachine.Name}, capiMachine); err != nil {
+			return fmt.Errorf("failed to get Cluster API machine: %w", err)
+		}
+
+		infraMachineRef := capiMachine.Spec.InfrastructureRef
+
+		infraMachine, err := util.GetReferencedObject(ctx, r.Client, r.Scheme, infraMachineRef)
+		if err != nil {
+			return fmt.Errorf("failed to get Cluster API infra machine: %w", err)
+		}
+
+		if annotations.HasPaused(capiMachine) {
+			capiMachineCopy := capiMachine.DeepCopy()
+			delete(capiMachine.Annotations, capiv1beta1.PausedAnnotation)
+
+			if err := r.Patch(ctx, capiMachine, client.MergeFrom(capiMachineCopy)); err != nil {
+				return fmt.Errorf("failed to patch Cluster API machine: %w", err)
+			}
+		}
+
+		if annotations.HasPaused(infraMachine) {
+			infraMachineCopy, ok := infraMachine.DeepCopyObject().(client.Object)
+			if !ok {
+				return fmt.Errorf("unable to assert Cluster API infra machine as client.Object: %w", err)
+			}
+			util.RemoveAnnotation(infraMachine, capiv1beta1.PausedAnnotation)
+
+			if err := r.Patch(ctx, infraMachine, client.MergeFrom(infraMachineCopy)); err != nil {
+				return fmt.Errorf("failed to patch Cluster API infra machine: %w", err)
+			}
+		}
+	case machinev1beta1.MachineAuthorityMachineAPI:
+		// For requesting unpausing of a MAPI resource, it is sufficient to switch the spec.AuthoritativeAPI field on the MAPI resource.
+		// which is already done before this code runs in this controller. Nothing to do here.
+	case machinev1beta1.MachineAuthorityMigrating:
+		// Value is disallowed by the openAPI schema validation.
+	}
+
+	return nil
+}
+
+// requestOldAuthoritativeResourcePaused requests the old authoritative resource is paused.
+func (r *MachineMigrationReconciler) requestOldAuthoritativeResourcePaused(ctx context.Context, m *machinev1beta1.Machine) (bool, error) {
+	// Request that the old authoritative resource reconciliation is paused.
+	updated := false
+	//nolint:wsl
+	switch m.Spec.AuthoritativeAPI {
+	case machinev1beta1.MachineAuthorityClusterAPI:
+		// For requesting pausing of a MAPI resource, it is sufficient to switch the spec.AuthoritativeAPI field on the MAPI resource.
+		// which is already done before this code runs in this controller.
+	case machinev1beta1.MachineAuthorityMachineAPI:
+		// For requesting pausing of a CAPI resource, set the paused annotation on it.
+		// The spec.AuthoritativeAPI is set to MachineAPI, meaning that the old authoritativeAPI was ClusterAPI.
+		// So Check if the ClusterAPI resource has the paused annotation, otherwise set it.
+		capiMachine := &capiv1beta1.Machine{}
+		if err := r.Get(ctx, client.ObjectKey{Namespace: r.CAPINamespace, Name: m.Name}, capiMachine); err != nil {
+			return false, fmt.Errorf("failed to get Cluster API machine: %w", err)
+		}
+
+		infraMachineRef := capiMachine.Spec.InfrastructureRef
+
+		infraMachine, err := util.GetReferencedObject(ctx, r.Client, r.Scheme, infraMachineRef)
+		if err != nil {
+			return false, fmt.Errorf("failed to get Cluster API infra machine: %w", err)
+		}
+
+		if !annotations.HasPaused(capiMachine) {
+			capiMachineCopy := capiMachine.DeepCopy()
+			annotations.AddAnnotations(capiMachine, map[string]string{capiv1beta1.PausedAnnotation: ""})
+			if err := r.Patch(ctx, capiMachine, client.MergeFrom(capiMachineCopy)); err != nil {
+				return false, fmt.Errorf("failed to patch Cluster API machine: %w", err)
+			}
+
+			updated = true
+		}
+
+		if !annotations.HasPaused(infraMachine) {
+			infraMachineCopy, ok := infraMachine.DeepCopyObject().(client.Object)
+			if !ok {
+				return false, fmt.Errorf("unable to assert Cluster API infra machine as client.Object: %w", err)
+			}
+			annotations.AddAnnotations(infraMachine, map[string]string{capiv1beta1.PausedAnnotation: ""})
+			if err := r.Patch(ctx, infraMachine, client.MergeFrom(infraMachineCopy)); err != nil {
+				return false, fmt.Errorf("failed to patch Cluster API infra machine: %w", err)
+			}
+
+			updated = true
+		}
+	case machinev1beta1.MachineAuthorityMigrating:
+		// Value is disallowed by the openAPI schema validation.
+	}
+
+	return updated, nil
+}
+
+func (r *MachineMigrationReconciler) isSynchronizedGenerationMatchingOldAuthoritativeAPIGeneration(ctx context.Context, mapiMachine *machinev1beta1.Machine) (bool, error) {
+	//nolint:wsl
+	switch mapiMachine.Spec.AuthoritativeAPI {
+	case machinev1beta1.MachineAuthorityClusterAPI:
+		// ClusterAPI is the desired authoritative API but
+		// MachineAPI is currently still the authoritative one.
+		// Check MachineAPI generation against the synchronized one.
+		return mapiMachine.Status.SynchronizedGeneration == mapiMachine.Generation, nil
+	case machinev1beta1.MachineAuthorityMachineAPI:
+		// MachineAPI is the desired authoritative API but
+		// ClusterAPI is currently still the authoritative one.
+		// Check ClusterAPI generation against the synchronized one.
+		capiMachine := &capiv1beta1.Machine{}
+		if err := r.Get(ctx, client.ObjectKey{Namespace: r.CAPINamespace, Name: mapiMachine.Name}, capiMachine); err != nil {
+			return false, fmt.Errorf("failed to get Cluster API machine: %w", err)
+		}
+
+		// Do not check this for the CAPI infra machine.
+		// As its ref is embedded in the capiMachine and they get updated together.
+		return (mapiMachine.Status.SynchronizedGeneration == capiMachine.Generation), nil
+	case machinev1beta1.MachineAuthorityMigrating:
+		// Value is disallowed by the openAPI schema validation.
+	}
+
+	return false, nil
+}
+
+// applyStatusAuthoritativeAPIWithPatch updates the resource status.authoritativeAPI using a server-side apply patch.
+func (r *MachineMigrationReconciler) applyStatusAuthoritativeAPIWithPatch(ctx context.Context, m *machinev1beta1.Machine, authority machinev1beta1.MachineAuthority) error {
+	logger := log.FromContext(ctx)
+	logger.Info(fmt.Sprintf("Setting AuthoritativeAPI status to %q for resource", authority))
+
+	ac := machinev1applyconfigs.Machine(m.Name, m.Namespace).
+		WithStatus(machinev1applyconfigs.MachineStatus().WithAuthoritativeAPI(authority))
+
+	if err := r.Status().Patch(ctx, m, util.ApplyConfigPatch(ac), client.ForceOwnership, client.FieldOwner(controllerName+"-AuthoritativeAPI")); err != nil {
+		return fmt.Errorf("failed to patch Machine API machine status with authoritativeAPI %q: %w", authority, err)
+	}
+
+	return nil
+}
+
+// setNewAuthoritativeAPIAndResetSynchronized updates the Machine status to the new authoritativeAPI,
+// resets the synchronized generation, and removes the Synchronized condition.
+func (r *MachineMigrationReconciler) setNewAuthoritativeAPIAndResetSynchronized(ctx context.Context, m *machinev1beta1.Machine, authority machinev1beta1.MachineAuthority) error {
+	var newConditions []*machinev1applyconfigs.ConditionApplyConfiguration
+
+	for _, cond := range m.Status.Conditions {
+		if cond.Type != consts.SynchronizedCondition {
+			newConditions = append(newConditions, &machinev1applyconfigs.ConditionApplyConfiguration{
+				LastTransitionTime: &cond.LastTransitionTime,
+				Message:            &cond.Message,
+				Reason:             &cond.Reason,
+				Status:             &cond.Status,
+				Severity:           &cond.Severity,
+				Type:               &cond.Type,
+			})
+		}
+	}
+
+	statusAc := machinev1applyconfigs.MachineStatus().
+		WithAuthoritativeAPI(authority).
+		WithConditions(newConditions...).
+		WithSynchronizedGeneration(0)
+
+	ac := machinev1applyconfigs.Machine(m.Name, m.Namespace).WithStatus(statusAc)
+
+	if err := r.Status().Patch(ctx, m, util.ApplyConfigPatch(ac), client.ForceOwnership, client.FieldOwner(controllerName+"-AuthoritativeAPI")); err != nil {
+		return fmt.Errorf("failed to patch Machine API machine status with authoritativeAPI %q: %w", authority, err)
+	}
+
+	return nil
+}

--- a/pkg/controllers/machinemigration/machine_migration_controller_test.go
+++ b/pkg/controllers/machinemigration/machine_migration_controller_test.go
@@ -1,0 +1,725 @@
+/*
+Copyright 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machinemigration
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	capiv1resourcebuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/cluster-api/core/v1beta1"
+	capav1builder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2"
+	corev1resourcebuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/core/v1"
+	machinev1resourcebuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	capav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+
+	capiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-api-actuator-pkg/testutils"
+	consts "github.com/openshift/cluster-capi-operator/pkg/controllers"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ = Describe("With a running MachineMigration controller", func() {
+	var (
+		k          komega.Komega
+		reconciler *MachineMigrationReconciler
+
+		migrationControllerNamespace *corev1.Namespace
+		capiNamespace                *corev1.Namespace
+		mapiNamespace                *corev1.Namespace
+
+		mapiMachineBuilder machinev1resourcebuilder.MachineBuilder
+		mapiMachine        *machinev1beta1.Machine
+		capiMachineBuilder capiv1resourcebuilder.MachineBuilder
+		capiMachine        *capiv1beta1.Machine
+		capaMachine        *capav1.AWSMachine
+		capaMachineBuilder capav1builder.AWSMachineBuilder
+		capaClusterBuilder capav1builder.AWSClusterBuilder
+		capiClusterBuilder capiv1resourcebuilder.ClusterBuilder
+		capiCluster        *capiv1beta1.Cluster
+	)
+
+	BeforeEach(func() {
+		By("Setting up namespaces for the test")
+		migrationControllerNamespace = corev1resourcebuilder.Namespace().
+			WithGenerateName("machine-migration-controller-").Build()
+		Expect(k8sClient.Create(ctx, migrationControllerNamespace)).To(Succeed(), "migration controller namespace should be able to be created")
+
+		mapiNamespace = corev1resourcebuilder.Namespace().
+			WithGenerateName("openshift-machine-api-").Build()
+		Expect(k8sClient.Create(ctx, mapiNamespace)).To(Succeed(), "MAPI namespace should be able to be created")
+
+		capiNamespace = corev1resourcebuilder.Namespace().
+			WithGenerateName("openshift-cluster-api-").Build()
+		Expect(k8sClient.Create(ctx, capiNamespace)).To(Succeed(), "CAPI namespace should be able to be created")
+
+		mapiMachineBuilder = machinev1resourcebuilder.Machine().
+			WithNamespace(mapiNamespace.GetName()).
+			WithName("foo").
+			WithProviderSpecBuilder(machinev1resourcebuilder.AWSProviderSpec().WithLoadBalancers(nil))
+
+		infrastructureName := "cluster-foo"
+		capaClusterBuilder = capav1builder.AWSCluster().
+			WithNamespace(capiNamespace.GetName()).
+			WithName(infrastructureName)
+		Expect(k8sClient.Create(ctx, capaClusterBuilder.Build())).To(Succeed(), "CAPA cluster should be able to be created")
+
+		capiClusterBuilder = capiv1resourcebuilder.Cluster().
+			WithNamespace(capiNamespace.GetName()).
+			WithName(infrastructureName)
+		Expect(k8sClient.Create(ctx, capiClusterBuilder.Build())).To(Succeed(), "CAPI cluster should be able to be created")
+
+		capiCluster = &capiv1beta1.Cluster{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{Name: infrastructureName, Namespace: capiNamespace.GetName()}, capiCluster)).To(Succeed())
+
+		capaMachineBuilder = capav1builder.AWSMachine().
+			WithNamespace(capiNamespace.GetName()).
+			WithName("machine-template")
+
+		capaMachine = capaMachineBuilder.Build()
+
+		capaMachineRef := corev1.ObjectReference{
+			APIVersion: capaMachine.APIVersion,
+			Kind:       capaMachine.Kind,
+			Name:       capaMachine.GetName(),
+			Namespace:  capaMachine.GetNamespace(),
+		}
+
+		capiMachineBuilder = capiv1resourcebuilder.Machine().
+			WithNamespace(capiNamespace.GetName()).
+			WithInfrastructureRef(capaMachineRef).
+			WithName("foo").
+			WithClusterName(infrastructureName)
+
+		reconciler = &MachineMigrationReconciler{
+			Client:        k8sClient,
+			Scheme:        testEnv.Scheme,
+			CAPINamespace: capiNamespace.GetName(),
+			MAPINamespace: mapiNamespace.GetName(),
+		}
+
+		k = komega.New(k8sClient)
+	})
+
+	AfterEach(func() {
+		By("Cleaning up MAPI test resources")
+		testutils.CleanupResources(Default, ctx, cfg, k8sClient, mapiNamespace.GetName(),
+			&machinev1beta1.Machine{},
+			&machinev1beta1.MachineSet{},
+			&configv1.Infrastructure{},
+		)
+		testutils.CleanupResources(Default, ctx, cfg, k8sClient, capiNamespace.GetName(),
+			&capiv1beta1.Machine{},
+			&capiv1beta1.MachineSet{},
+			&capav1.AWSCluster{},
+			&capav1.AWSMachineTemplate{},
+			&capav1.AWSMachine{},
+		)
+	})
+
+	Describe("Reconcile", func() {
+		var req reconcile.Request
+
+		Context("when no migration is requested (status equals spec)", func() {
+			BeforeEach(func() {
+				By("Setting the MAPI machine spec AuthoritativeAPI to MachineAPI")
+				mapiMachine = mapiMachineBuilder.
+					WithAuthoritativeAPI(machinev1beta1.MachineAuthorityMachineAPI).
+					Build()
+				Eventually(k8sClient.Create(ctx, mapiMachine)).Should(Succeed())
+
+				By("Setting the MAPI machine status AuthoritativeAPI to MachineAPI")
+				Eventually(k.UpdateStatus(mapiMachine, func() {
+					mapiMachine.Status.AuthoritativeAPI = machinev1beta1.MachineAuthorityMachineAPI
+				})).Should(Succeed())
+
+				req = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(mapiMachine)}
+			})
+
+			It("should do nothing", func() {
+				initialMAPIMachineRV := mapiMachine.ResourceVersion
+				_, err := reconciler.Reconcile(ctx, req)
+				Expect(err).NotTo(HaveOccurred(), "reconciler should not have errored")
+				Eventually(k.Object(mapiMachine)).Should(HaveField("ObjectMeta.ResourceVersion", Equal(initialMAPIMachineRV)), "should not have modified the machine")
+			})
+		})
+
+		Context("when status.AuthoritativeAPI is empty (first observation)", func() {
+			BeforeEach(func() {
+				By("Setting the MAPI machine spec AuthoritativeAPI to MachineAPI")
+				mapiMachine = mapiMachineBuilder.
+					WithAuthoritativeAPI(machinev1beta1.MachineAuthorityMachineAPI).
+					Build()
+				Eventually(k8sClient.Create(ctx, mapiMachine)).Should(Succeed())
+
+				By("Leaving the MAPI machine status AuthoritativeAPI empty")
+
+				req = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(mapiMachine)}
+			})
+
+			It("should patch the status to match spec and requeue", func() {
+				By("Running one reconciliation")
+				_, err := reconciler.Reconcile(ctx, req)
+				Expect(err).NotTo(HaveOccurred(), "reconciler should not have errored")
+				updatedM := &machinev1beta1.Machine{}
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(mapiMachine), updatedM)).To(Succeed())
+				Expect(updatedM.Status.AuthoritativeAPI).To(Equal(updatedM.Spec.AuthoritativeAPI))
+			})
+		})
+
+		Context("when the Synchronized condition is not True", func() {
+			BeforeEach(func() {
+				By("Setting the MAPI machine spec AuthoritativeAPI to ClusterAPI")
+				mapiMachine = mapiMachineBuilder.
+					WithAuthoritativeAPI(machinev1beta1.MachineAuthorityClusterAPI).
+					Build()
+				Eventually(k8sClient.Create(ctx, mapiMachine)).Should(Succeed())
+
+				By("Setting the MAPI machine status AuthoritativeAPI to MachineAPI")
+				Eventually(k.UpdateStatus(mapiMachine, func() {
+					updatedMAPIMachine := mapiMachineBuilder.
+						WithAuthoritativeAPIStatus(machinev1beta1.MachineAuthorityMachineAPI).
+						WithConditions([]machinev1beta1.Condition{{
+							Type:               consts.SynchronizedCondition,
+							LastTransitionTime: metav1.Now(),
+							Status:             corev1.ConditionFalse}}).
+						Build()
+					mapiMachine.Status.AuthoritativeAPI = updatedMAPIMachine.Status.AuthoritativeAPI
+					mapiMachine.Status.Conditions = updatedMAPIMachine.Status.Conditions
+				})).Should(Succeed())
+
+				req = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(mapiMachine)}
+			})
+
+			It("should do nothing", func() {
+				initialMAPIMachineRV := mapiMachine.ResourceVersion
+				_, err := reconciler.Reconcile(ctx, req)
+				Expect(err).NotTo(HaveOccurred(), "reconciler should not have errored")
+				Eventually(k.Object(mapiMachine)).Should(HaveField("ObjectMeta.ResourceVersion", Equal(initialMAPIMachineRV)), "should not have modified the machine")
+			})
+		})
+
+		Context("when a migration request is first detected", func() {
+			BeforeEach(func() {
+				By("Setting the MAPI machine spec AuthoritativeAPI to ClusterAPI")
+				mapiMachine = mapiMachineBuilder.
+					WithAuthoritativeAPI(machinev1beta1.MachineAuthorityClusterAPI).
+					Build()
+				Eventually(k8sClient.Create(ctx, mapiMachine)).Should(Succeed())
+
+				By("Setting the MAPI machine status AuthoritativeAPI to MachineAPI")
+				Eventually(k.UpdateStatus(mapiMachine, func() {
+					updatedMAPIMachine := mapiMachineBuilder.
+						WithAuthoritativeAPIStatus(machinev1beta1.MachineAuthorityMachineAPI).
+						WithConditions([]machinev1beta1.Condition{{
+							Type:               consts.SynchronizedCondition,
+							LastTransitionTime: metav1.Now(),
+							Status:             corev1.ConditionTrue}}).
+						Build()
+					mapiMachine.Status.AuthoritativeAPI = updatedMAPIMachine.Status.AuthoritativeAPI
+					mapiMachine.Status.Conditions = updatedMAPIMachine.Status.Conditions
+				})).Should(Succeed())
+
+				req = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(mapiMachine)}
+			})
+
+			It("should acknowledge the migration by updating status to 'Migrating' and requeuing", func() {
+				_, err := reconciler.Reconcile(ctx, req)
+				Expect(err).NotTo(HaveOccurred())
+
+				updatedM := &machinev1beta1.Machine{}
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(mapiMachine), updatedM)).To(Succeed())
+				Expect(updatedM.Status.AuthoritativeAPI).To(Equal(machinev1beta1.MachineAuthorityMigrating))
+			})
+		})
+
+		Context("when the resource migration has been acknowledged (resource status migrating)", func() {
+			Context("when migrating from MachineAPI to ClusterAPI", func() {
+				BeforeEach(func() {
+					By("Setting the MAPI machine spec AuthoritativeAPI to ClusterAPI")
+					mapiMachine = mapiMachineBuilder.
+						WithAuthoritativeAPI(machinev1beta1.MachineAuthorityClusterAPI).
+						Build()
+					Eventually(k8sClient.Create(ctx, mapiMachine)).Should(Succeed())
+
+					By("Setting the MAPI machine status AuthoritativeAPI to 'Migrating'")
+					Eventually(k.UpdateStatus(mapiMachine, func() {
+						updatedMAPIMachine := mapiMachineBuilder.
+							WithAuthoritativeAPIStatus(machinev1beta1.MachineAuthorityMigrating).
+							WithConditions([]machinev1beta1.Condition{{
+								Type:               consts.SynchronizedCondition,
+								LastTransitionTime: metav1.Now(),
+								Status:             corev1.ConditionTrue}}).
+							Build()
+						mapiMachine.Status.AuthoritativeAPI = updatedMAPIMachine.Status.AuthoritativeAPI
+						mapiMachine.Status.Conditions = updatedMAPIMachine.Status.Conditions
+					})).Should(Succeed())
+
+					req = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(mapiMachine)}
+				})
+
+				It("should request pausing for the old authoritative resource (MAPI) and stay in Migrating status", func() {
+					_, err := reconciler.Reconcile(ctx, req)
+					Expect(err).NotTo(HaveOccurred())
+
+					updatedM := &machinev1beta1.Machine{}
+					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(mapiMachine), updatedM)).To(Succeed())
+					// To check for requesting pausing on the the MAPI resource it is sufficient
+					// see that the spec.AuthoritativeAPI field is set to ClusterAPI,
+					// which is already done anyway on the requester side.
+					Expect(updatedM.Spec.AuthoritativeAPI).To(Equal(machinev1beta1.MachineAuthorityClusterAPI))
+					Expect(updatedM.Status.AuthoritativeAPI).To(Equal(machinev1beta1.MachineAuthorityMigrating))
+				})
+			})
+			Context("when migrating from ClusterAPI to MachineAPI", func() {
+				BeforeEach(func() {
+					By("Setting the MAPI machine spec AuthoritativeAPI to MachineAPI")
+					mapiMachine = mapiMachineBuilder.WithAuthoritativeAPI(machinev1beta1.MachineAuthorityMachineAPI).Build()
+					Eventually(k8sClient.Create(ctx, mapiMachine)).Should(Succeed())
+
+					By("Creating a mirror CAPI machine")
+					capiMachine = capiMachineBuilder.Build()
+					Eventually(k8sClient.Create(ctx, capiMachine)).Should(Succeed())
+					capaMachine = capaMachineBuilder.Build()
+					Eventually(k8sClient.Create(ctx, capaMachine)).Should(Succeed())
+
+					By("Setting the MAPI machine status AuthoritativeAPI to 'Migrating'")
+					Eventually(k.UpdateStatus(mapiMachine, func() {
+						updatedMAPIMachine := mapiMachineBuilder.
+							WithAuthoritativeAPIStatus(machinev1beta1.MachineAuthorityMigrating).
+							WithConditions([]machinev1beta1.Condition{{
+								Type:               consts.SynchronizedCondition,
+								LastTransitionTime: metav1.Now(),
+								Status:             corev1.ConditionTrue}}).
+							Build()
+						mapiMachine.Status.AuthoritativeAPI = updatedMAPIMachine.Status.AuthoritativeAPI
+						mapiMachine.Status.Conditions = updatedMAPIMachine.Status.Conditions
+					})).Should(Succeed())
+
+					req = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(mapiMachine)}
+				})
+
+				It("should request pausing for the old authoritative resource (CAPI) and stay in Migrating status", func() {
+					_, err := reconciler.Reconcile(ctx, req)
+					Expect(err).NotTo(HaveOccurred())
+
+					updatedM := &machinev1beta1.Machine{}
+					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(mapiMachine), updatedM)).To(Succeed())
+					Expect(updatedM.Status.AuthoritativeAPI).To(Equal(machinev1beta1.MachineAuthorityMigrating))
+
+					updatedCAPIM := &capiv1beta1.Machine{}
+					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(capiMachine), updatedCAPIM)).To(Succeed())
+					Expect(updatedCAPIM.Annotations).To(HaveKeyWithValue(capiv1beta1.PausedAnnotation, ""))
+
+					updatedCAPIInfraMachine := &capav1.AWSMachine{}
+					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(capaMachine), updatedCAPIInfraMachine)).To(Succeed())
+					Expect(updatedCAPIInfraMachine.Annotations).To(HaveKeyWithValue(capiv1beta1.PausedAnnotation, ""))
+				})
+			})
+		})
+
+		Context("when the old authoritative resource pausing has been requested", func() {
+			Context("when migrating from MachineAPI to ClusterAPI", func() {
+				Context("when status is not paused for the old authoritative resource (MAPI)", func() {
+					BeforeEach(func() {
+						By("Setting the MAPI machine spec AuthoritativeAPI to ClusterAPI")
+						mapiMachine = mapiMachineBuilder.
+							// Set desired authoritative API in spec to ClusterAPI.
+							// To check for requesting pausing on the the MAPI resource it is sufficient
+							// see that the spec.AuthoritativeAPI field is set to ClusterAPI.
+							WithAuthoritativeAPI(machinev1beta1.MachineAuthorityClusterAPI).
+							Build()
+						Eventually(k8sClient.Create(ctx, mapiMachine)).Should(Succeed())
+
+						By("Setting the MAPI machine status AuthoritativeAPI to 'Migrating'")
+						Eventually(k.UpdateStatus(mapiMachine, func() {
+							updatedMAPIMachine := mapiMachineBuilder.
+								WithAuthoritativeAPIStatus(machinev1beta1.MachineAuthorityMigrating).
+								WithConditions([]machinev1beta1.Condition{
+									{
+										Type:               consts.SynchronizedCondition,
+										LastTransitionTime: metav1.Now(),
+										Status:             corev1.ConditionTrue,
+									},
+									{
+										Type:               "Paused",
+										LastTransitionTime: metav1.Now(),
+										Status:             corev1.ConditionTrue,
+									},
+								}).
+								Build()
+							mapiMachine.Status.AuthoritativeAPI = updatedMAPIMachine.Status.AuthoritativeAPI
+							mapiMachine.Status.Conditions = updatedMAPIMachine.Status.Conditions
+						})).Should(Succeed())
+
+						req = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(mapiMachine)}
+					})
+
+					It("should set old authoritative API (MAPI) status to paused and requeue", func() {
+						_, err := reconciler.Reconcile(ctx, req)
+						Expect(err).NotTo(HaveOccurred())
+
+						Eventually(komega.Object(mapiMachine)).Should(
+							HaveField("Status.Conditions", SatisfyAll(
+								Not(BeEmpty()),
+								ContainElement(SatisfyAll(
+									HaveField("Type", BeEquivalentTo("Paused")),
+									HaveField("Status", Equal(corev1.ConditionTrue)),
+								)),
+							)),
+						)
+					})
+				})
+			})
+			Context("when migrating from ClusterAPI to MachineAPI", func() {
+				Context("when status is not paused for the old authoritative resource (CAPI)", func() {
+					BeforeEach(func() {
+						By("Setting the MAPI machine spec AuthoritativeAPI to MachineAPI")
+						mapiMachine = mapiMachineBuilder.
+							WithAuthoritativeAPI(machinev1beta1.MachineAuthorityMachineAPI).
+							Build()
+						Eventually(k8sClient.Create(ctx, mapiMachine)).Should(Succeed())
+
+						By("Creating a mirror CAPI machine")
+						capiMachine = capiMachineBuilder.Build()
+						Eventually(k8sClient.Create(ctx, capiMachine)).Should(Succeed())
+						capaMachine = capaMachineBuilder.Build()
+						Eventually(k8sClient.Create(ctx, capaMachine)).Should(Succeed())
+
+						By("Setting the MAPI machine status AuthoritativeAPI to 'Migrating'")
+						Eventually(k.UpdateStatus(mapiMachine, func() {
+							updatedMAPIMachine := mapiMachineBuilder.
+								WithAuthoritativeAPIStatus(machinev1beta1.MachineAuthorityMigrating).
+								WithConditions([]machinev1beta1.Condition{{
+									Type:               consts.SynchronizedCondition,
+									LastTransitionTime: metav1.Now(),
+									Status:             corev1.ConditionTrue}}).
+								Build()
+							mapiMachine.Status.AuthoritativeAPI = updatedMAPIMachine.Status.AuthoritativeAPI
+							mapiMachine.Status.Conditions = updatedMAPIMachine.Status.Conditions
+						})).Should(Succeed())
+
+						By("Setting the CAPI machine status condition to 'Paused'")
+						Eventually(k.UpdateStatus(capiMachine, func() {
+							updatedCAPIMachine := capiMachineBuilder.Build()
+							updatedCAPIMachine.Status.V1Beta2 = &capiv1beta1.MachineV1Beta2Status{
+								Conditions: []metav1.Condition{{
+									Type:               capiv1beta1.PausedV1Beta2Condition,
+									Status:             metav1.ConditionTrue,
+									LastTransitionTime: metav1.Now(),
+								}},
+							}
+							capiMachine.Status = updatedCAPIMachine.Status
+						})).Should(Succeed())
+
+						By("Setting the CAPI infra machine status condition to 'Paused'")
+						Eventually(k.UpdateStatus(capaMachine, func() {
+							updatedCAPIInfraMachine := capaMachineBuilder.Build()
+							updatedCAPIInfraMachine.Status.Conditions = capiv1beta1.Conditions{
+								{
+									Type:               capiv1beta1.PausedV1Beta2Condition,
+									Status:             corev1.ConditionTrue,
+									LastTransitionTime: metav1.Now(),
+								},
+							}
+							capaMachine.Status = updatedCAPIInfraMachine.Status
+						})).Should(Succeed())
+
+						req = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(mapiMachine)}
+					})
+
+					It("should set old authoritative API (CAPI) status to paused and requeue", func() {
+						_, err := reconciler.Reconcile(ctx, req)
+						Expect(err).NotTo(HaveOccurred())
+
+						Eventually(komega.Object(capiMachine)).Should(
+							HaveField("Status.V1Beta2.Conditions", SatisfyAll(
+								Not(BeEmpty()),
+								ContainElement(SatisfyAll(
+									HaveField("Type", Equal(capiv1beta1.PausedV1Beta2Condition)),
+									HaveField("Status", Equal(metav1.ConditionTrue)),
+								)),
+							)),
+						)
+						Eventually(komega.Object(capaMachine)).Should(
+							HaveField("Status.Conditions", SatisfyAll(
+								Not(BeEmpty()),
+								ContainElement(SatisfyAll(
+									HaveField("Type", BeEquivalentTo(capiv1beta1.PausedV1Beta2Condition)),
+									HaveField("Status", Equal(corev1.ConditionTrue)),
+								)),
+							)),
+						)
+					})
+				})
+			})
+		})
+
+		Context("when the old authoritative resource has been paused", func() {
+			Context("when migrating from MachineAPI to ClusterAPI", func() {
+				Context("when status synchronizedGeneration is not matching the old authoritativeAPI generation (MAPI)", func() {
+					BeforeEach(func() {
+						By("Setting the MAPI machine spec AuthoritativeAPI to ClusterAPI")
+						mapiMachine = mapiMachineBuilder.
+							// Set desired authoritative API in spec to ClusterAPI.
+							// To check for requesting pausing on the the MAPI resource it is sufficient
+							// see that the spec.AuthoritativeAPI field is set to ClusterAPI.
+							WithAuthoritativeAPI(machinev1beta1.MachineAuthorityClusterAPI).
+							Build()
+						Eventually(k8sClient.Create(ctx, mapiMachine)).Should(Succeed())
+
+						By("Setting the MAPI machine status AuthoritativeAPI to 'Migrating'")
+						Eventually(k.UpdateStatus(mapiMachine, func() {
+							updatedMAPIMachine := mapiMachineBuilder.
+								WithAuthoritativeAPIStatus(machinev1beta1.MachineAuthorityMigrating).
+								WithConditions([]machinev1beta1.Condition{{
+									Type:               consts.SynchronizedCondition,
+									LastTransitionTime: metav1.Now(),
+									Status:             corev1.ConditionTrue}}).
+								Build()
+							mapiMachine.Status.AuthoritativeAPI = updatedMAPIMachine.Status.AuthoritativeAPI
+							mapiMachine.Status.SynchronizedGeneration = 9999 // Do not match .metadata.generation field.
+							mapiMachine.Status.Conditions = updatedMAPIMachine.Status.Conditions
+						})).Should(Succeed())
+
+						req = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(mapiMachine)}
+					})
+
+					It("should do nothing", func() {
+						initialMAPIMachineRV := mapiMachine.ResourceVersion
+						_, err := reconciler.Reconcile(ctx, req)
+						Expect(err).NotTo(HaveOccurred(), "reconciler should not have errored")
+						Eventually(k.Object(mapiMachine)).Should(HaveField("ObjectMeta.ResourceVersion", Equal(initialMAPIMachineRV)), "should not have modified the machine")
+					})
+				})
+			})
+			Context("when migrating from ClusterAPI to MachineAPI", func() {
+				Context("when status synchronizedGeneration is not matching the old authoritativeAPI generation (CAPI)", func() {
+					BeforeEach(func() {
+						By("Setting the MAPI machine spec AuthoritativeAPI to MachineAPI")
+						mapiMachine = mapiMachineBuilder.
+							WithAuthoritativeAPI(machinev1beta1.MachineAuthorityMachineAPI).
+							Build()
+						Eventually(k8sClient.Create(ctx, mapiMachine)).Should(Succeed())
+
+						By("Creating a mirror CAPI machine")
+						capiMachine = capiMachineBuilder.Build()
+						Eventually(k8sClient.Create(ctx, capiMachine)).Should(Succeed())
+						capaMachine = capaMachineBuilder.Build()
+						Eventually(k8sClient.Create(ctx, capaMachine)).Should(Succeed())
+
+						By("Setting the MAPI machine status AuthoritativeAPI to 'Migrating'")
+						Eventually(k.UpdateStatus(mapiMachine, func() {
+							updatedMAPIMachine := mapiMachineBuilder.
+								WithAuthoritativeAPIStatus(machinev1beta1.MachineAuthorityMigrating).
+								WithConditions([]machinev1beta1.Condition{{
+									Type:               consts.SynchronizedCondition,
+									LastTransitionTime: metav1.Now(),
+									Status:             corev1.ConditionTrue}}).
+								Build()
+							mapiMachine.Status.AuthoritativeAPI = updatedMAPIMachine.Status.AuthoritativeAPI
+							mapiMachine.Status.SynchronizedGeneration = 9999 // Do not match .metadata.generation field.
+							mapiMachine.Status.Conditions = updatedMAPIMachine.Status.Conditions
+						})).Should(Succeed())
+
+						req = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(mapiMachine)}
+					})
+
+					It("should do nothing", func() {
+						initialMAPIMachineRV := mapiMachine.ResourceVersion
+						_, err := reconciler.Reconcile(ctx, req)
+						Expect(err).NotTo(HaveOccurred(), "reconciler should not have errored")
+						Eventually(k.Object(mapiMachine)).Should(HaveField("ObjectMeta.ResourceVersion", Equal(initialMAPIMachineRV)), "should not have modified the machine")
+					})
+				})
+			})
+		})
+
+		Context("when all the prerequisites for switching the authoritative API are satisfied", func() {
+			Context("when migrating from MachineAPI to ClusterAPI", func() {
+				BeforeEach(func() {
+					By("Setting the MAPI machine spec AuthoritativeAPI to ClusterAPI")
+					mapiMachine = mapiMachineBuilder.
+						// Set desired authoritative API in spec to ClusterAPI.
+						// To check for requesting pausing on the the MAPI resource it is sufficient
+						// see that the spec.AuthoritativeAPI field is set to ClusterAPI.
+						WithAuthoritativeAPI(machinev1beta1.MachineAuthorityClusterAPI).
+						Build()
+					Eventually(k8sClient.Create(ctx, mapiMachine)).Should(Succeed())
+
+					By("Setting the MAPI machine status AuthoritativeAPI to 'Migrating'")
+					Eventually(k.UpdateStatus(mapiMachine, func() {
+						updatedMAPIMachine := mapiMachineBuilder.
+							WithAuthoritativeAPIStatus(machinev1beta1.MachineAuthorityMigrating).
+							WithConditions([]machinev1beta1.Condition{
+								{
+									Type:               consts.SynchronizedCondition,
+									LastTransitionTime: metav1.Now(),
+									Status:             corev1.ConditionTrue,
+								},
+								{
+									Type:               "Paused",
+									LastTransitionTime: metav1.Now(),
+									Status:             corev1.ConditionTrue,
+								},
+							}).
+							Build()
+						mapiMachine.Status.AuthoritativeAPI = updatedMAPIMachine.Status.AuthoritativeAPI
+						mapiMachine.Status.SynchronizedGeneration = mapiMachine.Generation // Match the MAPI .metadata.generation field.
+						mapiMachine.Status.Conditions = updatedMAPIMachine.Status.Conditions
+					})).Should(Succeed())
+
+					By("Creating a mirror CAPI machine")
+					capiMachine = capiMachineBuilder.
+						WithAnnotations(map[string]string{
+							capiv1beta1.PausedAnnotation: "",
+						}).
+						Build()
+					capiMachine.Finalizers = append(capiMachine.Finalizers, capiv1beta1.MachineFinalizer)
+					Eventually(k8sClient.Create(ctx, capiMachine)).Should(Succeed())
+
+					capaMachine = capaMachineBuilder.
+						WithAnnotations(map[string]string{
+							capiv1beta1.PausedAnnotation: "",
+						}).
+						Build()
+					Eventually(k8sClient.Create(ctx, capaMachine)).Should(Succeed())
+
+					By("Setting the CAPI machine status condition to 'Paused'")
+					Eventually(k.UpdateStatus(capiMachine, func() {
+						updatedCAPIMachine := capiMachineBuilder.Build()
+						updatedCAPIMachine.Status.V1Beta2 = &capiv1beta1.MachineV1Beta2Status{
+							Conditions: []metav1.Condition{{
+								Type:               capiv1beta1.PausedV1Beta2Condition,
+								Status:             metav1.ConditionTrue,
+								LastTransitionTime: metav1.Now(),
+							}},
+						}
+						capiMachine.Status = updatedCAPIMachine.Status
+					})).Should(Succeed())
+
+					req = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(mapiMachine)}
+				})
+
+				It("should set the new to-be authoritative resource (CAPI) to actually be authoritative and unpause it", func() {
+					result, err := reconciler.Reconcile(ctx, req)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result.Requeue).To(BeFalse())
+
+					Eventually(komega.Object(mapiMachine)).Should(SatisfyAll(
+						HaveField("Status.AuthoritativeAPI", Equal(machinev1beta1.MachineAuthorityClusterAPI)),
+						HaveField("Status.SynchronizedGeneration", BeZero()),
+					))
+
+					Eventually(komega.Object(capiMachine)).ShouldNot(
+						HaveField("ObjectMeta.Annotations", ContainElement(HaveKeyWithValue(capiv1beta1.PausedAnnotation, ""))))
+				})
+			})
+			Context("when migrating from ClusterAPI to MachineAPI", func() {
+				BeforeEach(func() {
+					By("Setting the MAPI machine spec AuthoritativeAPI to MachineAPI")
+					mapiMachine = mapiMachineBuilder.
+						WithAuthoritativeAPI(machinev1beta1.MachineAuthorityMachineAPI).
+						Build()
+					Eventually(k8sClient.Create(ctx, mapiMachine)).Should(Succeed())
+
+					By("Creating a mirror CAPI machine")
+					capiMachine = capiMachineBuilder.
+						WithAnnotations(map[string]string{
+							capiv1beta1.PausedAnnotation: "",
+						}).
+						Build()
+					Eventually(k8sClient.Create(ctx, capiMachine)).Should(Succeed())
+					capaMachine = capaMachineBuilder.
+						WithAnnotations(map[string]string{
+							capiv1beta1.PausedAnnotation: "",
+						}).
+						Build()
+					Eventually(k8sClient.Create(ctx, capaMachine)).Should(Succeed())
+
+					By("Setting the MAPI machine status AuthoritativeAPI to 'Migrating'")
+					Eventually(k.UpdateStatus(mapiMachine, func() {
+						updatedMAPIMachine := mapiMachineBuilder.
+							WithAuthoritativeAPIStatus(machinev1beta1.MachineAuthorityMigrating).
+							WithConditions([]machinev1beta1.Condition{
+								{
+									Type:               consts.SynchronizedCondition,
+									LastTransitionTime: metav1.Now(),
+									Status:             corev1.ConditionTrue,
+								},
+								{
+									Type:               "Paused",
+									LastTransitionTime: metav1.Now(),
+									Status:             corev1.ConditionTrue,
+								},
+							}).
+							Build()
+						mapiMachine.Status.AuthoritativeAPI = updatedMAPIMachine.Status.AuthoritativeAPI
+						mapiMachine.Status.SynchronizedGeneration = capiMachine.Generation // Match the CAPI .metadata.generation field.
+						mapiMachine.Status.Conditions = updatedMAPIMachine.Status.Conditions
+					})).Should(Succeed())
+
+					By("Setting the CAPI machine status condition to 'Paused'")
+					Eventually(k.UpdateStatus(capiMachine, func() {
+						updatedCAPIMachine := capiMachineBuilder.Build()
+						updatedCAPIMachine.Status.V1Beta2 = &capiv1beta1.MachineV1Beta2Status{
+							Conditions: []metav1.Condition{{
+								Type:               capiv1beta1.PausedV1Beta2Condition,
+								Status:             metav1.ConditionTrue,
+								LastTransitionTime: metav1.Now(),
+							}},
+						}
+						capiMachine.Status = updatedCAPIMachine.Status
+					})).Should(Succeed())
+
+					By("Setting the CAPI infra machine status condition to 'Paused'")
+					Eventually(k.UpdateStatus(capaMachine, func() {
+						updatedCAPIInfraMachine := capaMachineBuilder.WithAnnotations(map[string]string{capiv1beta1.PausedAnnotation: ""}).Build()
+						updatedCAPIInfraMachine.Status.Conditions = capiv1beta1.Conditions{
+							{
+								Type:               capiv1beta1.PausedV1Beta2Condition,
+								Status:             corev1.ConditionTrue,
+								LastTransitionTime: metav1.Now(),
+							},
+						}
+						capaMachine.Status = updatedCAPIInfraMachine.Status
+					})).Should(Succeed())
+					req = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(mapiMachine)}
+				})
+
+				It("should set the new to-be authoritative resource (MAPI) to actually be authoritative and requeue to unpause it", func() {
+					result, err := reconciler.Reconcile(ctx, req)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result.Requeue).To(BeFalse())
+
+					Eventually(komega.Object(mapiMachine)).Should(SatisfyAll(
+						HaveField("Status.AuthoritativeAPI", Equal(machinev1beta1.MachineAuthorityMachineAPI)),
+						HaveField("Status.SynchronizedGeneration", BeZero()),
+					))
+				})
+			})
+		})
+	})
+})

--- a/pkg/controllers/machinemigration/suite_test.go
+++ b/pkg/controllers/machinemigration/suite_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machinemigration
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	configv1builder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/config/v1"
+	"github.com/openshift/cluster-capi-operator/pkg/test"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/textlogger"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	//+kubebuilder:scaffold:imports
+)
+
+var cfg *rest.Config
+var k8sClient client.Client
+var testEnv *envtest.Environment
+var testRESTMapper meta.RESTMapper
+var ctx = context.Background()
+
+func TestMachineMigration(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Controller Suite")
+}
+
+var _ = BeforeSuite(func() {
+	klog.SetOutput(GinkgoWriter)
+
+	logf.SetLogger(textlogger.NewLogger(textlogger.NewConfig()))
+
+	By("bootstrapping test environment")
+	var err error
+	testEnv = &envtest.Environment{}
+	cfg, k8sClient, err = test.StartEnvTest(testEnv)
+
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+	Expect(k8sClient).NotTo(BeNil())
+
+	infrastructure := configv1builder.Infrastructure().AsAWS("test", "eu-west-2").WithName("cluster").Build()
+	Expect(k8sClient.Create(ctx, infrastructure)).To(Succeed())
+
+	httpClient, err := rest.HTTPClientFor(cfg)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(httpClient).NotTo(BeNil())
+
+	testRESTMapper, err = apiutil.NewDynamicRESTMapper(cfg, httpClient)
+	Expect(err).NotTo(HaveOccurred())
+
+	komega.SetClient(k8sClient)
+	komega.SetContext(ctx)
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/pkg/controllers/machinesetmigration/machineset_migration_controller.go
+++ b/pkg/controllers/machinesetmigration/machineset_migration_controller.go
@@ -1,0 +1,356 @@
+/*
+Copyright 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machinesetmigration
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	capiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/annotations"
+	conditionsv1beta2 "sigs.k8s.io/cluster-api/util/conditions/v1beta2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	machinev1applyconfigs "github.com/openshift/client-go/machine/applyconfigurations/machine/v1beta1"
+	consts "github.com/openshift/cluster-capi-operator/pkg/controllers"
+	"github.com/openshift/cluster-capi-operator/pkg/util"
+)
+
+const controllerName = "MachineSetMigrationController"
+
+// MachineSetMigrationReconciler reconciles MachineSet resources for migration.
+type MachineSetMigrationReconciler struct {
+	client.Client
+	Scheme        *runtime.Scheme
+	Recorder      record.EventRecorder
+	CAPINamespace string
+	MAPINamespace string
+}
+
+// SetupWithManager sets up the MachineSetMigration controller.
+func (r *MachineSetMigrationReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// Allow the namespaces to be set externally for test purposes, when not set,
+	// default to the production namespaces.
+	if r.CAPINamespace == "" {
+		r.CAPINamespace = consts.DefaultManagedNamespace
+	}
+
+	if r.MAPINamespace == "" {
+		r.MAPINamespace = consts.DefaultMAPIManagedNamespace
+	}
+
+	if err := ctrl.NewControllerManagedBy(mgr).
+		Named(controllerName).
+		For(&machinev1beta1.MachineSet{}, builder.WithPredicates(util.FilterNamespace(r.MAPINamespace))).
+		Complete(r); err != nil {
+		return fmt.Errorf("failed to create controller: %w", err)
+	}
+
+	r.Client = mgr.GetClient()
+	r.Scheme = mgr.GetScheme()
+	r.Recorder = mgr.GetEventRecorderFor(controllerName)
+
+	return nil
+}
+
+// Reconcile performs the reconciliation for a MachineSet.
+//
+//nolint:funlen
+func (r *MachineSetMigrationReconciler) Reconcile(ctx context.Context, req reconcile.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues("namespace", req.Namespace, "name", req.Name)
+	ctx = logr.NewContext(ctx, logger)
+
+	logger.V(1).Info("Reconciling machine set")
+	defer logger.V(1).Info("Finished reconciling machine set")
+
+	mapiMachineSet := &machinev1beta1.MachineSet{}
+	if err := r.Get(ctx, client.ObjectKey{Namespace: req.Namespace, Name: req.Name}, mapiMachineSet); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get MAPI machine set: %w", err)
+	}
+
+	if mapiMachineSet.Spec.AuthoritativeAPI == mapiMachineSet.Status.AuthoritativeAPI {
+		// No migration is being requested for this resource, nothing to do.
+		return ctrl.Result{}, nil
+	}
+
+	// If authoritativeAPI status is empty, it means it is the first time we see this resource.
+	// Set the status.authoritativeAPI to match the spec.authoritativeAPI.
+	if mapiMachineSet.Status.AuthoritativeAPI == "" {
+		if err := r.applyStatusAuthoritativeAPIWithPatch(ctx, mapiMachineSet, mapiMachineSet.Spec.AuthoritativeAPI); err != nil {
+			return ctrl.Result{}, fmt.Errorf("unable to apply authoritativeAPI to status with patch: %w", err)
+		}
+
+		// Wait for the patching to take effect.
+		return ctrl.Result{}, nil
+	}
+
+	// Check if the Synchronized condition is set to True.
+	// If it is not, this indicates an unmigratable resource and therefore should take no action.
+	if cond, err := util.GetConditionStatus(mapiMachineSet, string(consts.SynchronizedCondition)); err != nil {
+		return ctrl.Result{}, fmt.Errorf("unable to get synchronizedCondition for %s/%s: %w", mapiMachineSet.Namespace, mapiMachineSet.Name, err)
+	} else if cond != corev1.ConditionTrue {
+		logger.Info("Machine set not synchronized with latest authoritative generation, will retry later")
+
+		return ctrl.Result{}, nil
+	}
+
+	// Make sure the authoritativeAPI resource status is set to migrating.
+	if mapiMachineSet.Status.AuthoritativeAPI != machinev1beta1.MachineAuthorityMigrating {
+		logger.Info("Detected migration request for machine set")
+
+		if err := r.applyStatusAuthoritativeAPIWithPatch(ctx, mapiMachineSet, machinev1beta1.MachineAuthorityMigrating); err != nil {
+			return ctrl.Result{}, fmt.Errorf("unable to set authoritativeAPI %q to status: %w", machinev1beta1.MachineAuthorityMigrating, err)
+		}
+
+		logger.Info("Acknowledged migration request for machine set")
+
+		// Wait for the change to propagate.
+		return ctrl.Result{}, nil
+	}
+
+	// Request pausing on the authoritative resource.
+	if updated, err := r.requestOldAuthoritativeResourcePaused(ctx, mapiMachineSet); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to request pause on authoritative machine set: %w", err)
+	} else if updated {
+		logger.Info("Requested pausing for authoritative machine set")
+
+		// Wait for the change to propagate.
+		return ctrl.Result{}, nil
+	}
+
+	// Check that the old authoritative resource is paused.
+	if paused, err := r.isOldAuthoritativeResourcePaused(ctx, mapiMachineSet); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to check paused on old authoritative machine set: %w", err)
+	} else if !paused {
+		// The Authoritative API resource is not paused yet, requeue to check later.
+		logger.Info("Authoritative machine set is not paused yet, will retry later")
+
+		return ctrl.Result{}, nil
+	}
+
+	// Check if the synchronizedGeneration matches the old authoritativeAPI's resource current generation.
+	if isSynchronizedGenMatchingOldAuthority, err := r.isSynchronizedGenerationMatchingOldAuthoritativeAPIGeneration(ctx, mapiMachineSet); err != nil {
+		return ctrl.Result{}, fmt.Errorf("unable to check synchronizedGeneration matches old authority: %w", err)
+	} else if !isSynchronizedGenMatchingOldAuthority {
+		// The Authoritative API resource is not fully synced up yet, requeue to check later.
+		logger.Info("Authoritative machine set and its copy are not synchronized yet, will retry later")
+
+		return ctrl.Result{}, nil
+	}
+
+	// Set the actual AuthoritativeAPI to the desired one, reset the synchronized generation and condition.
+	if err := r.setNewAuthoritativeAPIAndResetSynchronized(ctx, mapiMachineSet, mapiMachineSet.Spec.AuthoritativeAPI); err != nil {
+		return ctrl.Result{}, fmt.Errorf("unable to apply authoritativeAPI to status with patch: %w", err)
+	}
+
+	// Make sure the new authoritative resource has been requested to unpause.
+	if err := r.ensureUnpauseRequestedOnNewAuthoritativeResource(ctx, mapiMachineSet); err != nil {
+		return ctrl.Result{}, fmt.Errorf("unable to ensure the new AuthoritativeAPI has been un-paused: %w", err)
+	}
+
+	logger.Info("Machine set authority switch has now been completed and the resource unpaused")
+	logger.Info("Machine set migrated successfully")
+
+	return ctrl.Result{}, nil
+}
+
+// isOldAuthoritativeResourcePaused checks whether the old authoritative resource is paused.
+func (r *MachineSetMigrationReconciler) isOldAuthoritativeResourcePaused(ctx context.Context, ms *machinev1beta1.MachineSet) (bool, error) {
+	if ms.Spec.AuthoritativeAPI == machinev1beta1.MachineAuthorityClusterAPI {
+		cond, err := util.GetConditionStatus(ms, "Paused")
+		if err != nil {
+			return false, fmt.Errorf("unable to get paused condition for %s/%s: %w", ms.Namespace, ms.Name, err)
+		}
+
+		return cond == corev1.ConditionTrue, nil
+	}
+
+	// For MachineAuthorityMachineAPI, check the corresponding CAPI resource.
+	capiMachineSet := &capiv1beta1.MachineSet{}
+	if err := r.Get(ctx, client.ObjectKey{Namespace: r.CAPINamespace, Name: ms.Name}, capiMachineSet); err != nil {
+		return false, fmt.Errorf("failed to get Cluster API machine set: %w", err)
+	}
+
+	machinePausedCondition := conditionsv1beta2.Get(capiMachineSet, capiv1beta1.PausedV1Beta2Condition)
+	if machinePausedCondition == nil {
+		return false, nil
+	}
+
+	// InfraMachineTemplate doesn't have a reconciler and thus it doesn't need pausing.
+	// The only provider we are interested in, that reconciles the inframachinetemplate, is ibmcloud/powervs
+	// which only updates its status
+	// see: https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/controllers/ibmpowervsmachinetemplate_controller.go
+	return (machinePausedCondition.Status == metav1.ConditionTrue), nil
+}
+
+func (r *MachineSetMigrationReconciler) ensureUnpauseRequestedOnNewAuthoritativeResource(ctx context.Context, mapiMachineSet *machinev1beta1.MachineSet) error {
+	// Request that the new authoritative resource reconciliation is un-paused.
+	//nolint:wsl
+	switch mapiMachineSet.Spec.AuthoritativeAPI {
+	case machinev1beta1.MachineAuthorityClusterAPI:
+		// For requesting unpausing of a CAPI resource, remove the paused annotation on it.
+		// So check if the ClusterAPI resource has the paused annotation and if so remove it.
+		capiMachineSet := &capiv1beta1.MachineSet{}
+		if err := r.Get(ctx, client.ObjectKey{Namespace: r.CAPINamespace, Name: mapiMachineSet.Name}, capiMachineSet); err != nil {
+			return fmt.Errorf("failed to get Cluster API machine set: %w", err)
+		}
+
+		if annotations.HasPaused(capiMachineSet) {
+			capiMachineSetCopy := capiMachineSet.DeepCopy()
+			delete(capiMachineSet.Annotations, capiv1beta1.PausedAnnotation)
+
+			if err := r.Patch(ctx, capiMachineSet, client.MergeFrom(capiMachineSetCopy)); err != nil {
+				return fmt.Errorf("failed to patch Cluster API machine set: %w", err)
+			}
+		}
+
+		// InfraMachineTemplate doesn't have a reconciler and thus it doesn't need pausing.
+		// The only provider we are interested in, that reconciles the inframachinetemplate, is ibmcloud/powervs
+		// which only updates its status
+		// see: https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/controllers/ibmpowervsmachinetemplate_controller.go
+	case machinev1beta1.MachineAuthorityMachineAPI:
+		// For requesting unpausing of a MAPI resource, it is sufficient to switch the spec.AuthoritativeAPI field on the MAPI resource.
+		// which is already done before this code runs in this controller. Nothing to do here.
+	case machinev1beta1.MachineAuthorityMigrating:
+		// Value is disallowed by the openAPI schema validation.
+	}
+
+	return nil
+}
+
+// requestOldAuthoritativeResourcePaused requests the old authoritative resource is paused.
+func (r *MachineSetMigrationReconciler) requestOldAuthoritativeResourcePaused(ctx context.Context, ms *machinev1beta1.MachineSet) (bool, error) {
+	// Request that the old authoritative resource reconciliation is paused.
+	updated := false
+	//nolint:wsl
+	switch ms.Spec.AuthoritativeAPI {
+	case machinev1beta1.MachineAuthorityClusterAPI:
+		// For requesting pausing of a MAPI resource, it is sufficient to switch the spec.AuthoritativeAPI field on the MAPI resource.
+		// which is already done before this code runs in this controller.
+	case machinev1beta1.MachineAuthorityMachineAPI:
+		// For requesting pausing of a CAPI resource, set the paused annotation on it.
+		// The spec.AuthoritativeAPI is set to MachineAPI, meaning that the old authoritativeAPI was ClusterAPI.
+		// So Check if the ClusterAPI resource has the paused annotation, otherwise set it.
+		capiMachineSet := &capiv1beta1.MachineSet{}
+		if err := r.Get(ctx, client.ObjectKey{Namespace: r.CAPINamespace, Name: ms.Name}, capiMachineSet); err != nil {
+			return false, fmt.Errorf("failed to get Cluster API machine set: %w", err)
+		}
+
+		if !annotations.HasPaused(capiMachineSet) {
+			capiMachineSetCopy := capiMachineSet.DeepCopy()
+			annotations.AddAnnotations(capiMachineSet, map[string]string{capiv1beta1.PausedAnnotation: ""})
+			if err := r.Patch(ctx, capiMachineSet, client.MergeFrom(capiMachineSetCopy)); err != nil {
+				return false, fmt.Errorf("failed to patch Cluster API machine set: %w", err)
+			}
+
+			updated = true
+		}
+
+		// InfraMachineTemplate doesn't have a reconciler and thus it doesn't need pausing.
+		// The only provider we are interested in, that reconciles the inframachinetemplate, is ibmcloud/powervs
+		// which only updates its status
+		// see: https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/controllers/ibmpowervsmachinetemplate_controller.go
+	case machinev1beta1.MachineAuthorityMigrating:
+		// Value is disallowed by the openAPI schema validation.
+	}
+
+	return updated, nil
+}
+
+func (r *MachineSetMigrationReconciler) isSynchronizedGenerationMatchingOldAuthoritativeAPIGeneration(ctx context.Context, mapiMachineSet *machinev1beta1.MachineSet) (bool, error) {
+	//nolint:wsl
+	switch mapiMachineSet.Spec.AuthoritativeAPI {
+	case machinev1beta1.MachineAuthorityClusterAPI:
+		// ClusterAPI is the desired authoritative API but
+		// MachineAPI is currently still the authoritative one.
+		// Check MachineAPI generation against the synchronized one.
+		return mapiMachineSet.Status.SynchronizedGeneration == mapiMachineSet.Generation, nil
+	case machinev1beta1.MachineAuthorityMachineAPI:
+		// MachineAPI is the desired authoritative API but
+		// ClusterAPI is currently still the authoritative one.
+		// Check ClusterAPI generation against the synchronized one.
+		capiMachineSet := &capiv1beta1.MachineSet{}
+		if err := r.Get(ctx, client.ObjectKey{Namespace: r.CAPINamespace, Name: mapiMachineSet.Name}, capiMachineSet); err != nil {
+			return false, fmt.Errorf("failed to get Cluster API machine set: %w", err)
+		}
+
+		// Given the CAPI infra machine template is immutable
+		// we do not check for its generation to be synced up with the generation of the MAPI machine set.
+		return (mapiMachineSet.Status.SynchronizedGeneration == capiMachineSet.Generation), nil
+	case machinev1beta1.MachineAuthorityMigrating:
+		// Value is disallowed by the openAPI schema validation.
+	}
+
+	return false, nil
+}
+
+// applyStatusAuthoritativeAPIWithPatch updates the resource status.authoritativeAPI using a server-side apply patch.
+func (r *MachineSetMigrationReconciler) applyStatusAuthoritativeAPIWithPatch(ctx context.Context, ms *machinev1beta1.MachineSet, authority machinev1beta1.MachineAuthority) error {
+	logger := log.FromContext(ctx)
+	logger.Info(fmt.Sprintf("Setting AuthoritativeAPI status to %q for resource", authority))
+
+	ac := machinev1applyconfigs.MachineSet(ms.Name, ms.Namespace).
+		WithStatus(machinev1applyconfigs.MachineSetStatus().WithAuthoritativeAPI(authority))
+
+	if err := r.Status().Patch(ctx, ms, util.ApplyConfigPatch(ac), client.ForceOwnership, client.FieldOwner(controllerName+"-AuthoritativeAPI")); err != nil {
+		return fmt.Errorf("failed to patch Machine API machine set status with authoritativeAPI %q: %w", authority, err)
+	}
+
+	return nil
+}
+
+// setNewAuthoritativeAPIAndResetSynchronized updates the MachineSet status to the new authoritativeAPI,
+// resets the synchronized generation, and removes the Synchronized condition.
+func (r *MachineSetMigrationReconciler) setNewAuthoritativeAPIAndResetSynchronized(ctx context.Context, ms *machinev1beta1.MachineSet, authority machinev1beta1.MachineAuthority) error {
+	var newConditions []*machinev1applyconfigs.ConditionApplyConfiguration
+
+	for _, cond := range ms.Status.Conditions {
+		if cond.Type != consts.SynchronizedCondition {
+			newConditions = append(newConditions, &machinev1applyconfigs.ConditionApplyConfiguration{
+				LastTransitionTime: &cond.LastTransitionTime,
+				Message:            &cond.Message,
+				Reason:             &cond.Reason,
+				Status:             &cond.Status,
+				Severity:           &cond.Severity,
+				Type:               &cond.Type,
+			})
+		}
+	}
+
+	statusAc := machinev1applyconfigs.MachineSetStatus().
+		WithAuthoritativeAPI(authority).
+		WithConditions(newConditions...).
+		WithSynchronizedGeneration(0)
+
+	ac := machinev1applyconfigs.MachineSet(ms.Name, ms.Namespace).WithStatus(statusAc)
+
+	if err := r.Status().Patch(ctx, ms, util.ApplyConfigPatch(ac), client.ForceOwnership, client.FieldOwner(controllerName+"-AuthoritativeAPI")); err != nil {
+		return fmt.Errorf("failed to patch Machine API machine set status with authoritativeAPI %q: %w", authority, err)
+	}
+
+	return nil
+}

--- a/pkg/controllers/machinesetmigration/machineset_migration_controller_test.go
+++ b/pkg/controllers/machinesetmigration/machineset_migration_controller_test.go
@@ -1,0 +1,672 @@
+/*
+Copyright 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machinesetmigration
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	capiv1resourcebuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/cluster-api/core/v1beta1"
+	capav1builder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2"
+	corev1resourcebuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/core/v1"
+	machinev1resourcebuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	capav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+
+	capiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-api-actuator-pkg/testutils"
+	consts "github.com/openshift/cluster-capi-operator/pkg/controllers"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ = Describe("With a running MachineSetMigration controller", func() {
+	var (
+		k          komega.Komega
+		reconciler *MachineSetMigrationReconciler
+
+		migrationControllerNamespace *corev1.Namespace
+		capiNamespace                *corev1.Namespace
+		mapiNamespace                *corev1.Namespace
+
+		mapiMachineSetBuilder      machinev1resourcebuilder.MachineSetBuilder
+		mapiMachineSet             *machinev1beta1.MachineSet
+		capiMachineSetBuilder      capiv1resourcebuilder.MachineSetBuilder
+		capiMachineSet             *capiv1beta1.MachineSet
+		capaMachineTemplateBuilder capav1builder.AWSMachineTemplateBuilder
+		capaMachineTemplate        *capav1.AWSMachineTemplate
+		capaClusterBuilder         capav1builder.AWSClusterBuilder
+		capiClusterBuilder         capiv1resourcebuilder.ClusterBuilder
+		capiCluster                *capiv1beta1.Cluster
+	)
+
+	BeforeEach(func() {
+		By("Setting up namespaces for the test")
+		migrationControllerNamespace = corev1resourcebuilder.Namespace().
+			WithGenerateName("machineset-migration-controller-").Build()
+		Expect(k8sClient.Create(ctx, migrationControllerNamespace)).To(Succeed(), "migration controller namespace should be able to be created")
+
+		mapiNamespace = corev1resourcebuilder.Namespace().
+			WithGenerateName("openshift-machine-api-").Build()
+		Expect(k8sClient.Create(ctx, mapiNamespace)).To(Succeed(), "MAPI namespace should be able to be created")
+
+		capiNamespace = corev1resourcebuilder.Namespace().
+			WithGenerateName("openshift-cluster-api-").Build()
+		Expect(k8sClient.Create(ctx, capiNamespace)).To(Succeed(), "CAPI namespace should be able to be created")
+
+		mapiMachineSetBuilder = machinev1resourcebuilder.MachineSet().
+			WithNamespace(mapiNamespace.GetName()).
+			WithName("foo").
+			WithProviderSpecBuilder(machinev1resourcebuilder.AWSProviderSpec().WithLoadBalancers(nil))
+
+		infrastructureName := "cluster-foo"
+		capaClusterBuilder = capav1builder.AWSCluster().
+			WithNamespace(capiNamespace.GetName()).
+			WithName(infrastructureName)
+		Expect(k8sClient.Create(ctx, capaClusterBuilder.Build())).To(Succeed(), "CAPA cluster should be able to be created")
+
+		capiClusterBuilder = capiv1resourcebuilder.Cluster().
+			WithNamespace(capiNamespace.GetName()).
+			WithName(infrastructureName)
+		Expect(k8sClient.Create(ctx, capiClusterBuilder.Build())).To(Succeed(), "CAPI cluster should be able to be created")
+
+		capiCluster = &capiv1beta1.Cluster{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{Name: infrastructureName, Namespace: capiNamespace.GetName()}, capiCluster)).To(Succeed())
+
+		capaMachineTemplateBuilder = capav1builder.AWSMachineTemplate().
+			WithNamespace(capiNamespace.GetName()).
+			WithName("machine-template")
+		capaMachineTemplate = capaMachineTemplateBuilder.Build()
+
+		capiMachineTemplate := capiv1beta1.MachineTemplateSpec{
+			Spec: capiv1beta1.MachineSpec{
+				InfrastructureRef: corev1.ObjectReference{
+					APIVersion: capaMachineTemplate.APIVersion,
+					Kind:       capaMachineTemplate.Kind,
+					Name:       capaMachineTemplate.GetName(),
+					Namespace:  capaMachineTemplate.GetNamespace(),
+				},
+			},
+		}
+		capiMachineSetBuilder = capiv1resourcebuilder.MachineSet().
+			WithNamespace(capiNamespace.GetName()).
+			WithName("foo").
+			WithTemplate(capiMachineTemplate).
+			WithClusterName(infrastructureName)
+
+		reconciler = &MachineSetMigrationReconciler{
+			Client:        k8sClient,
+			CAPINamespace: capiNamespace.GetName(),
+			MAPINamespace: mapiNamespace.GetName(),
+		}
+
+		k = komega.New(k8sClient)
+	})
+
+	AfterEach(func() {
+		By("Cleaning up MAPI test resources")
+		testutils.CleanupResources(Default, ctx, cfg, k8sClient, mapiNamespace.GetName(),
+			&machinev1beta1.Machine{},
+			&machinev1beta1.MachineSet{},
+			&configv1.Infrastructure{},
+		)
+		testutils.CleanupResources(Default, ctx, cfg, k8sClient, capiNamespace.GetName(),
+			&capiv1beta1.Machine{},
+			&capiv1beta1.MachineSet{},
+			&capav1.AWSCluster{},
+			&capav1.AWSMachineTemplate{},
+		)
+	})
+
+	Describe("Reconcile", func() {
+		var req reconcile.Request
+
+		Context("when no migration is requested (status equals spec)", func() {
+			BeforeEach(func() {
+				By("Setting the MAPI machine set spec AuthoritativeAPI to MachineAPI")
+				mapiMachineSet = mapiMachineSetBuilder.
+					WithAuthoritativeAPI(machinev1beta1.MachineAuthorityMachineAPI).
+					Build()
+				Eventually(k8sClient.Create(ctx, mapiMachineSet)).Should(Succeed())
+
+				By("Setting the MAPI machine set status AuthoritativeAPI to MachineAPI")
+				Eventually(k.UpdateStatus(mapiMachineSet, func() {
+					mapiMachineSet.Status.AuthoritativeAPI = machinev1beta1.MachineAuthorityMachineAPI
+				})).Should(Succeed())
+
+				req = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(mapiMachineSet)}
+			})
+
+			It("should do nothing", func() {
+				initialMAPIMachineSetRV := mapiMachineSet.ResourceVersion
+				_, err := reconciler.Reconcile(ctx, req)
+				Expect(err).NotTo(HaveOccurred(), "reconciler should not have errored")
+				Eventually(k.Object(mapiMachineSet)).Should(HaveField("ObjectMeta.ResourceVersion", Equal(initialMAPIMachineSetRV)), "should not have modified the machine set")
+			})
+		})
+
+		Context("when status.AuthoritativeAPI is empty (first observation)", func() {
+			BeforeEach(func() {
+				By("Setting the MAPI machine set spec AuthoritativeAPI to MachineAPI")
+				mapiMachineSet = mapiMachineSetBuilder.
+					WithAuthoritativeAPI(machinev1beta1.MachineAuthorityMachineAPI).
+					Build()
+				Eventually(k8sClient.Create(ctx, mapiMachineSet)).Should(Succeed())
+
+				By("Leaving the MAPI machine set status AuthoritativeAPI empty")
+
+				req = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(mapiMachineSet)}
+			})
+
+			It("should patch the status to match spec and requeue", func() {
+				By("Running one reconciliation")
+				_, err := reconciler.Reconcile(ctx, req)
+				Expect(err).NotTo(HaveOccurred(), "reconciler should not have errored")
+				updatedMS := &machinev1beta1.MachineSet{}
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(mapiMachineSet), updatedMS)).To(Succeed())
+				Expect(updatedMS.Status.AuthoritativeAPI).To(Equal(updatedMS.Spec.AuthoritativeAPI))
+			})
+		})
+
+		Context("when the Synchronized condition is not True", func() {
+			BeforeEach(func() {
+				By("Setting the MAPI machine set spec AuthoritativeAPI to ClusterAPI")
+				mapiMachineSet = mapiMachineSetBuilder.
+					WithAuthoritativeAPI(machinev1beta1.MachineAuthorityClusterAPI).
+					Build()
+				Eventually(k8sClient.Create(ctx, mapiMachineSet)).Should(Succeed())
+
+				By("Setting the MAPI machine set status AuthoritativeAPI to MachineAPI")
+				Eventually(k.UpdateStatus(mapiMachineSet, func() {
+					updatedMAPIMachineSet := mapiMachineSetBuilder.
+						WithAuthoritativeAPIStatus(machinev1beta1.MachineAuthorityMachineAPI).
+						WithConditions([]machinev1beta1.Condition{{
+							Type:               consts.SynchronizedCondition,
+							LastTransitionTime: metav1.Now(),
+							Status:             corev1.ConditionFalse}}).
+						Build()
+					mapiMachineSet.Status.AuthoritativeAPI = updatedMAPIMachineSet.Status.AuthoritativeAPI
+					mapiMachineSet.Status.Conditions = updatedMAPIMachineSet.Status.Conditions
+				})).Should(Succeed())
+
+				req = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(mapiMachineSet)}
+			})
+
+			It("should do nothing", func() {
+				initialMAPIMachineSetRV := mapiMachineSet.ResourceVersion
+				_, err := reconciler.Reconcile(ctx, req)
+				Expect(err).NotTo(HaveOccurred(), "reconciler should not have errored")
+				Eventually(k.Object(mapiMachineSet)).Should(HaveField("ObjectMeta.ResourceVersion", Equal(initialMAPIMachineSetRV)), "should not have modified the machine set")
+			})
+		})
+
+		Context("when a migration request is first detected", func() {
+			BeforeEach(func() {
+				By("Setting the MAPI machine set spec AuthoritativeAPI to ClusterAPI")
+				mapiMachineSet = mapiMachineSetBuilder.
+					WithAuthoritativeAPI(machinev1beta1.MachineAuthorityClusterAPI).
+					Build()
+				Eventually(k8sClient.Create(ctx, mapiMachineSet)).Should(Succeed())
+
+				By("Setting the MAPI machine set status AuthoritativeAPI to MachineAPI")
+				Eventually(k.UpdateStatus(mapiMachineSet, func() {
+					updatedMAPIMachineSet := mapiMachineSetBuilder.
+						WithAuthoritativeAPIStatus(machinev1beta1.MachineAuthorityMachineAPI).
+						WithConditions([]machinev1beta1.Condition{{
+							Type:               consts.SynchronizedCondition,
+							LastTransitionTime: metav1.Now(),
+							Status:             corev1.ConditionTrue}}).
+						Build()
+					mapiMachineSet.Status.AuthoritativeAPI = updatedMAPIMachineSet.Status.AuthoritativeAPI
+					mapiMachineSet.Status.Conditions = updatedMAPIMachineSet.Status.Conditions
+				})).Should(Succeed())
+
+				req = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(mapiMachineSet)}
+			})
+
+			It("should acknowledge the migration by updating status to 'Migrating' and requeuing", func() {
+				_, err := reconciler.Reconcile(ctx, req)
+				Expect(err).NotTo(HaveOccurred())
+
+				updatedMS := &machinev1beta1.MachineSet{}
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(mapiMachineSet), updatedMS)).To(Succeed())
+				Expect(updatedMS.Status.AuthoritativeAPI).To(Equal(machinev1beta1.MachineAuthorityMigrating))
+			})
+		})
+
+		Context("when the resource migration has been acknowledged (resource status migrating)", func() {
+			Context("when migrating from MachineAPI to ClusterAPI", func() {
+				BeforeEach(func() {
+					By("Setting the MAPI machine set spec AuthoritativeAPI to ClusterAPI")
+					mapiMachineSet = mapiMachineSetBuilder.
+						WithAuthoritativeAPI(machinev1beta1.MachineAuthorityClusterAPI).
+						Build()
+					Eventually(k8sClient.Create(ctx, mapiMachineSet)).Should(Succeed())
+
+					By("Setting the MAPI machine set status AuthoritativeAPI to 'Migrating'")
+					Eventually(k.UpdateStatus(mapiMachineSet, func() {
+						updatedMAPIMachineSet := mapiMachineSetBuilder.
+							WithAuthoritativeAPIStatus(machinev1beta1.MachineAuthorityMigrating).
+							WithConditions([]machinev1beta1.Condition{{
+								Type:               consts.SynchronizedCondition,
+								LastTransitionTime: metav1.Now(),
+								Status:             corev1.ConditionTrue}}).
+							Build()
+						mapiMachineSet.Status.AuthoritativeAPI = updatedMAPIMachineSet.Status.AuthoritativeAPI
+						mapiMachineSet.Status.Conditions = updatedMAPIMachineSet.Status.Conditions
+					})).Should(Succeed())
+
+					req = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(mapiMachineSet)}
+				})
+
+				It("should request pausing for the old authoritative resource (MAPI) and stay in Migrating status", func() {
+					_, err := reconciler.Reconcile(ctx, req)
+					Expect(err).NotTo(HaveOccurred())
+
+					updatedMS := &machinev1beta1.MachineSet{}
+					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(mapiMachineSet), updatedMS)).To(Succeed())
+					// To check for requesting pausing on the the MAPI resource it is sufficient
+					// see that the spec.AuthoritativeAPI field is set to ClusterAPI,
+					// which is already done anyway on the requester side.
+					Expect(updatedMS.Spec.AuthoritativeAPI).To(Equal(machinev1beta1.MachineAuthorityClusterAPI))
+					Expect(updatedMS.Status.AuthoritativeAPI).To(Equal(machinev1beta1.MachineAuthorityMigrating))
+				})
+			})
+			Context("when migrating from ClusterAPI to MachineAPI", func() {
+				BeforeEach(func() {
+					By("Setting the MAPI machine set spec AuthoritativeAPI to MachineAPI")
+					mapiMachineSet = mapiMachineSetBuilder.WithAuthoritativeAPI(machinev1beta1.MachineAuthorityMachineAPI).Build()
+					Eventually(k8sClient.Create(ctx, mapiMachineSet)).Should(Succeed())
+
+					By("Creating a mirror CAPI machine set")
+					capiMachineSet = capiMachineSetBuilder.Build()
+					Eventually(k8sClient.Create(ctx, capiMachineSet)).Should(Succeed())
+
+					By("Setting the MAPI machine set status AuthoritativeAPI to 'Migrating'")
+					Eventually(k.UpdateStatus(mapiMachineSet, func() {
+						updatedMAPIMachineSet := mapiMachineSetBuilder.
+							WithAuthoritativeAPIStatus(machinev1beta1.MachineAuthorityMigrating).
+							WithConditions([]machinev1beta1.Condition{{
+								Type:               consts.SynchronizedCondition,
+								LastTransitionTime: metav1.Now(),
+								Status:             corev1.ConditionTrue}}).
+							Build()
+						mapiMachineSet.Status.AuthoritativeAPI = updatedMAPIMachineSet.Status.AuthoritativeAPI
+						mapiMachineSet.Status.Conditions = updatedMAPIMachineSet.Status.Conditions
+					})).Should(Succeed())
+
+					req = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(mapiMachineSet)}
+				})
+
+				It("should request pausing for the old authoritative resource (CAPI) and stay in Migrating status", func() {
+					_, err := reconciler.Reconcile(ctx, req)
+					Expect(err).NotTo(HaveOccurred())
+
+					updatedMS := &machinev1beta1.MachineSet{}
+					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(mapiMachineSet), updatedMS)).To(Succeed())
+					Expect(updatedMS.Status.AuthoritativeAPI).To(Equal(machinev1beta1.MachineAuthorityMigrating))
+
+					updatedCAPIMS := &capiv1beta1.MachineSet{}
+					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(capiMachineSet), updatedCAPIMS)).To(Succeed())
+					Expect(updatedCAPIMS.Annotations).To(HaveKeyWithValue(capiv1beta1.PausedAnnotation, ""))
+				})
+			})
+		})
+
+		Context("when the old authoritative resource pausing has been requested", func() {
+			Context("when migrating from MachineAPI to ClusterAPI", func() {
+				Context("when status is not paused for the old authoritative resource (MAPI)", func() {
+					BeforeEach(func() {
+						By("Setting the MAPI machine set spec AuthoritativeAPI to ClusterAPI")
+						mapiMachineSet = mapiMachineSetBuilder.
+							// Set desired authoritative API in spec to ClusterAPI.
+							// To check for requesting pausing on the the MAPI resource it is sufficient
+							// see that the spec.AuthoritativeAPI field is set to ClusterAPI.
+							WithAuthoritativeAPI(machinev1beta1.MachineAuthorityClusterAPI).
+							Build()
+						Eventually(k8sClient.Create(ctx, mapiMachineSet)).Should(Succeed())
+
+						By("Setting the MAPI machine set status AuthoritativeAPI to 'Migrating'")
+						Eventually(k.UpdateStatus(mapiMachineSet, func() {
+							updatedMAPIMachineSet := mapiMachineSetBuilder.
+								WithAuthoritativeAPIStatus(machinev1beta1.MachineAuthorityMigrating).
+								WithConditions([]machinev1beta1.Condition{
+									{
+										Type:               consts.SynchronizedCondition,
+										LastTransitionTime: metav1.Now(),
+										Status:             corev1.ConditionTrue,
+									},
+									{
+										Type:               "Paused",
+										LastTransitionTime: metav1.Now(),
+										Status:             corev1.ConditionTrue,
+									},
+								}).
+								Build()
+							mapiMachineSet.Status.AuthoritativeAPI = updatedMAPIMachineSet.Status.AuthoritativeAPI
+							mapiMachineSet.Status.Conditions = updatedMAPIMachineSet.Status.Conditions
+						})).Should(Succeed())
+
+						req = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(mapiMachineSet)}
+					})
+
+					It("should set old authoritative API (MAPI) status to paused and requeue", func() {
+						_, err := reconciler.Reconcile(ctx, req)
+						Expect(err).NotTo(HaveOccurred())
+
+						Eventually(komega.Object(mapiMachineSet)).Should(
+							HaveField("Status.Conditions", SatisfyAll(
+								Not(BeEmpty()),
+								ContainElement(SatisfyAll(
+									HaveField("Type", BeEquivalentTo("Paused")),
+									HaveField("Status", Equal(corev1.ConditionTrue)),
+								)),
+							)),
+						)
+					})
+				})
+			})
+			Context("when migrating from ClusterAPI to MachineAPI", func() {
+				Context("when status is not paused for the old authoritative resource (CAPI)", func() {
+					BeforeEach(func() {
+						By("Setting the MAPI machine set spec AuthoritativeAPI to MachineAPI")
+						mapiMachineSet = mapiMachineSetBuilder.
+							WithAuthoritativeAPI(machinev1beta1.MachineAuthorityMachineAPI).
+							Build()
+						Eventually(k8sClient.Create(ctx, mapiMachineSet)).Should(Succeed())
+
+						By("Creating a mirror CAPI machine set")
+						capiMachineSet = capiMachineSetBuilder.Build()
+						Eventually(k8sClient.Create(ctx, capiMachineSet)).Should(Succeed())
+
+						By("Setting the MAPI machine set status AuthoritativeAPI to 'Migrating'")
+						Eventually(k.UpdateStatus(mapiMachineSet, func() {
+							updatedMAPIMachineSet := mapiMachineSetBuilder.
+								WithAuthoritativeAPIStatus(machinev1beta1.MachineAuthorityMigrating).
+								WithConditions([]machinev1beta1.Condition{{
+									Type:               consts.SynchronizedCondition,
+									LastTransitionTime: metav1.Now(),
+									Status:             corev1.ConditionTrue}}).
+								Build()
+							mapiMachineSet.Status.AuthoritativeAPI = updatedMAPIMachineSet.Status.AuthoritativeAPI
+							mapiMachineSet.Status.Conditions = updatedMAPIMachineSet.Status.Conditions
+						})).Should(Succeed())
+
+						By("Setting the CAPI machine set status condition to 'Paused'")
+						Eventually(k.UpdateStatus(capiMachineSet, func() {
+							updatedCAPIMachineSet := capiMachineSetBuilder.Build()
+							updatedCAPIMachineSet.Status.V1Beta2 = &capiv1beta1.MachineSetV1Beta2Status{
+								Conditions: []metav1.Condition{{
+									Type:               capiv1beta1.PausedV1Beta2Condition,
+									Status:             metav1.ConditionTrue,
+									LastTransitionTime: metav1.Now(),
+								}},
+							}
+							capiMachineSet.Status = updatedCAPIMachineSet.Status
+						})).Should(Succeed())
+
+						req = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(mapiMachineSet)}
+					})
+
+					It("should set old authoritative API (CAPI) status to paused and requeue", func() {
+						_, err := reconciler.Reconcile(ctx, req)
+						Expect(err).NotTo(HaveOccurred())
+
+						Eventually(komega.Object(capiMachineSet)).Should(
+							HaveField("Status.V1Beta2.Conditions", SatisfyAll(
+								Not(BeEmpty()),
+								ContainElement(SatisfyAll(
+									HaveField("Type", Equal(capiv1beta1.PausedV1Beta2Condition)),
+									HaveField("Status", Equal(metav1.ConditionTrue)),
+								)),
+							)),
+						)
+					})
+				})
+			})
+		})
+
+		Context("when the old authoritative resource has been paused", func() {
+			Context("when migrating from MachineAPI to ClusterAPI", func() {
+				Context("when status synchronizedGeneration is not matching the old authoritativeAPI generation (MAPI)", func() {
+					BeforeEach(func() {
+						By("Setting the MAPI machine set spec AuthoritativeAPI to ClusterAPI")
+						mapiMachineSet = mapiMachineSetBuilder.
+							// Set desired authoritative API in spec to ClusterAPI.
+							// To check for requesting pausing on the the MAPI resource it is sufficient
+							// see that the spec.AuthoritativeAPI field is set to ClusterAPI.
+							WithAuthoritativeAPI(machinev1beta1.MachineAuthorityClusterAPI).
+							Build()
+						Eventually(k8sClient.Create(ctx, mapiMachineSet)).Should(Succeed())
+
+						By("Setting the MAPI machine set status AuthoritativeAPI to 'Migrating'")
+						Eventually(k.UpdateStatus(mapiMachineSet, func() {
+							updatedMAPIMachineSet := mapiMachineSetBuilder.
+								WithAuthoritativeAPIStatus(machinev1beta1.MachineAuthorityMigrating).
+								WithSynchronizedGeneration(9999). // Do not match .metadata.generation field.
+								WithConditions([]machinev1beta1.Condition{{
+									Type:               consts.SynchronizedCondition,
+									LastTransitionTime: metav1.Now(),
+									Status:             corev1.ConditionTrue}}).
+								Build()
+							mapiMachineSet.Status.AuthoritativeAPI = updatedMAPIMachineSet.Status.AuthoritativeAPI
+							mapiMachineSet.Status.SynchronizedGeneration = updatedMAPIMachineSet.Status.SynchronizedGeneration
+							mapiMachineSet.Status.Conditions = updatedMAPIMachineSet.Status.Conditions
+						})).Should(Succeed())
+
+						req = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(mapiMachineSet)}
+					})
+
+					It("should do nothing", func() {
+						initialMAPIMachineSetRV := mapiMachineSet.ResourceVersion
+						_, err := reconciler.Reconcile(ctx, req)
+						Expect(err).NotTo(HaveOccurred(), "reconciler should not have errored")
+						Eventually(k.Object(mapiMachineSet)).Should(HaveField("ObjectMeta.ResourceVersion", Equal(initialMAPIMachineSetRV)), "should not have modified the machine set")
+					})
+				})
+			})
+			Context("when migrating from ClusterAPI to MachineAPI", func() {
+				Context("when status synchronizedGeneration is not matching the old authoritativeAPI generation (CAPI)", func() {
+					BeforeEach(func() {
+						By("Setting the MAPI machine set spec AuthoritativeAPI to MachineAPI")
+						mapiMachineSet = mapiMachineSetBuilder.
+							WithAuthoritativeAPI(machinev1beta1.MachineAuthorityMachineAPI).
+							Build()
+						Eventually(k8sClient.Create(ctx, mapiMachineSet)).Should(Succeed())
+
+						By("Creating a mirror CAPI machine set")
+						capiMachineSet = capiMachineSetBuilder.Build()
+						Eventually(k8sClient.Create(ctx, capiMachineSet)).Should(Succeed())
+
+						By("Setting the MAPI machine set status AuthoritativeAPI to 'Migrating'")
+						Eventually(k.UpdateStatus(mapiMachineSet, func() {
+							updatedMAPIMachineSet := mapiMachineSetBuilder.
+								WithAuthoritativeAPIStatus(machinev1beta1.MachineAuthorityMigrating).
+								WithSynchronizedGeneration(9999). // Do not match .metadata.generation field.
+								WithConditions([]machinev1beta1.Condition{{
+									Type:               consts.SynchronizedCondition,
+									LastTransitionTime: metav1.Now(),
+									Status:             corev1.ConditionTrue}}).
+								Build()
+							mapiMachineSet.Status.AuthoritativeAPI = updatedMAPIMachineSet.Status.AuthoritativeAPI
+							mapiMachineSet.Status.SynchronizedGeneration = updatedMAPIMachineSet.Status.SynchronizedGeneration
+							mapiMachineSet.Status.Conditions = updatedMAPIMachineSet.Status.Conditions
+						})).Should(Succeed())
+
+						req = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(mapiMachineSet)}
+					})
+
+					It("should do nothing", func() {
+						initialMAPIMachineSetRV := mapiMachineSet.ResourceVersion
+						_, err := reconciler.Reconcile(ctx, req)
+						Expect(err).NotTo(HaveOccurred(), "reconciler should not have errored")
+						Eventually(k.Object(mapiMachineSet)).Should(HaveField("ObjectMeta.ResourceVersion", Equal(initialMAPIMachineSetRV)), "should not have modified the machine set")
+					})
+				})
+			})
+		})
+
+		Context("when all the prerequisites for switching the authoritative API are satisfied", func() {
+			Context("when migrating from MachineAPI to ClusterAPI", func() {
+				BeforeEach(func() {
+					By("Setting the MAPI machine set spec AuthoritativeAPI to ClusterAPI")
+					mapiMachineSet = mapiMachineSetBuilder.
+						// Set desired authoritative API in spec to ClusterAPI.
+						// To check for requesting pausing on the the MAPI resource it is sufficient
+						// see that the spec.AuthoritativeAPI field is set to ClusterAPI.
+						WithAuthoritativeAPI(machinev1beta1.MachineAuthorityClusterAPI).
+						Build()
+					Eventually(k8sClient.Create(ctx, mapiMachineSet)).Should(Succeed())
+
+					By("Setting the MAPI machine set status AuthoritativeAPI to 'Migrating'")
+					Eventually(k.UpdateStatus(mapiMachineSet, func() {
+						updatedMAPIMachineSet := mapiMachineSetBuilder.
+							WithAuthoritativeAPIStatus(machinev1beta1.MachineAuthorityMigrating).
+							WithSynchronizedGeneration(mapiMachineSet.Generation). // Match the MAPI .metadata.generation field.
+							WithConditions([]machinev1beta1.Condition{
+								{
+									Type:               consts.SynchronizedCondition,
+									LastTransitionTime: metav1.Now(),
+									Status:             corev1.ConditionTrue,
+								},
+								{
+									Type:               "Paused",
+									LastTransitionTime: metav1.Now(),
+									Status:             corev1.ConditionTrue,
+								},
+							}).
+							Build()
+						mapiMachineSet.Status.AuthoritativeAPI = updatedMAPIMachineSet.Status.AuthoritativeAPI
+						mapiMachineSet.Status.SynchronizedGeneration = updatedMAPIMachineSet.Status.SynchronizedGeneration
+						mapiMachineSet.Status.Conditions = updatedMAPIMachineSet.Status.Conditions
+					})).Should(Succeed())
+
+					By("Creating a mirror CAPI machine set")
+					capiMachineSet = capiMachineSetBuilder.
+						WithAnnotations(map[string]string{
+							capiv1beta1.PausedAnnotation: "",
+						}).
+						Build()
+					capiMachineSet.Finalizers = append(capiMachineSet.Finalizers, capiv1beta1.MachineSetFinalizer)
+					Eventually(k8sClient.Create(ctx, capiMachineSet)).Should(Succeed())
+
+					By("Setting the CAPI machine set status condition to 'Paused'")
+					Eventually(k.UpdateStatus(capiMachineSet, func() {
+						updatedCAPIMachineSet := capiMachineSetBuilder.Build()
+						updatedCAPIMachineSet.Status.V1Beta2 = &capiv1beta1.MachineSetV1Beta2Status{
+							Conditions: []metav1.Condition{{
+								Type:               capiv1beta1.PausedV1Beta2Condition,
+								Status:             metav1.ConditionTrue,
+								LastTransitionTime: metav1.Now(),
+							}},
+						}
+						capiMachineSet.Status = updatedCAPIMachineSet.Status
+					})).Should(Succeed())
+
+					req = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(mapiMachineSet)}
+				})
+
+				It("should set the new to-be authoritative resource (CAPI) to actually be authoritative and unpause it", func() {
+					result, err := reconciler.Reconcile(ctx, req)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result.Requeue).To(BeFalse())
+
+					Eventually(komega.Object(mapiMachineSet)).Should(SatisfyAll(
+						HaveField("Status.AuthoritativeAPI", Equal(machinev1beta1.MachineAuthorityClusterAPI)),
+						HaveField("Status.SynchronizedGeneration", BeZero()),
+					))
+
+					Eventually(komega.Object(capiMachineSet)).ShouldNot(
+						HaveField("ObjectMeta.Annotations", ContainElement(HaveKeyWithValue(capiv1beta1.PausedAnnotation, ""))))
+				})
+			})
+			Context("when migrating from ClusterAPI to MachineAPI", func() {
+				BeforeEach(func() {
+					By("Setting the MAPI machine set spec AuthoritativeAPI to MachineAPI")
+					mapiMachineSet = mapiMachineSetBuilder.
+						WithAuthoritativeAPI(machinev1beta1.MachineAuthorityMachineAPI).
+						Build()
+					Eventually(k8sClient.Create(ctx, mapiMachineSet)).Should(Succeed())
+
+					By("Creating a mirror CAPI machine set")
+					capiMachineSet = capiMachineSetBuilder.
+						WithAnnotations(map[string]string{
+							capiv1beta1.PausedAnnotation: "",
+						}).
+						Build()
+					Eventually(k8sClient.Create(ctx, capiMachineSet)).Should(Succeed())
+
+					By("Setting the MAPI machine set status AuthoritativeAPI to 'Migrating'")
+					Eventually(k.UpdateStatus(mapiMachineSet, func() {
+						updatedMAPIMachineSet := mapiMachineSetBuilder.
+							WithAuthoritativeAPIStatus(machinev1beta1.MachineAuthorityMigrating).
+							WithSynchronizedGeneration(capiMachineSet.Generation). // Match the CAPI .metadata.generation field.
+							WithConditions([]machinev1beta1.Condition{
+								{
+									Type:               consts.SynchronizedCondition,
+									LastTransitionTime: metav1.Now(),
+									Status:             corev1.ConditionTrue,
+								},
+								{
+									Type:               "Paused",
+									LastTransitionTime: metav1.Now(),
+									Status:             corev1.ConditionTrue,
+								},
+							}).
+							Build()
+						mapiMachineSet.Status.AuthoritativeAPI = updatedMAPIMachineSet.Status.AuthoritativeAPI
+						mapiMachineSet.Status.SynchronizedGeneration = updatedMAPIMachineSet.Status.SynchronizedGeneration
+						mapiMachineSet.Status.Conditions = updatedMAPIMachineSet.Status.Conditions
+					})).Should(Succeed())
+
+					By("Setting the CAPI machine set status condition to 'Paused'")
+					Eventually(k.UpdateStatus(capiMachineSet, func() {
+						updatedCAPIMachineSet := capiMachineSetBuilder.Build()
+						updatedCAPIMachineSet.Status.V1Beta2 = &capiv1beta1.MachineSetV1Beta2Status{
+							Conditions: []metav1.Condition{{
+								Type:               capiv1beta1.PausedV1Beta2Condition,
+								Status:             metav1.ConditionTrue,
+								LastTransitionTime: metav1.Now(),
+							}},
+						}
+						capiMachineSet.Status = updatedCAPIMachineSet.Status
+					})).Should(Succeed())
+
+					req = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(mapiMachineSet)}
+				})
+
+				It("should set the new to-be authoritative resource (MAPI) to actually be authoritative and requeue to unpause it", func() {
+					result, err := reconciler.Reconcile(ctx, req)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result.Requeue).To(BeFalse())
+
+					Eventually(komega.Object(mapiMachineSet)).Should(SatisfyAll(
+						HaveField("Status.AuthoritativeAPI", Equal(machinev1beta1.MachineAuthorityMachineAPI)),
+						HaveField("Status.SynchronizedGeneration", BeZero()),
+					))
+				})
+			})
+		})
+	})
+})

--- a/pkg/controllers/machinesetmigration/suite_test.go
+++ b/pkg/controllers/machinesetmigration/suite_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machinesetmigration
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	configv1builder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/config/v1"
+	"github.com/openshift/cluster-capi-operator/pkg/test"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/textlogger"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	//+kubebuilder:scaffold:imports
+)
+
+var cfg *rest.Config
+var k8sClient client.Client
+var testEnv *envtest.Environment
+var testRESTMapper meta.RESTMapper
+var ctx = context.Background()
+
+func TestMachineSetMigration(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Controller Suite")
+}
+
+var _ = BeforeSuite(func() {
+	klog.SetOutput(GinkgoWriter)
+
+	logf.SetLogger(textlogger.NewLogger(textlogger.NewConfig()))
+
+	By("bootstrapping test environment")
+	var err error
+	testEnv = &envtest.Environment{}
+	cfg, k8sClient, err = test.StartEnvTest(testEnv)
+
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+	Expect(k8sClient).NotTo(BeNil())
+
+	infrastructure := configv1builder.Infrastructure().AsAWS("test", "eu-west-2").WithName("cluster").Build()
+	Expect(k8sClient.Create(ctx, infrastructure)).To(Succeed())
+
+	httpClient, err := rest.HTTPClientFor(cfg)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(httpClient).NotTo(BeNil())
+
+	testRESTMapper, err = apiutil.NewDynamicRESTMapper(cfg, httpClient)
+	Expect(err).NotTo(HaveOccurred())
+
+	komega.SetClient(k8sClient)
+	komega.SetContext(ctx)
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/pkg/conversion/capi2mapi/machine.go
+++ b/pkg/conversion/capi2mapi/machine.go
@@ -45,6 +45,7 @@ func fromCAPIMachineToMAPIMachine(capiMachine *capiv1.Machine) (*mapiv1.Machine,
 			Namespace:       mapiNamespace,
 			Labels:          convertCAPILabelsToMAPILabels(capiMachine.Labels),
 			Annotations:     convertCAPIAnnotationsToMAPIAnnotations(capiMachineNonHookAnnotations),
+			Finalizers:      []string{mapiv1.MachineFinalizer},
 			OwnerReferences: nil, // OwnerReferences not populated here. They are added later by the machineSync controller.
 		},
 		Spec: mapiv1.MachineSpec{

--- a/pkg/conversion/capi2mapi/machineset.go
+++ b/pkg/conversion/capi2mapi/machineset.go
@@ -33,6 +33,7 @@ func fromCAPIMachineSetToMAPIMachineSet(capiMachineSet *capiv1.MachineSet) (*map
 			Namespace:       capiMachineSet.Namespace,
 			Labels:          convertCAPILabelsToMAPILabels(capiMachineSet.Labels),
 			Annotations:     convertCAPIAnnotationsToMAPIAnnotations(capiMachineSet.Annotations),
+			Finalizers:      nil, // MAPI MachineSet does not have finalizers.
 			OwnerReferences: nil, // OwnerReferences not populated here. They are added later by the machineSetSync controller.
 		},
 		Spec: mapiv1.MachineSetSpec{

--- a/pkg/conversion/mapi2capi/machine.go
+++ b/pkg/conversion/mapi2capi/machine.go
@@ -41,8 +41,8 @@ func fromMAPIMachineToCAPIMachine(mapiMachine *mapiv1beta1.Machine, apiVersion, 
 			Namespace:       capiNamespace,
 			Labels:          convertMAPILabelsToCAPI(mapiMachine.Labels),
 			Annotations:     convertMAPIAnnotationsToCAPI(mapiMachine.Annotations),
+			Finalizers:      []string{capiv1.MachineFinalizer},
 			OwnerReferences: nil, // OwnerReferences not populated here. They are added later by the machineSync controller.
-			Finalizers:      nil, // Finalizers not populated here. They are added later by the machine controllers.
 		},
 		Spec: capiv1.MachineSpec{
 			InfrastructureRef: corev1.ObjectReference{

--- a/pkg/conversion/mapi2capi/machineset.go
+++ b/pkg/conversion/mapi2capi/machineset.go
@@ -36,6 +36,7 @@ func fromMAPIMachineSetToCAPIMachineSet(mapiMachineSet *mapiv1.MachineSet) (*cap
 			Namespace:       mapiMachineSet.Namespace,
 			Labels:          convertMAPILabelsToCAPI(mapiMachineSet.Labels),
 			Annotations:     convertMAPIAnnotationsToCAPI(mapiMachineSet.Annotations),
+			Finalizers:      nil, // The CAPI MachineSet finalizer is managed by the CAPI machineset controller.
 			OwnerReferences: nil, // OwnerReferences not populated here. They are added later by the machineSetSync controller.
 		},
 		Spec: capiv1.MachineSetSpec{

--- a/pkg/conversion/test/fuzz/fuzz.go
+++ b/pkg/conversion/test/fuzz/fuzz.go
@@ -130,10 +130,12 @@ func CAPI2MAPIMachineRoundTripFuzzTest(scheme *runtime.Scheme, infra *configv1.I
 		// Expect(capiMachine.Status).To(Equal(in.machine.Status))
 		// Expect(infraMachine.Status).To(Equal(in.infraMachine.Status))
 
+		capiMachine.Finalizers = nil
 		Expect(capiMachine.TypeMeta).To(Equal(in.machine.TypeMeta))
 		Expect(capiMachine.ObjectMeta).To(Equal(in.machine.ObjectMeta))
 		Expect(capiMachine.Spec).To(Equal(in.machine.Spec))
 
+		infraMachine.SetFinalizers(nil)
 		infraMachineJSON, err := json.Marshal(infraMachine)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -201,10 +203,12 @@ func CAPI2MAPIMachineSetRoundTripFuzzTest(scheme *runtime.Scheme, infra *configv
 		// Expect(capiMachineSet.Status).To(Equal(in.machineSet.Status))
 		// Expect(infraMachineTemplate.Status).To(Equal(in.infraMachineTemplate.Status))
 
+		capiMachineSet.Finalizers = nil
 		Expect(capiMachineSet.TypeMeta).To(Equal(in.machineSet.TypeMeta))
 		Expect(capiMachineSet.ObjectMeta).To(Equal(in.machineSet.ObjectMeta))
 		Expect(capiMachineSet.Spec).To(Equal(in.machineSet.Spec))
 
+		infraMachineTemplate.SetFinalizers(nil)
 		infraMachineTemplateJSON, err := json.Marshal(infraMachineTemplate)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -267,6 +271,7 @@ func MAPI2CAPIMachineRoundTripFuzzTest(scheme *runtime.Scheme, infra *configv1.I
 		// Do not match on status yet, we do not support status conversion.
 		// Expect(mapiMachine.Status).To(Equal(in.machine.Status))
 
+		mapiMachine.Finalizers = nil
 		Expect(mapiMachine.TypeMeta).To(Equal(in.machine.TypeMeta), "converted MAPI machine should have matching .typeMeta")
 		Expect(mapiMachine.ObjectMeta).To(Equal(in.machine.ObjectMeta), "converted MAPI machine should have matching .metadata")
 		Expect(mapiMachine.Spec).To(WithTransform(ignoreMachineProviderSpec, testutils.MatchViaJSON(ignoreMachineProviderSpec(in.machine.Spec))), "converted MAPI machine should have matching .spec")
@@ -324,6 +329,7 @@ func MAPI2CAPIMachineSetRoundTripFuzzTest(scheme *runtime.Scheme, infra *configv
 		// Do not match on status yet, we do not support status conversion.
 		// Expect(mapiMachineSet.Status).To(Equal(in.machineSet.Status))
 
+		mapiMachineSet.Finalizers = nil
 		Expect(mapiMachineSet.TypeMeta).To(Equal(in.machineSet.TypeMeta), "converted MAPI machine set should have matching .typeMeta")
 		Expect(mapiMachineSet.ObjectMeta).To(Equal(in.machineSet.ObjectMeta), "converted MAPI machine set should have matching .metadata")
 		Expect(mapiMachineSet.Spec).To(WithTransform(ignoreMachineSetProviderSpec, testutils.MatchViaJSON(ignoreMachineSetProviderSpec(in.machineSet.Spec))), "converted MAPI machine set should have matching .spec")

--- a/pkg/util/annotations.go
+++ b/pkg/util/annotations.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package util
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// RemoveAnnotation deletes a specific annotation from a client.Object.
+func RemoveAnnotation(obj client.Object, key string) {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return
+	}
+
+	if _, exists := annotations[key]; !exists {
+		return
+	}
+
+	delete(annotations, key)
+	obj.SetAnnotations(annotations)
+}

--- a/pkg/util/conditions.go
+++ b/pkg/util/conditions.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package util
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	errStatusNotMap                 = errors.New("unable to assert status structure to map")
+	errStatusConditionsNotInterface = errors.New("unable to assert status.condition structure to interface")
+)
+
+// GetCondition retrieves a specific condition from a client.Object.
+func GetCondition(obj client.Object, conditionType string) (*metav1.Condition, error) {
+	// Convert client.Object to unstructured.Unstructured
+	unstructuredMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert object to unstructured: %w", err)
+	}
+
+	unstructuredObj := &unstructured.Unstructured{Object: unstructuredMap}
+
+	data := unstructuredObj.UnstructuredContent()
+
+	status, ok := data["status"].(map[string]interface{})
+	if !ok {
+		return nil, errStatusNotMap
+	}
+
+	conditions, ok := status["conditions"].([]interface{})
+	if !ok {
+		return nil, errStatusConditionsNotInterface
+	}
+
+	for _, c := range conditions {
+		condMap, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		status, ok := condMap["status"].(string)
+		if !ok {
+			continue
+		}
+
+		if condMap["type"] == conditionType {
+			return &metav1.Condition{
+				Type:               conditionType,
+				Status:             metav1.ConditionStatus(status),
+				Reason:             getString(condMap, "reason"),
+				Message:            getString(condMap, "message"),
+				LastTransitionTime: getTime(condMap, "lastTransitionTime"),
+			}, nil
+		}
+	}
+
+	return nil, nil //nolint:nilnil
+}
+
+// GetConditionStatus returns the status for the condition.
+func GetConditionStatus(obj client.Object, conditionType string) (corev1.ConditionStatus, error) {
+	cond, err := GetCondition(obj, conditionType)
+	if err != nil {
+		return corev1.ConditionUnknown, fmt.Errorf("unable to get condition %q for the object: %w", conditionType, err)
+	}
+
+	if cond == nil {
+		return corev1.ConditionUnknown, nil
+	}
+
+	return corev1.ConditionStatus(cond.Status), nil
+}
+
+func getString(data map[string]interface{}, key string) string {
+	if val, ok := data[key].(string); ok {
+		return val
+	}
+
+	return ""
+}
+
+func getTime(data map[string]interface{}, key string) metav1.Time {
+	if val, ok := data[key].(string); ok {
+		parsedTime, err := time.Parse(time.RFC3339, val)
+		if err == nil {
+			return metav1.Time{Time: parsedTime}
+		}
+	}
+
+	return metav1.Time{}
+}

--- a/pkg/util/finalizer.go
+++ b/pkg/util/finalizer.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package util
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+var (
+	errUnableToAssertClientObject = errors.New("unable to assert client.Object after deepcopy")
+)
+
+// EnsureFinalizer ensures that the specified finalizer is added to the given object using a Patch operation.
+func EnsureFinalizer(ctx context.Context, c client.Client, obj client.Object, finalizer string) (bool, error) {
+	// Create a deep copy of the original object.
+	originalObj, ok := obj.DeepCopyObject().(client.Object)
+	if !ok {
+		return false, errUnableToAssertClientObject
+	}
+
+	if updated := controllerutil.AddFinalizer(obj, finalizer); !updated {
+		return false, nil
+	}
+	// Apply the patch operation.
+	if err := c.Patch(ctx, obj, client.MergeFrom(originalObj)); err != nil {
+		if kerrors.IsNotFound(err) {
+			return false, fmt.Errorf("object %s/%s not found: %w", obj.GetNamespace(), obj.GetName(), err)
+		}
+
+		return false, fmt.Errorf("error patching resource %s/%s to add finalizer: %w", obj.GetNamespace(), obj.GetName(), err)
+	}
+
+	return true, nil
+}
+
+// RemoveFinalizer ensures that the specified finalizer is removed from the given object using a Patch operation.
+func RemoveFinalizer(ctx context.Context, c client.Client, obj client.Object, finalizer string) (bool, error) {
+	// Create a deep copy of the original object.
+	originalObj, ok := obj.DeepCopyObject().(client.Object)
+	if !ok {
+		return false, errUnableToAssertClientObject
+	}
+
+	if updated := controllerutil.RemoveFinalizer(obj, finalizer); !updated {
+		return false, nil
+	}
+
+	// Apply the patch operation.
+	if err := c.Patch(ctx, obj, client.MergeFrom(originalObj)); err != nil {
+		if kerrors.IsNotFound(err) {
+			return false, fmt.Errorf("object %s/%s not found: %w", obj.GetNamespace(), obj.GetName(), err)
+		}
+
+		return false, fmt.Errorf("error patching resource %s/%s to remove finalizer: %w", obj.GetNamespace(), obj.GetName(), err)
+	}
+
+	return true, nil
+}

--- a/pkg/util/object.go
+++ b/pkg/util/object.go
@@ -16,12 +16,53 @@ limitations under the License.
 package util
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"reflect"
 
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+var errObjectNotClientObject = errors.New("object does not implement client.Object")
 
 // IsNilObject checks whether a client.Object is nil or not.
 func IsNilObject(obj client.Object) bool {
 	return obj == nil || reflect.ValueOf(obj).IsNil()
+}
+
+// GetReferencedObject retrieves a Kubernetes object dynamically based on an ObjectReference.
+func GetReferencedObject(ctx context.Context, c client.Reader, scheme *runtime.Scheme, ref corev1.ObjectReference) (client.Object, error) {
+	// Construct GVK from the reference.
+	gvk := schema.FromAPIVersionAndKind(ref.APIVersion, ref.Kind)
+
+	// Create an empty object dynamically.
+	obj, err := scheme.New(gvk)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create object for GVK %v: %w", gvk, err)
+	}
+
+	// Ensure it implements client.Object.
+	clientObj, ok := obj.(client.Object)
+	if !ok {
+		return nil, errObjectNotClientObject
+	}
+
+	// Set GVK explicitly.
+	clientObj.GetObjectKind().SetGroupVersionKind(gvk)
+
+	// Fetch the object from the cluster.
+	if err := c.Get(ctx, client.ObjectKey{Namespace: ref.Namespace, Name: ref.Name}, clientObj); err != nil {
+		if kerrors.IsNotFound(err) {
+			return nil, fmt.Errorf("object %s/%s not found: %w", ref.Namespace, ref.Name, err)
+		}
+
+		return nil, fmt.Errorf("failed to get object %s/%s: %w", ref.Namespace, ref.Name, err)
+	}
+
+	return clientObj, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2351,6 +2351,7 @@ sigs.k8s.io/cluster-api/feature
 sigs.k8s.io/cluster-api/util
 sigs.k8s.io/cluster-api/util/annotations
 sigs.k8s.io/cluster-api/util/conditions
+sigs.k8s.io/cluster-api/util/conditions/v1beta2
 sigs.k8s.io/cluster-api/util/contract
 sigs.k8s.io/cluster-api/util/flags
 sigs.k8s.io/cluster-api/util/labels/format

--- a/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/aggregate.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/aggregate.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// AggregateOption is some configuration that modifies options for a aggregate call.
+type AggregateOption interface {
+	// ApplyToAggregate applies this configuration to the given aggregate options.
+	ApplyToAggregate(option *AggregateOptions)
+}
+
+// AggregateOptions allows to set options for the aggregate operation.
+type AggregateOptions struct {
+	mergeStrategy                  MergeStrategy
+	targetConditionType            string
+	negativePolarityConditionTypes []string
+}
+
+// ApplyOptions applies the given list options on these options,
+// and then returns itself (for convenient chaining).
+func (o *AggregateOptions) ApplyOptions(opts []AggregateOption) *AggregateOptions {
+	for _, opt := range opts {
+		opt.ApplyToAggregate(o)
+	}
+	return o
+}
+
+// NewAggregateCondition aggregates a condition from a list of objects; the given condition must have positive polarity;
+// if the given condition does not exist in one of the source objects, missing conditions are considered Unknown, reason NotYetReported.
+//
+// If the source conditions type has negative polarity, it should be indicated with the NegativePolarityConditionTypes option;
+// in this case NegativePolarityConditionTypes must match the sourceConditionType, and by default also the resulting condition
+// will have negative polarity.
+//
+// By default, the Aggregate condition has the same type of the source condition, but this can be changed by using
+// the TargetConditionType option.
+//
+// Additionally, it is possible to inject custom merge strategies using the CustomMergeStrategy option.
+func NewAggregateCondition[T Getter](sourceObjs []T, sourceConditionType string, opts ...AggregateOption) (*metav1.Condition, error) {
+	if len(sourceObjs) == 0 {
+		return nil, errors.New("sourceObjs can't be empty")
+	}
+
+	aggregateOpt := &AggregateOptions{
+		targetConditionType: sourceConditionType,
+	}
+	aggregateOpt.ApplyOptions(opts)
+
+	if len(aggregateOpt.negativePolarityConditionTypes) != 0 && (aggregateOpt.negativePolarityConditionTypes[0] != sourceConditionType || len(aggregateOpt.negativePolarityConditionTypes) > 1) {
+		return nil, errors.Errorf("negativePolarityConditionTypes can only be set to [%q]", sourceConditionType)
+	}
+
+	if aggregateOpt.mergeStrategy == nil {
+		// Note: If mergeStrategy is not explicitly set, target condition has negative polarity if source condition has negative polarity
+		targetConditionHasPositivePolarity := !sets.New[string](aggregateOpt.negativePolarityConditionTypes...).Has(sourceConditionType)
+		aggregateOpt.mergeStrategy = DefaultMergeStrategy(TargetConditionHasPositivePolarity(targetConditionHasPositivePolarity), GetPriorityFunc(GetDefaultMergePriorityFunc(aggregateOpt.negativePolarityConditionTypes...)))
+	}
+
+	conditionsInScope := make([]ConditionWithOwnerInfo, 0, len(sourceObjs))
+	for _, obj := range sourceObjs {
+		conditions := getConditionsWithOwnerInfo(obj)
+
+		// Drops all the conditions not in scope for the merge operation
+		hasConditionType := false
+		for _, condition := range conditions {
+			if condition.Type != sourceConditionType {
+				continue
+			}
+			conditionsInScope = append(conditionsInScope, condition)
+			hasConditionType = true
+			break
+		}
+
+		// Add the expected conditions if it does not exist, so we are compliant with K8s guidelines
+		// (all missing conditions should be considered unknown).
+		if !hasConditionType {
+			conditionOwner := getConditionOwnerInfo(obj)
+
+			conditionsInScope = append(conditionsInScope, ConditionWithOwnerInfo{
+				OwnerResource: conditionOwner,
+				Condition: metav1.Condition{
+					Type:    sourceConditionType,
+					Status:  metav1.ConditionUnknown,
+					Reason:  NotYetReportedReason,
+					Message: fmt.Sprintf("Condition %s not yet reported", sourceConditionType),
+					// NOTE: LastTransitionTime and ObservedGeneration are not relevant for merge.
+				},
+			})
+		}
+	}
+
+	status, reason, message, err := aggregateOpt.mergeStrategy.Merge(conditionsInScope, []string{sourceConditionType})
+	if err != nil {
+		return nil, err
+	}
+
+	c := &metav1.Condition{
+		Type:    aggregateOpt.targetConditionType,
+		Status:  status,
+		Reason:  reason,
+		Message: message,
+		// NOTE: LastTransitionTime and ObservedGeneration will be set when this condition is added to an object by calling Set.
+	}
+
+	return c, err
+}
+
+// SetAggregateCondition is a convenience method that calls NewAggregateCondition to create an aggregate condition from the source objects,
+// and then calls Set to add the new condition to the target object.
+func SetAggregateCondition[T Getter](sourceObjs []T, targetObj Setter, conditionType string, opts ...AggregateOption) error {
+	aggregateCondition, err := NewAggregateCondition(sourceObjs, conditionType, opts...)
+	if err != nil {
+		return err
+	}
+	Set(targetObj, *aggregateCondition)
+	return nil
+}

--- a/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/doc.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/doc.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package v1beta2 implements utils for metav1.Conditions that will be used starting with the v1beta2 API.
+//
+// Please note that in order to make this change while respecting API deprecation rules, it is required
+// to go through a phased approach:
+// - Phase 1. metav1.Conditions will be added into v1beta1 API types under the Status.V1Beta2.Conditions struct (clusterv1.Conditions will remain in Status.Conditions)
+// - Phase 2. when introducing v1beta2 API types:
+//   - clusterv1.Conditions will be moved from Status.Conditions to Status.Deprecated.V1Beta1.Conditions
+//   - metav1.Conditions will be moved from Status.V1Beta2.Conditions to Status.Conditions
+//
+// - Phase 3. when removing v1beta1 API types, Status.Deprecated will be dropped.
+//
+// Please see the proposal https://github.com/kubernetes-sigs/cluster-api/tree/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+//
+// In order to make this transition easier both for CAPI and other projects using this package,
+// utils automatically adapt to handle objects at different stage of the transition.
+package v1beta2

--- a/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/getter.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/getter.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"sigs.k8s.io/cluster-api/util"
+)
+
+// TODO: Move to the API package.
+const (
+	// NoReasonReported identifies a clusterv1.Condition that reports no reason.
+	NoReasonReported = "NoReasonReported"
+)
+
+// Getter interface defines methods that an API object should implement in order to
+// use the conditions package for getting conditions.
+type Getter interface {
+	// GetV1Beta2Conditions returns the list of conditions for a cluster API object.
+	// Note: GetV1Beta2Conditions will be renamed to GetConditions in a later stage of the transition to V1Beta2.
+	GetV1Beta2Conditions() []metav1.Condition
+}
+
+// Get returns a condition from the object implementing the Getter interface.
+//
+// Please note that Get does not support reading conditions from unstructured objects nor from API types not implementing
+// the Getter interface. Eventually, users can implement wrappers on those types implementing this interface and
+// taking care of aligning the condition format if necessary.
+func Get(sourceObj Getter, sourceConditionType string) *metav1.Condition {
+	// if obj is nil, the requested condition does not exist.
+	if util.IsNil(sourceObj) {
+		return nil
+	}
+
+	// Otherwise get the requested condition.
+	return meta.FindStatusCondition(sourceObj.GetV1Beta2Conditions(), sourceConditionType)
+}
+
+// Has returns true if a condition with the given type exists.
+func Has(from Getter, conditionType string) bool {
+	return Get(from, conditionType) != nil
+}
+
+// IsTrue is true if the condition with the given type is True, otherwise it returns false
+// if the condition is not True or if the condition does not exist (is nil).
+func IsTrue(from Getter, conditionType string) bool {
+	if c := Get(from, conditionType); c != nil {
+		return c.Status == metav1.ConditionTrue
+	}
+	return false
+}
+
+// IsFalse is true if the condition with the given type is False, otherwise it returns false
+// if the condition is not False or if the condition does not exist (is nil).
+func IsFalse(from Getter, conditionType string) bool {
+	if c := Get(from, conditionType); c != nil {
+		return c.Status == metav1.ConditionFalse
+	}
+	return false
+}
+
+// IsUnknown is true if the condition with the given type is Unknown or if the condition
+// does not exist (is nil).
+func IsUnknown(from Getter, conditionType string) bool {
+	if c := Get(from, conditionType); c != nil {
+		return c.Status == metav1.ConditionUnknown
+	}
+	return true
+}
+
+// UnstructuredGetAll returns conditions from an Unstructured object.
+//
+// UnstructuredGetAll supports retrieving conditions from objects at different stages of the transition from
+// clusterv1.conditions to the metav1.Condition type:
+//   - Objects with clusterv1.Conditions in status.conditions; in this case a best effort conversion
+//     to metav1.Condition is performed, just enough to allow surfacing a condition from a provider object with Mirror
+//   - Objects with metav1.Condition in status.v1beta2.conditions
+//   - Objects with metav1.Condition in status.conditions
+func UnstructuredGetAll(sourceObj runtime.Unstructured) ([]metav1.Condition, error) {
+	if util.IsNil(sourceObj) {
+		return nil, errors.New("sourceObj is nil")
+	}
+
+	ownerInfo := getConditionOwnerInfo(sourceObj)
+
+	value, exists, err := unstructured.NestedFieldNoCopy(sourceObj.UnstructuredContent(), "status", "v1beta2", "conditions")
+	if exists && err == nil {
+		if conditions, ok := value.([]interface{}); ok {
+			r, err := convertFromUnstructuredConditions(conditions)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to convert status.v1beta2.conditions from %s to []metav1.Condition", ownerInfo.Kind)
+			}
+			return r, nil
+		}
+	}
+
+	value, exists, err = unstructured.NestedFieldNoCopy(sourceObj.UnstructuredContent(), "status", "conditions")
+	if exists && err == nil {
+		if conditions, ok := value.([]interface{}); ok {
+			r, err := convertFromUnstructuredConditions(conditions)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to convert status.conditions from %s to []metav1.Condition", ownerInfo.Kind)
+			}
+			return r, nil
+		}
+	}
+
+	// With unstructured, it is not possible to detect if conditions are not set if the type is wrongly defined.
+	// This methods assume condition are not set.
+	return nil, nil
+}
+
+// UnstructuredGet returns a condition from an Unstructured object.
+//
+// UnstructuredGet supports retrieving conditions from objects at different stages of the transition from
+// clusterv1.conditions to the metav1.Condition type:
+//   - Objects with clusterv1.Conditions in status.conditions; in this case a best effort conversion
+//     to metav1.Condition is performed, just enough to allow surfacing a condition from a provider object with Mirror
+//   - Objects with metav1.Condition in status.v1beta2.conditions
+//   - Objects with metav1.Condition in status.conditions
+func UnstructuredGet(sourceObj runtime.Unstructured, sourceConditionType string) (*metav1.Condition, error) {
+	r, err := UnstructuredGetAll(sourceObj)
+	if err != nil {
+		return nil, err
+	}
+	return meta.FindStatusCondition(r, sourceConditionType), nil
+}
+
+// convertFromUnstructuredConditions converts []interface{} to []metav1.Condition; this operation must account for
+// objects which are not transitioning to metav1.Condition, or not yet fully transitioned, and thus a best
+// effort conversion of values to metav1.Condition is performed.
+func convertFromUnstructuredConditions(conditions []interface{}) ([]metav1.Condition, error) {
+	if conditions == nil {
+		return nil, nil
+	}
+
+	convertedConditions := make([]metav1.Condition, 0, len(conditions))
+	for _, c := range conditions {
+		cMap, ok := c.(map[string]interface{})
+		if !ok || cMap == nil {
+			continue
+		}
+
+		var conditionType string
+		if v, ok := cMap["type"]; ok {
+			conditionType = v.(string)
+		}
+
+		var status string
+		if v, ok := cMap["status"]; ok {
+			status = v.(string)
+		}
+
+		var observedGeneration int64
+		if v, ok := cMap["observedGeneration"]; ok {
+			observedGeneration = v.(int64)
+		}
+
+		var lastTransitionTime metav1.Time
+		if v, ok := cMap["lastTransitionTime"]; ok && v != nil && v.(string) != "" {
+			if err := lastTransitionTime.UnmarshalQueryParameter(v.(string)); err != nil {
+				return nil, errors.Wrapf(err, "failed to unmarshal lastTransitionTime value: %s", v)
+			}
+		}
+
+		var reason string
+		if v, ok := cMap["reason"]; ok {
+			reason = v.(string)
+		}
+
+		var message string
+		if v, ok := cMap["message"]; ok {
+			message = v.(string)
+		}
+
+		c := metav1.Condition{
+			Type:               conditionType,
+			Status:             metav1.ConditionStatus(status),
+			ObservedGeneration: observedGeneration,
+			LastTransitionTime: lastTransitionTime,
+			Reason:             reason,
+			Message:            message,
+		}
+		if err := validateAndFixConvertedCondition(&c); err != nil {
+			return nil, err
+		}
+
+		convertedConditions = append(convertedConditions, c)
+	}
+	return convertedConditions, nil
+}
+
+// validateAndFixConvertedCondition validates and fixes a clusterv1.Condition converted to a metav1.Condition.
+// this operation assumes conditions have been set using Cluster API condition utils;
+// also, only a few, minimal rules are enforced, just enough to allow surfacing a condition from a providers object with Mirror.
+func validateAndFixConvertedCondition(c *metav1.Condition) error {
+	if c.Type == "" {
+		return errors.New("type must be set for all conditions")
+	}
+	if c.Status == "" {
+		return errors.Errorf("status must be set for the %s condition", c.Type)
+	}
+	switch c.Status {
+	case metav1.ConditionFalse, metav1.ConditionTrue, metav1.ConditionUnknown:
+		break
+	default:
+		return errors.Errorf("status for the %s condition must be one of %s, %s, %s", c.Type, metav1.ConditionTrue, metav1.ConditionFalse, metav1.ConditionUnknown)
+	}
+	if c.Reason == "" {
+		c.Reason = NoReasonReported
+	}
+
+	// NOTE: Empty LastTransitionTime is tolerated because it will be set when assigning the newly generated mirror condition to an object.
+	// NOTE: Other metav1.Condition validations rules, e.g. regex, are not enforced at this stage; they will be enforced by the API server at a later stage.
+
+	return nil
+}

--- a/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/matcher.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/matcher.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	"fmt"
+
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// IgnoreLastTransitionTime instructs MatchConditions and MatchCondition to ignore the LastTransitionTime field.
+type IgnoreLastTransitionTime bool
+
+// ApplyMatch applies this configuration to the given Match options.
+func (f IgnoreLastTransitionTime) ApplyMatch(opts *MatchOptions) {
+	opts.ignoreLastTransitionTime = bool(f)
+}
+
+// MatchOption is some configuration that modifies options for a match call.
+type MatchOption interface {
+	// ApplyMatch applies this configuration to the given match options.
+	ApplyMatch(option *MatchOptions)
+}
+
+// MatchOptions allows to set options for the match operation.
+type MatchOptions struct {
+	ignoreLastTransitionTime bool
+}
+
+// ApplyOptions applies the given list options on these options,
+// and then returns itself (for convenient chaining).
+func (o *MatchOptions) ApplyOptions(opts []MatchOption) *MatchOptions {
+	for _, opt := range opts {
+		opt.ApplyMatch(o)
+	}
+	return o
+}
+
+// MatchConditions returns a custom matcher to check equality of []metav1.Condition.
+func MatchConditions(expected []metav1.Condition, opts ...MatchOption) types.GomegaMatcher {
+	return &matchConditions{
+		opts:     opts,
+		expected: expected,
+	}
+}
+
+type matchConditions struct {
+	opts     []MatchOption
+	expected []metav1.Condition
+}
+
+func (m matchConditions) Match(actual interface{}) (success bool, err error) {
+	elems := []interface{}{}
+	for _, condition := range m.expected {
+		elems = append(elems, MatchCondition(condition, m.opts...))
+	}
+
+	return gomega.ConsistOf(elems...).Match(actual)
+}
+
+func (m matchConditions) FailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("expected\n\t%#v\nto match\n\t%#v\n", actual, m.expected)
+}
+
+func (m matchConditions) NegatedFailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("expected\n\t%#v\nto not match\n\t%#v\n", actual, m.expected)
+}
+
+// MatchCondition returns a custom matcher to check equality of metav1.Condition.
+func MatchCondition(expected metav1.Condition, opts ...MatchOption) types.GomegaMatcher {
+	return &matchCondition{
+		opts:     opts,
+		expected: expected,
+	}
+}
+
+type matchCondition struct {
+	opts     []MatchOption
+	expected metav1.Condition
+}
+
+func (m matchCondition) Match(actual interface{}) (success bool, err error) {
+	matchOpt := &MatchOptions{
+		ignoreLastTransitionTime: false,
+	}
+	matchOpt.ApplyOptions(m.opts)
+
+	actualCondition, ok := actual.(metav1.Condition)
+	if !ok {
+		return false, fmt.Errorf("actual should be of type metav1.Condition")
+	}
+
+	ok, err = gomega.Equal(m.expected.Type).Match(actualCondition.Type)
+	if !ok {
+		return ok, err
+	}
+	ok, err = gomega.Equal(m.expected.Status).Match(actualCondition.Status)
+	if !ok {
+		return ok, err
+	}
+	ok, err = gomega.Equal(m.expected.ObservedGeneration).Match(actualCondition.ObservedGeneration)
+	if !ok {
+		return ok, err
+	}
+	ok, err = gomega.Equal(m.expected.Reason).Match(actualCondition.Reason)
+	if !ok {
+		return ok, err
+	}
+	ok, err = gomega.Equal(m.expected.Message).Match(actualCondition.Message)
+	if !ok {
+		return ok, err
+	}
+
+	if !matchOpt.ignoreLastTransitionTime {
+		ok, err = gomega.BeTemporally("==", m.expected.LastTransitionTime.Time).Match(actualCondition.LastTransitionTime.Time)
+		if !ok {
+			return ok, err
+		}
+	}
+
+	return ok, err
+}
+
+func (m matchCondition) FailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("expected\n\t%#v\nto match\n\t%#v\n", actual, m.expected)
+}
+
+func (m matchCondition) NegatedFailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("expected\n\t%#v\nto not match\n\t%#v\n", actual, m.expected)
+}

--- a/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/merge_strategies.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/merge_strategies.go
@@ -1,0 +1,646 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/gobuffalo/flect"
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+// ConditionWithOwnerInfo is a wrapper around metav1.Condition with additional ConditionOwnerInfo.
+// These infos can be used when generating the message resulting from the merge operation.
+type ConditionWithOwnerInfo struct {
+	OwnerResource ConditionOwnerInfo
+	metav1.Condition
+}
+
+// ConditionOwnerInfo contains infos about the object that owns the condition.
+type ConditionOwnerInfo struct {
+	Kind                  string
+	Name                  string
+	IsControlPlaneMachine bool
+}
+
+// String returns a string representation of the ConditionOwnerInfo.
+func (o ConditionOwnerInfo) String() string {
+	return fmt.Sprintf("%s %s", o.Kind, o.Name)
+}
+
+// MergeStrategy defines a strategy used to merge conditions during the aggregate or summary operation.
+type MergeStrategy interface {
+	// Merge passed in conditions.
+	//
+	// It is up to the caller to ensure that all the expected conditions exist (e.g. by adding new conditions with status Unknown).
+	// Conditions passed in must be of the given conditionTypes (other condition types must be discarded).
+	//
+	// The list of conditionTypes has an implicit order; it is up to the implementation of merge to use this info or not.
+	Merge(conditions []ConditionWithOwnerInfo, conditionTypes []string) (status metav1.ConditionStatus, reason, message string, err error)
+}
+
+// DefaultMergeStrategyOption is some configuration that modifies the DefaultMergeStrategy behaviour.
+type DefaultMergeStrategyOption interface {
+	// ApplyToDefaultMergeStrategy applies this configuration to the given DefaultMergeStrategy options.
+	ApplyToDefaultMergeStrategy(option *DefaultMergeStrategyOptions)
+}
+
+// DefaultMergeStrategyOptions allows to set options for the DefaultMergeStrategy behaviour.
+type DefaultMergeStrategyOptions struct {
+	getPriorityFunc                    func(condition metav1.Condition) MergePriority
+	targetConditionHasPositivePolarity bool
+	computeReasonFunc                  func(issueConditions []ConditionWithOwnerInfo, unknownConditions []ConditionWithOwnerInfo, infoConditions []ConditionWithOwnerInfo) string
+	summaryMessageTransformFunc        func([]string) []string
+}
+
+// ApplyOptions applies the given list options on these options,
+// and then returns itself (for convenient chaining).
+func (o *DefaultMergeStrategyOptions) ApplyOptions(opts []DefaultMergeStrategyOption) *DefaultMergeStrategyOptions {
+	for _, opt := range opts {
+		opt.ApplyToDefaultMergeStrategy(o)
+	}
+	return o
+}
+
+// DefaultMergeStrategy returns the default merge strategy.
+//
+// Use the GetPriorityFunc option to customize how the MergePriority for a given condition is computed.
+// If not specified, conditions are considered issues or not if not to their normal state given the polarity
+// (e.g. a positive polarity condition is considered to be reporting an issue when status is false,
+// otherwise the condition is considered to be reporting an info unless status is unknown).
+//
+// Use the TargetConditionHasPositivePolarity to define the polarity of the condition returned by the DefaultMergeStrategy.
+// If not specified, the generate condition will have positive polarity (status true = good).
+//
+// Use the ComputeReasonFunc to customize how the reason for the resulting condition will be computed.
+// If not specified, generic reasons will be used.
+func DefaultMergeStrategy(opts ...DefaultMergeStrategyOption) MergeStrategy {
+	strategyOpt := &DefaultMergeStrategyOptions{
+		targetConditionHasPositivePolarity: true,
+		computeReasonFunc:                  GetDefaultComputeMergeReasonFunc(issuesReportedReason, unknownReportedReason, infoReportedReason), // NOTE: when no specific reason are provided, generic ones are used.
+		getPriorityFunc:                    GetDefaultMergePriorityFunc(),
+		summaryMessageTransformFunc:        nil,
+	}
+	strategyOpt.ApplyOptions(opts)
+
+	return &defaultMergeStrategy{
+		getPriorityFunc:                    strategyOpt.getPriorityFunc,
+		computeReasonFunc:                  strategyOpt.computeReasonFunc,
+		targetConditionHasPositivePolarity: strategyOpt.targetConditionHasPositivePolarity,
+		summaryMessageTransformFunc:        strategyOpt.summaryMessageTransformFunc,
+	}
+}
+
+// GetDefaultMergePriorityFunc returns the merge priority for each condition.
+// It assigns following priority values to conditions:
+// - issues: conditions with positive polarity (normal True) and status False or conditions with negative polarity (normal False) and status True.
+// - unknown: conditions with status unknown.
+// - info: conditions with positive polarity (normal True) and status True or conditions with negative polarity (normal False) and status False.
+func GetDefaultMergePriorityFunc(negativePolarityConditionTypes ...string) func(condition metav1.Condition) MergePriority {
+	negativePolarityConditionTypesSet := sets.New[string](negativePolarityConditionTypes...)
+	return func(condition metav1.Condition) MergePriority {
+		switch condition.Status {
+		case metav1.ConditionTrue:
+			if negativePolarityConditionTypesSet.Has(condition.Type) {
+				return IssueMergePriority
+			}
+			return InfoMergePriority
+		case metav1.ConditionFalse:
+			if negativePolarityConditionTypesSet.Has(condition.Type) {
+				return InfoMergePriority
+			}
+			return IssueMergePriority
+		case metav1.ConditionUnknown:
+			return UnknownMergePriority
+		}
+
+		// Note: this should never happen. In case, those conditions are considered like conditions with unknown status.
+		return UnknownMergePriority
+	}
+}
+
+// MergePriority defines the priority for a condition during a merge operation.
+type MergePriority uint8
+
+const (
+	// IssueMergePriority is the merge priority used by GetDefaultMergePriority in case the condition state is considered an issue.
+	IssueMergePriority MergePriority = iota
+
+	// UnknownMergePriority is the merge priority used by GetDefaultMergePriority in case of unknown conditions.
+	UnknownMergePriority
+
+	// InfoMergePriority is the merge priority used by GetDefaultMergePriority in case the condition state is not considered an issue.
+	InfoMergePriority
+)
+
+// GetDefaultComputeMergeReasonFunc return a function picking one of the three reasons in input depending on
+// the status of the conditions being merged.
+func GetDefaultComputeMergeReasonFunc(issueReason, unknownReason, infoReason string) func(issueConditions []ConditionWithOwnerInfo, unknownConditions []ConditionWithOwnerInfo, infoConditions []ConditionWithOwnerInfo) string {
+	return func(issueConditions []ConditionWithOwnerInfo, unknownConditions []ConditionWithOwnerInfo, _ []ConditionWithOwnerInfo) string {
+		switch {
+		case len(issueConditions) > 0:
+			return issueReason
+		case len(unknownConditions) > 0:
+			return unknownReason
+		default:
+			// Note: This func can assume that there is at least one condition, so this branch is equivalent to len(infoReason) > 0,
+			// and it makes the linter happy.
+			return infoReason
+		}
+	}
+}
+
+const (
+	// issuesReportedReason is set on conditions generated during aggregate or summary operations when at least one conditions/objects are reporting issues.
+	// NOTE: This const is used by GetDefaultComputeMergeReasonFunc if no specific reasons are provided.
+	issuesReportedReason = "IssuesReported"
+
+	// unknownReportedReason is set on conditions generated during aggregate or summary operations when at least one conditions/objects are reporting unknown.
+	// NOTE: This const is used by GetDefaultComputeMergeReasonFunc if no specific reasons are provided.
+	unknownReportedReason = "UnknownReported"
+
+	// infoReportedReason is set on conditions generated during aggregate or summary operations when at least one conditions/objects are reporting info.
+	// NOTE: This const is used by GetDefaultComputeMergeReasonFunc if no specific reasons are provided.
+	infoReportedReason = "InfoReported"
+)
+
+// defaultMergeStrategy defines the default merge strategy for Cluster API conditions.
+type defaultMergeStrategy struct {
+	getPriorityFunc                    func(condition metav1.Condition) MergePriority
+	targetConditionHasPositivePolarity bool
+	computeReasonFunc                  func(issueConditions []ConditionWithOwnerInfo, unknownConditions []ConditionWithOwnerInfo, infoConditions []ConditionWithOwnerInfo) string
+	summaryMessageTransformFunc        func([]string) []string
+}
+
+// Merge all conditions in input based on a strategy that surfaces issues first, then unknown conditions, then info (if none of issues and unknown condition exists).
+// - issues: conditions with positive polarity (normal True) and status False or conditions with negative polarity (normal False) and status True.
+// - unknown: conditions with status unknown.
+// - info: conditions with positive polarity (normal True) and status True or conditions with negative polarity (normal False) and status False.
+func (d *defaultMergeStrategy) Merge(conditions []ConditionWithOwnerInfo, conditionTypes []string) (status metav1.ConditionStatus, reason, message string, err error) {
+	if len(conditions) == 0 {
+		return "", "", "", errors.New("can't merge an empty list of conditions")
+	}
+
+	if d.getPriorityFunc == nil {
+		return "", "", "", errors.New("can't merge without a getPriority func")
+	}
+
+	// Infer which operation is calling this func, so it is possible to use different strategies for computing the message for the target condition.
+	// - When merge should consider a single condition type, we can assume this func is called within an aggregate operation
+	//   (Aggregate should merge the same condition across many objects)
+	isAggregateOperation := len(conditionTypes) == 1
+
+	// - Otherwise we can assume this func is called within a summary operation
+	//   (Summary should merge different conditions from the same object)
+	isSummaryOperation := !isAggregateOperation
+
+	// sortConditions the relevance defined by the users (the order of condition types), LastTransition time (older first).
+	sortConditions(conditions, conditionTypes)
+
+	issueConditions, unknownConditions, infoConditions := splitConditionsByPriority(conditions, d.getPriorityFunc)
+
+	// Compute the status for the target condition:
+	// Note: This function always returns a condition with positive polarity.
+	// - if there are issues, use false
+	// - else if there are unknown, use unknown
+	// - else if there are info, use true
+	switch {
+	case len(issueConditions) > 0:
+		if d.targetConditionHasPositivePolarity {
+			status = metav1.ConditionFalse
+		} else {
+			status = metav1.ConditionTrue
+		}
+	case len(unknownConditions) > 0:
+		status = metav1.ConditionUnknown
+	case len(infoConditions) > 0:
+		if d.targetConditionHasPositivePolarity {
+			status = metav1.ConditionTrue
+		} else {
+			status = metav1.ConditionFalse
+		}
+	default:
+		// NOTE: this is already handled above, but repeating also here for better readability.
+		return "", "", "", errors.New("can't merge an empty list of conditions")
+	}
+
+	// Compute the reason for the target condition:
+	// - In case there is only one condition in the top group, use the reason from this condition
+	// - In case there are more than one condition in the top group, use a generic reason (for the target group)
+	reason = d.computeReasonFunc(issueConditions, unknownConditions, infoConditions)
+
+	// Compute the message for the target condition, which is optimized for the operation being performed.
+
+	// When performing the summary operation, usually we are merging a small set of conditions from the same object,
+	// Considering the small number of conditions, involved it is acceptable/preferred to provide as much detail
+	// as possible about the messages from the conditions being merged.
+	//
+	// Accordingly, the resulting message is composed by all the messages from conditions classified as issues/unknown;
+	// messages from conditions classified as info are included only if there are no issues/unknown.
+	//
+	// e.g. Condition-B (False): Message-B; Condition-!C (True): Message-!C; Condition-A (Unknown): Message-A
+	//
+	// When including messages from conditions, they are sorted by issue/unknown and by the implicit order of condition types
+	// provided by the user (it is considered as order of relevance).
+	if isSummaryOperation {
+		message = summaryMessage(conditions, d, status)
+	}
+
+	// When performing the aggregate operation, we are merging one single condition from potentially many objects.
+	// Considering the high number of conditions involved, the messages from the conditions being merged must be filtered/summarized
+	// using rules designed to surface the most important issues.
+	//
+	// Accordingly, the resulting message is composed by only three messages from conditions classified as issues/unknown;
+	// instead three messages from conditions classified as info are included only if there are no issues/unknown.
+	//
+	// Three criteria are used to pick the messages to be shown
+	// - Messages for control plane machines always go first
+	// - Messages for issues always go before messages for unknown, info messages goes last
+	// - The number of objects reporting the same message determine the order used to pick within the messages in the same bucket
+	//
+	// For each message it is reported a list of max 3 objects reporting the message; if more objects are reporting the same
+	// message, the number of those objects is surfaced.
+	//
+	// e.g. (False): Message-1 from obj0, obj1, obj2 and 2 more Objects
+	//
+	// If there are other objects - objects not included in the list above - reporting issues/unknown (or info there no issues/unknown),
+	// the number of those objects is surfaced.
+	//
+	// e.g. ...; 2 more Objects with issues; 1 more Objects with unknown status
+	//
+	if isAggregateOperation {
+		n := 3
+		messages := []string{}
+
+		// Get max n issue/unknown messages, decrement n, and track if there are other objects reporting issues/unknown not included in the messages.
+		if len(issueConditions) > 0 || len(unknownConditions) > 0 {
+			issueMessages := aggregateMessages(append(issueConditions, unknownConditions...), &n, false, d.getPriorityFunc, map[MergePriority]string{IssueMergePriority: "with other issues", UnknownMergePriority: "with status unknown"})
+			messages = append(messages, issueMessages...)
+		}
+
+		// Only if there are no issue or unknown,
+		// Get max n info messages, decrement n, and track if there are other objects reporting info not included in the messages.
+		if len(issueConditions) == 0 && len(unknownConditions) == 0 && len(infoConditions) > 0 {
+			infoMessages := aggregateMessages(infoConditions, &n, true, d.getPriorityFunc, map[MergePriority]string{InfoMergePriority: "with additional info"})
+			messages = append(messages, infoMessages...)
+		}
+
+		message = strings.Join(messages, "\n")
+	}
+
+	return status, reason, message, nil
+}
+
+// sortConditions by condition types order, LastTransitionTime
+// (the order of relevance defined by the users, the oldest first).
+func sortConditions(conditions []ConditionWithOwnerInfo, orderedConditionTypes []string) {
+	conditionOrder := make(map[string]int, len(orderedConditionTypes))
+	for i, conditionType := range orderedConditionTypes {
+		conditionOrder[conditionType] = i
+	}
+
+	sort.SliceStable(conditions, func(i, j int) bool {
+		// Sort by condition order (user defined, useful when computing summary of different conditions from the same object)
+		return conditionOrder[conditions[i].Type] < conditionOrder[conditions[j].Type] ||
+			// If same condition order, sort by last transition time (useful when computing aggregation of the same conditions from different objects)
+			(conditionOrder[conditions[i].Type] == conditionOrder[conditions[j].Type] && conditions[i].LastTransitionTime.Before(&conditions[j].LastTransitionTime))
+	})
+}
+
+// splitConditionsByPriority split conditions in 3 groups:
+// - conditions representing an issue.
+// - conditions with status unknown.
+// - conditions representing an info.
+// NOTE: The order of conditions is preserved in each group.
+func splitConditionsByPriority(conditions []ConditionWithOwnerInfo, getPriority func(condition metav1.Condition) MergePriority) (issueConditions, unknownConditions, infoConditions []ConditionWithOwnerInfo) {
+	for _, condition := range conditions {
+		switch getPriority(condition.Condition) {
+		case IssueMergePriority:
+			issueConditions = append(issueConditions, condition)
+		case UnknownMergePriority:
+			unknownConditions = append(unknownConditions, condition)
+		case InfoMergePriority:
+			infoConditions = append(infoConditions, condition)
+		}
+	}
+	return issueConditions, unknownConditions, infoConditions
+}
+
+// summaryMessage returns message for the summary operation.
+func summaryMessage(conditions []ConditionWithOwnerInfo, d *defaultMergeStrategy, status metav1.ConditionStatus) string {
+	messages := []string{}
+
+	// Note: use conditions because we want to preserve the order of relevance defined by the users (the order of condition types).
+	for _, condition := range conditions {
+		priority := d.getPriorityFunc(condition.Condition)
+		if priority == InfoMergePriority {
+			// Drop info messages when we are surfacing issues or unknown.
+			if status != metav1.ConditionTrue {
+				continue
+			}
+			// Drop info conditions with empty messages.
+			if condition.Message == "" {
+				continue
+			}
+		}
+
+		m := fmt.Sprintf("* %s:", condition.Type)
+		if condition.Message != "" {
+			m += indentIfMultiline(condition.Message)
+		} else {
+			m += fmt.Sprintf(" %s", condition.Reason)
+		}
+		messages = append(messages, m)
+	}
+
+	if d.summaryMessageTransformFunc != nil {
+		messages = d.summaryMessageTransformFunc(messages)
+	}
+
+	return strings.Join(messages, "\n")
+}
+
+// aggregateMessages returns messages for the aggregate operation.
+func aggregateMessages(conditions []ConditionWithOwnerInfo, n *int, dropEmpty bool, getPriority func(condition metav1.Condition) MergePriority, otherMessages map[MergePriority]string) (messages []string) {
+	// create a map with all the messages and the list of objects reporting the same message.
+	messageObjMap := map[string]map[string][]string{}
+	messagePriorityMap := map[string]MergePriority{}
+	messageMustGoFirst := map[string]bool{}
+	cpMachines := sets.Set[string]{}
+	for _, condition := range conditions {
+		if dropEmpty && condition.Message == "" {
+			continue
+		}
+
+		// Keep track of the message and the list of objects it applies to.
+		m := condition.Message
+		if _, ok := messageObjMap[condition.OwnerResource.Kind]; !ok {
+			messageObjMap[condition.OwnerResource.Kind] = map[string][]string{}
+		}
+		messageObjMap[condition.OwnerResource.Kind][m] = append(messageObjMap[condition.OwnerResource.Kind][m], condition.OwnerResource.Name)
+
+		// Keep track of CP machines
+		if condition.OwnerResource.IsControlPlaneMachine {
+			cpMachines.Insert(condition.OwnerResource.Name)
+		}
+
+		// Keep track of the priority of the message.
+		// In case the same message exists with different priorities, the highest according to issue/unknown/info applies.
+		currentPriority, ok := messagePriorityMap[m]
+		newPriority := getPriority(condition.Condition)
+		switch {
+		case !ok:
+			messagePriorityMap[m] = newPriority
+		case currentPriority == IssueMergePriority:
+			// No-op, issue is already the highest priority.
+		case currentPriority == UnknownMergePriority:
+			// If current priority is unknown, use new one only if higher.
+			if newPriority == IssueMergePriority {
+				messagePriorityMap[m] = newPriority
+			}
+		case currentPriority == InfoMergePriority:
+			// if current priority is info, new one can be equal or higher, use it.
+			messagePriorityMap[m] = newPriority
+		}
+
+		// Keep track if this message belongs to control plane machines, and thus it should go first.
+		// Note: it is enough that on object is a control plane machine to move the message as first.
+		first, ok := messageMustGoFirst[m]
+		if !ok || !first {
+			if condition.OwnerResource.IsControlPlaneMachine {
+				messageMustGoFirst[m] = true
+			}
+		}
+	}
+
+	// Gets the objects kind (with a stable order).
+	kinds := make([]string, 0, len(messageObjMap))
+	for kind := range messageObjMap {
+		kinds = append(kinds, kind)
+	}
+	sort.Strings(kinds)
+
+	// Aggregate messages for each object kind.
+	for _, kind := range kinds {
+		kindPlural := flect.Pluralize(kind)
+		messageObjMapForKind := messageObjMap[kind]
+
+		// compute the order of messages according to:
+		// - message should go first (e.g. it applies to a control plane machine)
+		// - message priority (e.g. first issues, then unknown)
+		// - the number of objects reporting the same message.
+		// Note: The list of object names is used as a secondary criteria to sort messages with the same number of objects.
+		messageIndex := make([]string, 0, len(messageObjMapForKind))
+		for m := range messageObjMapForKind {
+			messageIndex = append(messageIndex, m)
+		}
+
+		sort.SliceStable(messageIndex, func(i, j int) bool {
+			return sortMessage(messageIndex[i], messageIndex[j], messageMustGoFirst, messagePriorityMap, messageObjMapForKind)
+		})
+
+		// Pick the first n messages, decrement n.
+		// For each message, add up to three objects; if more add the number of the remaining objects with the same message.
+		// Count the number of objects reporting messages not included in the above.
+		// Note: we are showing up to three objects because usually control plane has 3 machines, and we want to show all issues
+		// to control plane machines if any,
+		others := map[MergePriority]int{}
+		for _, m := range messageIndex {
+			if *n == 0 {
+				others[messagePriorityMap[m]] += len(messageObjMapForKind[m])
+				continue
+			}
+
+			msg := ""
+			allObjects := messageObjMapForKind[m]
+			sort.Slice(allObjects, func(i, j int) bool {
+				return sortObj(allObjects[i], allObjects[j], cpMachines)
+			})
+			switch {
+			case len(allObjects) == 0:
+				// This should never happen, entry in the map exists only when an object reports a message.
+			case len(allObjects) == 1:
+				msg += fmt.Sprintf("* %s %s:", kind, strings.Join(allObjects, ", "))
+			case len(allObjects) <= 3:
+				msg += fmt.Sprintf("* %s %s:", kindPlural, strings.Join(allObjects, ", "))
+			default:
+				msg += fmt.Sprintf("* %s %s, ... (%d more):", kindPlural, strings.Join(allObjects[:3], ", "), len(allObjects)-3)
+			}
+			msg += indentIfMultiline(m)
+
+			messages = append(messages, msg)
+			*n--
+		}
+
+		for _, p := range []MergePriority{IssueMergePriority, UnknownMergePriority, InfoMergePriority} {
+			other, ok := others[p]
+			if !ok {
+				continue
+			}
+
+			otherMessage, ok := otherMessages[p]
+			if !ok {
+				continue
+			}
+			if other == 1 {
+				messages = append(messages, fmt.Sprintf("And %d %s %s", other, kind, otherMessage))
+			}
+			if other > 1 {
+				messages = append(messages, fmt.Sprintf("And %d %s %s", other, kindPlural, otherMessage))
+			}
+		}
+	}
+
+	return messages
+}
+
+func sortMessage(i, j string, messageMustGoFirst map[string]bool, messagePriorityMap map[string]MergePriority, messageObjMapForKind map[string][]string) bool {
+	if messageMustGoFirst[i] && !messageMustGoFirst[j] {
+		return true
+	}
+	if !messageMustGoFirst[i] && messageMustGoFirst[j] {
+		return false
+	}
+
+	if messagePriorityMap[i] < messagePriorityMap[j] {
+		return true
+	}
+	if messagePriorityMap[i] > messagePriorityMap[j] {
+		return false
+	}
+
+	if len(messageObjMapForKind[i]) > len(messageObjMapForKind[j]) {
+		return true
+	}
+	if len(messageObjMapForKind[i]) < len(messageObjMapForKind[j]) {
+		return false
+	}
+
+	return strings.Join(messageObjMapForKind[i], ",") < strings.Join(messageObjMapForKind[j], ",")
+}
+
+func sortObj(i, j string, cpMachines sets.Set[string]) bool {
+	if cpMachines.Has(i) && !cpMachines.Has(j) {
+		return true
+	}
+	if !cpMachines.Has(i) && cpMachines.Has(j) {
+		return false
+	}
+	return i < j
+}
+
+var re = regexp.MustCompile(`\s*\*\s+`)
+
+func indentIfMultiline(m string) string {
+	msg := ""
+	// If it is a multiline string or if it start with a bullet, indent the message.
+	if strings.Contains(m, "\n") || re.MatchString(m) {
+		msg += "\n"
+
+		// Split the message in lines, and add a prefix; prefix can be
+		// "  " when indenting a line starting in a bullet
+		// "  * " when indenting a line starting without a bullet (indent + add a bullet)
+		// "    " when indenting a line starting with a bullet, but other lines required adding a bullet
+		lines := strings.Split(m, "\n")
+		prefix := "  "
+		hasLinesWithoutBullet := false
+		for i := range lines {
+			if !re.MatchString(lines[i]) {
+				hasLinesWithoutBullet = true
+				break
+			}
+		}
+		for i, l := range lines {
+			prefix := prefix
+			if hasLinesWithoutBullet {
+				if !re.MatchString(lines[i]) {
+					prefix += "* "
+				} else {
+					prefix += "  "
+				}
+			}
+			lines[i] = prefix + l
+		}
+		msg += strings.Join(lines, "\n")
+	} else {
+		msg += " " + m
+	}
+	return msg
+}
+
+// getConditionsWithOwnerInfo return all the conditions from an object each one with the corresponding ConditionOwnerInfo.
+func getConditionsWithOwnerInfo(obj Getter) []ConditionWithOwnerInfo {
+	ret := make([]ConditionWithOwnerInfo, 0, 10)
+	conditions := obj.GetV1Beta2Conditions()
+	ownerInfo := getConditionOwnerInfo(obj)
+	for _, condition := range conditions {
+		ret = append(ret, ConditionWithOwnerInfo{
+			OwnerResource: ownerInfo,
+			Condition:     condition,
+		})
+	}
+	return ret
+}
+
+// getConditionOwnerInfo return the ConditionOwnerInfo for the given object.
+// Note: Given that controller runtime often does not set typeMeta for objects,
+// in case kind is missing we are falling back to the type name, which in most cases
+// is the same as kind.
+func getConditionOwnerInfo(obj any) ConditionOwnerInfo {
+	var kind, name string
+	var isControlPlaneMachine bool
+	if runtimeObject, ok := obj.(runtime.Object); ok {
+		kind = runtimeObject.GetObjectKind().GroupVersionKind().Kind
+	}
+
+	if kind == "" {
+		t := reflect.TypeOf(obj)
+		if t.Kind() == reflect.Pointer {
+			kind = t.Elem().Name()
+		} else {
+			kind = t.Name()
+		}
+	}
+
+	if objMeta, ok := obj.(objectWithNameAndLabels); ok {
+		name = objMeta.GetName()
+		if kind == "Machine" {
+			_, isControlPlaneMachine = objMeta.GetLabels()[clusterv1.MachineControlPlaneLabel]
+		}
+	}
+
+	return ConditionOwnerInfo{
+		Kind:                  kind,
+		Name:                  name,
+		IsControlPlaneMachine: isControlPlaneMachine,
+	}
+}
+
+// objectWithNameAndLabels is a subset of metav1.Object.
+type objectWithNameAndLabels interface {
+	GetName() string
+	GetLabels() map[string]string
+}

--- a/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/mirror.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/mirror.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// NotYetReportedReason is set on missing conditions generated during mirror, aggregate or summary operations.
+// Missing conditions are generated during the above operations when an expected condition does not exist on a object.
+// TODO: Move to the API package.
+const NotYetReportedReason = "NotYetReported"
+
+// MirrorOption is some configuration that modifies options for a mirror call.
+type MirrorOption interface {
+	// ApplyToMirror applies this configuration to the given mirror options.
+	ApplyToMirror(*MirrorOptions)
+}
+
+// MirrorOptions allows to set options for the mirror operation.
+type MirrorOptions struct {
+	targetConditionType string
+	fallbackStatus      metav1.ConditionStatus
+	fallbackReason      string
+	fallbackMessage     string
+}
+
+// ApplyOptions applies the given list options on these options,
+// and then returns itself (for convenient chaining).
+func (o *MirrorOptions) ApplyOptions(opts []MirrorOption) *MirrorOptions {
+	for _, opt := range opts {
+		opt.ApplyToMirror(o)
+	}
+	return o
+}
+
+// NewMirrorCondition create a mirror of the given condition from obj; if the given condition does not exist in the source obj,
+// the condition specified in the FallbackCondition is used; if this option is not set, a new condition with status Unknown
+// and reason NotYetReported is created.
+//
+// By default, the Mirror condition has the same type as the source condition, but this can be changed by using
+// the TargetConditionType option.
+func NewMirrorCondition(sourceObj Getter, sourceConditionType string, opts ...MirrorOption) *metav1.Condition {
+	condition := Get(sourceObj, sourceConditionType)
+
+	return newMirrorCondition(condition, sourceConditionType, opts)
+}
+
+func newMirrorCondition(sourceCondition *metav1.Condition, sourceConditionType string, opts []MirrorOption) *metav1.Condition {
+	mirrorOpt := &MirrorOptions{
+		targetConditionType: sourceConditionType,
+	}
+	mirrorOpt.ApplyOptions(opts)
+
+	if sourceCondition != nil {
+		return &metav1.Condition{
+			Type:   mirrorOpt.targetConditionType,
+			Status: sourceCondition.Status,
+			// NOTE: we are preserving the original transition time (when the underlying condition changed)
+			LastTransitionTime: sourceCondition.LastTransitionTime,
+			Reason:             sourceCondition.Reason,
+			Message:            sourceCondition.Message,
+			// NOTE: ObservedGeneration will be set when this condition is added to an object by calling Set
+			// (also preserving ObservedGeneration from the source object will be confusing when the mirror conditions shows up in the target object).
+		}
+	}
+
+	if mirrorOpt.fallbackStatus != "" {
+		return &metav1.Condition{
+			Type:    mirrorOpt.targetConditionType,
+			Status:  mirrorOpt.fallbackStatus,
+			Reason:  mirrorOpt.fallbackReason,
+			Message: mirrorOpt.fallbackMessage,
+			// NOTE: LastTransitionTime and ObservedGeneration will be set when this condition is added to an object by calling Set.
+		}
+	}
+
+	return &metav1.Condition{
+		Type:    mirrorOpt.targetConditionType,
+		Status:  metav1.ConditionUnknown,
+		Reason:  NotYetReportedReason,
+		Message: fmt.Sprintf("Condition %s not yet reported", sourceConditionType),
+		// NOTE: LastTransitionTime and ObservedGeneration will be set when this condition is added to an object by calling Set.
+	}
+}
+
+// SetMirrorCondition is a convenience method that calls NewMirrorCondition to create a mirror condition from the source object,
+// and then calls Set to add the new condition to the target object.
+func SetMirrorCondition(sourceObj Getter, targetObj Setter, sourceConditionType string, opts ...MirrorOption) {
+	mirrorCondition := NewMirrorCondition(sourceObj, sourceConditionType, opts...)
+	Set(targetObj, *mirrorCondition)
+}
+
+// NewMirrorConditionFromUnstructured is a convenience method create a mirror of the given condition from the unstructured source obj.
+// It combines, UnstructuredGet, NewMirrorCondition (most specifically it uses only the logic to
+// create a mirror condition).
+func NewMirrorConditionFromUnstructured(sourceObj runtime.Unstructured, sourceConditionType string, opts ...MirrorOption) (*metav1.Condition, error) {
+	condition, err := UnstructuredGet(sourceObj, sourceConditionType)
+	if err != nil {
+		return nil, err
+	}
+	return newMirrorCondition(condition, sourceConditionType, opts), nil
+}
+
+// SetMirrorConditionFromUnstructured is a convenience method that mirror of the given condition from the unstructured source obj
+// into the target object. It combines, NewMirrorConditionFromUnstructured, and Set.
+func SetMirrorConditionFromUnstructured(sourceObj runtime.Unstructured, targetObj Setter, sourceConditionType string, opts ...MirrorOption) error {
+	condition, err := NewMirrorConditionFromUnstructured(sourceObj, sourceConditionType, opts...)
+	if err != nil {
+		return err
+	}
+	Set(targetObj, *condition)
+	return nil
+}
+
+// BoolToStatus converts a bool to either metav1.ConditionTrue or metav1.ConditionFalse.
+func BoolToStatus(status bool) metav1.ConditionStatus {
+	if status {
+		return metav1.ConditionTrue
+	}
+	return metav1.ConditionFalse
+}

--- a/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/options.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/options.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+// ConditionSortFunc defines the sort order when conditions are assigned to an object.
+type ConditionSortFunc func(i, j metav1.Condition) bool
+
+// ApplyToSet applies this configuration to the given Set options.
+func (f ConditionSortFunc) ApplyToSet(opts *SetOptions) {
+	opts.conditionSortFunc = f
+}
+
+// ApplyToPatchApply applies this configuration to the given patch apply options.
+func (f ConditionSortFunc) ApplyToPatchApply(opts *PatchApplyOptions) {
+	opts.conditionSortFunc = f
+}
+
+// TargetConditionType allows to specify the type of new mirror or aggregate conditions.
+type TargetConditionType string
+
+// ApplyToMirror applies this configuration to the given mirror options.
+func (t TargetConditionType) ApplyToMirror(opts *MirrorOptions) {
+	opts.targetConditionType = string(t)
+}
+
+// ApplyToAggregate applies this configuration to the given aggregate options.
+func (t TargetConditionType) ApplyToAggregate(opts *AggregateOptions) {
+	opts.targetConditionType = string(t)
+}
+
+// FallbackCondition defines the condition that should be returned by mirror if the source condition
+// does not exist.
+type FallbackCondition struct {
+	Status  metav1.ConditionStatus
+	Reason  string
+	Message string
+}
+
+// ApplyToMirror applies this configuration to the given mirror options.
+func (f FallbackCondition) ApplyToMirror(opts *MirrorOptions) {
+	opts.fallbackStatus = f.Status
+	opts.fallbackReason = f.Reason
+	opts.fallbackMessage = f.Message
+}
+
+// ForConditionTypes allows to define the set of conditions in scope for a summary operation.
+// Please note that condition types have an implicit order that can be used by the summary operation to determine relevance of the different conditions.
+type ForConditionTypes []string
+
+// ApplyToSummary applies this configuration to the given summary options.
+func (t ForConditionTypes) ApplyToSummary(opts *SummaryOptions) {
+	opts.conditionTypes = t
+}
+
+// NegativePolarityConditionTypes allows to define polarity for some of the conditions in scope for a summary or an aggregate operation.
+type NegativePolarityConditionTypes []string
+
+// ApplyToSummary applies this configuration to the given summary options.
+func (t NegativePolarityConditionTypes) ApplyToSummary(opts *SummaryOptions) {
+	opts.negativePolarityConditionTypes = t
+}
+
+// ApplyToAggregate applies this configuration to the given aggregate options.
+func (t NegativePolarityConditionTypes) ApplyToAggregate(opts *AggregateOptions) {
+	opts.negativePolarityConditionTypes = t
+}
+
+// IgnoreTypesIfMissing allows to define conditions types that should be ignored (not defaulted to unknown) when performing a summary operation.
+type IgnoreTypesIfMissing []string
+
+// ApplyToSummary applies this configuration to the given summary options.
+func (t IgnoreTypesIfMissing) ApplyToSummary(opts *SummaryOptions) {
+	opts.ignoreTypesIfMissing = t
+}
+
+// OverrideConditions allows to override conditions read from the source object only for the scope of a summary operation.
+// The condition on the source object will preserve the original value.
+type OverrideConditions []ConditionWithOwnerInfo
+
+// ApplyToSummary applies this configuration to the given summary options.
+func (t OverrideConditions) ApplyToSummary(opts *SummaryOptions) {
+	opts.overrideConditions = t
+}
+
+// CustomMergeStrategy allows to define a custom merge strategy when creating new summary or aggregate conditions.
+type CustomMergeStrategy struct {
+	MergeStrategy
+}
+
+// ApplyToSummary applies this configuration to the given summary options.
+func (t CustomMergeStrategy) ApplyToSummary(opts *SummaryOptions) {
+	opts.mergeStrategy = t
+}
+
+// ApplyToAggregate applies this configuration to the given aggregate options.
+func (t CustomMergeStrategy) ApplyToAggregate(opts *AggregateOptions) {
+	opts.mergeStrategy = t
+}
+
+// OwnedConditionTypes allows to define condition types owned by the controller when performing patch apply.
+// In case of conflicts for the owned conditions, the patch helper will always use the value provided by the controller.
+type OwnedConditionTypes []string
+
+// ApplyToPatchApply applies this configuration to the given patch apply options.
+func (o OwnedConditionTypes) ApplyToPatchApply(opts *PatchApplyOptions) {
+	opts.ownedConditionTypes = o
+}
+
+// ForceOverwrite instructs patch apply to always use the value provided by the controller (no matter of what value exists currently).
+type ForceOverwrite bool
+
+// ApplyToPatchApply applies this configuration to the given patch apply options.
+func (f ForceOverwrite) ApplyToPatchApply(opts *PatchApplyOptions) {
+	opts.forceOverwrite = bool(f)
+}
+
+// GetPriorityFunc defines priority of a given condition when processed by the DefaultMergeStrategy.
+// Note: The return value must be one of IssueMergePriority, UnknownMergePriority, InfoMergePriority.
+type GetPriorityFunc func(condition metav1.Condition) MergePriority
+
+// ApplyToDefaultMergeStrategy applies this configuration to the given DefaultMergeStrategy options.
+func (f GetPriorityFunc) ApplyToDefaultMergeStrategy(opts *DefaultMergeStrategyOptions) {
+	opts.getPriorityFunc = f
+}
+
+// TargetConditionHasPositivePolarity defines the polarity of the condition returned by the DefaultMergeStrategy.
+type TargetConditionHasPositivePolarity bool
+
+// ApplyToDefaultMergeStrategy applies this configuration to the given DefaultMergeStrategy options.
+func (t TargetConditionHasPositivePolarity) ApplyToDefaultMergeStrategy(opts *DefaultMergeStrategyOptions) {
+	opts.targetConditionHasPositivePolarity = bool(t)
+}
+
+// ComputeReasonFunc defines a function to be used when computing the reason of the condition returned by the DefaultMergeStrategy.
+type ComputeReasonFunc func(issueConditions []ConditionWithOwnerInfo, unknownConditions []ConditionWithOwnerInfo, infoConditions []ConditionWithOwnerInfo) string
+
+// ApplyToDefaultMergeStrategy applies this configuration to the given DefaultMergeStrategy options.
+func (f ComputeReasonFunc) ApplyToDefaultMergeStrategy(opts *DefaultMergeStrategyOptions) {
+	opts.computeReasonFunc = f
+}
+
+// SummaryMessageTransformFunc defines a function to be used when computing the message for a summary condition returned by the DefaultMergeStrategy.
+type SummaryMessageTransformFunc func([]string) []string
+
+// ApplyToDefaultMergeStrategy applies this configuration to the given DefaultMergeStrategy options.
+func (f SummaryMessageTransformFunc) ApplyToDefaultMergeStrategy(opts *DefaultMergeStrategyOptions) {
+	opts.summaryMessageTransformFunc = f
+}

--- a/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/patch.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/patch.go
@@ -1,0 +1,245 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	"reflect"
+	"sort"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/cluster-api/util"
+)
+
+// Patch defines a list of operations to change a list of conditions into another.
+type Patch []PatchOperation
+
+// PatchOperation defines an operation that changes a single condition.
+type PatchOperation struct {
+	Before *metav1.Condition
+	After  *metav1.Condition
+	Op     PatchOperationType
+}
+
+// PatchOperationType defines a condition patch operation type.
+type PatchOperationType string
+
+const (
+	// AddConditionPatch defines an add condition patch operation.
+	AddConditionPatch PatchOperationType = "Add"
+
+	// ChangeConditionPatch defines an change condition patch operation.
+	ChangeConditionPatch PatchOperationType = "Change"
+
+	// RemoveConditionPatch defines a remove condition patch operation.
+	RemoveConditionPatch PatchOperationType = "Remove"
+)
+
+// NewPatch returns the Patch required to align source conditions to after conditions.
+func NewPatch(before, after Getter) (Patch, error) {
+	var patch Patch
+
+	if util.IsNil(before) {
+		return nil, errors.New("error creating patch: before object is nil")
+	}
+	beforeConditions := before.GetV1Beta2Conditions()
+
+	if util.IsNil(after) {
+		return nil, errors.New("error creating patch: after object is nil")
+	}
+	afterConditions := after.GetV1Beta2Conditions()
+
+	// Identify AddCondition and ModifyCondition changes.
+	for i := range afterConditions {
+		afterCondition := afterConditions[i]
+		beforeCondition := meta.FindStatusCondition(beforeConditions, afterCondition.Type)
+		if beforeCondition == nil {
+			patch = append(patch, PatchOperation{Op: AddConditionPatch, After: &afterCondition})
+			continue
+		}
+
+		if !reflect.DeepEqual(&afterCondition, beforeCondition) {
+			patch = append(patch, PatchOperation{Op: ChangeConditionPatch, After: &afterCondition, Before: beforeCondition})
+		}
+	}
+
+	// Identify RemoveCondition changes.
+	for i := range beforeConditions {
+		beforeCondition := beforeConditions[i]
+		afterCondition := meta.FindStatusCondition(afterConditions, beforeCondition.Type)
+		if afterCondition == nil {
+			patch = append(patch, PatchOperation{Op: RemoveConditionPatch, Before: &beforeCondition})
+		}
+	}
+	return patch, nil
+}
+
+// PatchApplyOption is some configuration that modifies options for a patch apply call.
+type PatchApplyOption interface {
+	// ApplyToPatchApply applies this configuration to the given patch apply options.
+	ApplyToPatchApply(option *PatchApplyOptions)
+}
+
+// PatchApplyOptions allows to set strategies for patch apply.
+type PatchApplyOptions struct {
+	ownedConditionTypes []string
+	forceOverwrite      bool
+	conditionSortFunc   ConditionSortFunc
+}
+
+// ApplyOptions applies the given list options on these options,
+// and then returns itself (for convenient chaining).
+func (o *PatchApplyOptions) ApplyOptions(opts []PatchApplyOption) *PatchApplyOptions {
+	for _, opt := range opts {
+		if util.IsNil(opt) {
+			continue
+		}
+		opt.ApplyToPatchApply(o)
+	}
+	return o
+}
+
+func (o *PatchApplyOptions) isOwnedConditionType(conditionType string) bool {
+	for _, i := range o.ownedConditionTypes {
+		if i == conditionType {
+			return true
+		}
+	}
+	return false
+}
+
+// Apply executes a three-way merge of a list of Patch.
+// When merge conflicts are detected (latest deviated from before in an incompatible way), an error is returned.
+func (p Patch) Apply(latest Setter, opts ...PatchApplyOption) error {
+	if p.IsZero() {
+		return nil
+	}
+
+	if util.IsNil(latest) {
+		return errors.New("error patching conditions: latest object is nil")
+	}
+	latestConditions := latest.GetV1Beta2Conditions()
+
+	applyOpt := &PatchApplyOptions{
+		// By default, sort conditions by the default condition order: available and ready always first, deleting and paused always last, all the other conditions in alphabetical order.
+		conditionSortFunc: defaultSortLessFunc,
+	}
+	applyOpt.ApplyOptions(opts)
+
+	for _, conditionPatch := range p {
+		switch conditionPatch.Op {
+		case AddConditionPatch:
+			// If the condition is owned, always keep the after value.
+			if applyOpt.forceOverwrite || applyOpt.isOwnedConditionType(conditionPatch.After.Type) {
+				setStatusCondition(&latestConditions, *conditionPatch.After)
+				continue
+			}
+
+			// If the condition is already on latest, check if latest and after agree on the change; if not, this is a conflict.
+			if latestCondition := meta.FindStatusCondition(latestConditions, conditionPatch.After.Type); latestCondition != nil {
+				// If latest and after disagree on the change, then it is a conflict
+				if !HasSameState(latestCondition, conditionPatch.After) {
+					return errors.Errorf("error patching conditions: The condition %q was modified by a different process and this caused a merge/AddCondition conflict: %v", conditionPatch.After.Type, cmp.Diff(latestCondition, conditionPatch.After))
+				}
+				// otherwise, the latest is already as intended.
+				// NOTE: We are preserving LastTransitionTime from the latest in order to avoid altering the existing value.
+				continue
+			}
+			// If the condition does not exists on the latest, add the new after condition.
+			setStatusCondition(&latestConditions, *conditionPatch.After)
+
+		case ChangeConditionPatch:
+			// If the conditions is owned, always keep the after value.
+			if applyOpt.forceOverwrite || applyOpt.isOwnedConditionType(conditionPatch.After.Type) {
+				setStatusCondition(&latestConditions, *conditionPatch.After)
+				continue
+			}
+
+			latestCondition := meta.FindStatusCondition(latestConditions, conditionPatch.After.Type)
+
+			// If the condition does not exist anymore on the latest, this is a conflict.
+			if latestCondition == nil {
+				return errors.Errorf("error patching conditions: The condition %q was deleted by a different process and this caused a merge/ChangeCondition conflict", conditionPatch.After.Type)
+			}
+
+			// If the condition on the latest is different from the base condition, check if
+			// the after state corresponds to the desired value. If not this is a conflict (unless we should ignore conflicts for this condition type).
+			if !reflect.DeepEqual(latestCondition, conditionPatch.Before) {
+				if !HasSameState(latestCondition, conditionPatch.After) {
+					return errors.Errorf("error patching conditions: The condition %q was modified by a different process and this caused a merge/ChangeCondition conflict: %v", conditionPatch.After.Type, cmp.Diff(latestCondition, conditionPatch.After))
+				}
+				// Otherwise the latest is already as intended.
+				// NOTE: We are preserving LastTransitionTime from the latest in order to avoid altering the existing value.
+				continue
+			}
+			// Otherwise apply the new after condition.
+			setStatusCondition(&latestConditions, *conditionPatch.After)
+
+		case RemoveConditionPatch:
+			// If latestConditions is nil or empty, nothing to remove.
+			if len(latestConditions) == 0 {
+				continue
+			}
+
+			// If the conditions is owned, always keep the after value (condition should be deleted).
+			if applyOpt.forceOverwrite || applyOpt.isOwnedConditionType(conditionPatch.Before.Type) {
+				meta.RemoveStatusCondition(&latestConditions, conditionPatch.Before.Type)
+				continue
+			}
+
+			// If the condition is still on the latest, check if it is changed in the meantime;
+			// if so then this is a conflict.
+			if latestCondition := meta.FindStatusCondition(latestConditions, conditionPatch.Before.Type); latestCondition != nil {
+				if !HasSameState(latestCondition, conditionPatch.Before) {
+					return errors.Errorf("error patching conditions: The condition %q was modified by a different process and this caused a merge/RemoveCondition conflict: %v", conditionPatch.Before.Type, cmp.Diff(latestCondition, conditionPatch.Before))
+				}
+			}
+			// Otherwise the latest and after agreed on the delete operation, so there's nothing to change.
+			meta.RemoveStatusCondition(&latestConditions, conditionPatch.Before.Type)
+		}
+	}
+
+	if applyOpt.conditionSortFunc != nil {
+		sort.SliceStable(latestConditions, func(i, j int) bool {
+			return applyOpt.conditionSortFunc(latestConditions[i], latestConditions[j])
+		})
+	}
+
+	latest.SetV1Beta2Conditions(latestConditions)
+	return nil
+}
+
+// IsZero returns true if the patch is nil or has no changes.
+func (p Patch) IsZero() bool {
+	if p == nil {
+		return true
+	}
+	return len(p) == 0
+}
+
+// HasSameState returns true if a condition has the same state of another; state is defined
+// by the union of following fields: Type, Status, Reason, ObservedGeneration and Message (it excludes LastTransitionTime).
+func HasSameState(i, j *metav1.Condition) bool {
+	return i.Type == j.Type &&
+		i.Status == j.Status &&
+		i.ObservedGeneration == j.ObservedGeneration &&
+		i.Reason == j.Reason &&
+		i.Message == j.Message
+}

--- a/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/setter.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/setter.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	"sort"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/cluster-api/util"
+)
+
+// Setter interface defines methods that a Cluster API object should implement in order to
+// use the conditions package for setting conditions.
+type Setter interface {
+	Getter
+
+	// SetV1Beta2Conditions sets conditions for an API object.
+	// Note: SetV1Beta2Conditions will be renamed to SetConditions in a later stage of the transition to V1Beta2.
+	SetV1Beta2Conditions([]metav1.Condition)
+}
+
+// SetOption is some configuration that modifies options for a Set request.
+type SetOption interface {
+	// ApplyToSet applies this configuration to the given Set options.
+	ApplyToSet(option *SetOptions)
+}
+
+// SetOptions allows to define options for the set operation.
+type SetOptions struct {
+	conditionSortFunc ConditionSortFunc
+}
+
+// ApplyOptions applies the given list options on these options,
+// and then returns itself (for convenient chaining).
+func (o *SetOptions) ApplyOptions(opts []SetOption) *SetOptions {
+	for _, opt := range opts {
+		opt.ApplyToSet(o)
+	}
+	return o
+}
+
+// Set a condition on the given object implementing the Setter interface; if the object is nil, the operation is a no-op.
+//
+// When setting a condition:
+// - condition.ObservedGeneration will be set to object.Metadata.Generation if targetObj is a metav1.Object.
+// - If the condition does not exist and condition.LastTransitionTime is not set, time.Now is used.
+// - If the condition already exists, condition.Status is changing and condition.LastTransitionTime is not set, time.Now is used.
+// - If the condition already exists, condition.Status is NOT changing, all the fields can be changed except for condition.LastTransitionTime.
+//
+// Additionally, Set enforces a default condition order (Available and Ready fist, everything else in alphabetical order),
+// but this can be changed by using the ConditionSortFunc option.
+//
+// Please note that Set does not support setting conditions to an unstructured object nor to API types not implementing
+// the Setter interface. Eventually, users can implement wrappers on those types implementing this interface and
+// taking care of aligning the condition format if necessary.
+func Set(targetObj Setter, condition metav1.Condition, opts ...SetOption) {
+	if util.IsNil(targetObj) {
+		return
+	}
+
+	setOpt := &SetOptions{
+		// By default, sort conditions by the default condition order: available and ready always first, deleting and paused always last, all the other conditions in alphabetical order.
+		conditionSortFunc: defaultSortLessFunc,
+	}
+	setOpt.ApplyOptions(opts)
+
+	if objMeta, ok := targetObj.(metav1.Object); ok {
+		condition.ObservedGeneration = objMeta.GetGeneration()
+	}
+
+	conditions := targetObj.GetV1Beta2Conditions()
+	if changed := setStatusCondition(&conditions, condition); !changed {
+		return
+	}
+
+	if setOpt.conditionSortFunc != nil {
+		sort.SliceStable(conditions, func(i, j int) bool {
+			return setOpt.conditionSortFunc(conditions[i], conditions[j])
+		})
+	}
+
+	targetObj.SetV1Beta2Conditions(conditions)
+}
+
+func setStatusCondition(conditions *[]metav1.Condition, condition metav1.Condition) bool {
+	// Truncate last transition time to seconds.
+	// This prevents inconsistencies from what we have in objects in memory and what Marshal/Unmarshal
+	// will do while the data is sent to/read from the API server.
+	if condition.LastTransitionTime.IsZero() {
+		condition.LastTransitionTime = metav1.Now()
+	}
+	condition.LastTransitionTime.Time = condition.LastTransitionTime.Truncate(1 * time.Second)
+	return meta.SetStatusCondition(conditions, condition)
+}
+
+// Delete deletes the condition with the given type.
+func Delete(to Setter, conditionType string) {
+	if to == nil {
+		return
+	}
+
+	conditions := to.GetV1Beta2Conditions()
+	newConditions := make([]metav1.Condition, 0, len(conditions)-1)
+	for _, condition := range conditions {
+		if condition.Type != conditionType {
+			newConditions = append(newConditions, condition)
+		}
+	}
+	to.SetV1Beta2Conditions(newConditions)
+}

--- a/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/sort.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/sort.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+var orderMap = map[string]int{}
+
+func init() {
+	for i, c := range order {
+		orderMap[c] = i
+	}
+}
+
+// defaultSortLessFunc returns true if a condition is less than another with regards to the
+// order of conditions designed for convenience of the consumer, i.e. kubectl get.
+// According to this order the Available and the Ready condition always goes first, Deleting and Paused always goes last,
+// and all the other conditions are sorted by Type.
+func defaultSortLessFunc(i, j metav1.Condition) bool {
+	fi, oki := orderMap[i.Type]
+	if !oki {
+		fi = orderMap[readinessAndAvailabilityGates]
+	}
+	fj, okj := orderMap[j.Type]
+	if !okj {
+		fj = orderMap[readinessAndAvailabilityGates]
+	}
+	return fi < fj ||
+		(fi == fj && i.Type < j.Type)
+}
+
+// The order array below leads to the following condition ordering:
+//
+// | Condition                      | Cluster | KCP | MD | MS | MP | Machine |
+// |--------------------------------|---------|-----|:---|----|----|---------|
+// | -- Availability conditions --  |         |     |    |    |    |         |
+// | Available                      | x       | x   | x  |    | x  | x       |
+// | Ready                          |         |     |    |    |    | x       |
+// | UpToDate                       |         |     |    |    |    | x       |
+// | RemoteConnectionProbe          | x       |     |    |    |    |         |
+// | BootstrapConfigReady           |         |     |    |    | x  | x       |
+// | InfrastructureReady            | x       |     |    |    | x  | x       |
+// | ControlPlaneInitialized        | x       |     |    |    |    |         |
+// | ControlPlaneAvailable          | x       |     |    |    |    |         |
+// | WorkersAvailable               | x       |     |    |    |    |         |
+// | CertificatesAvailable          |         | x   |    |    |    |         |
+// | Initialized                    |         | x   |    |    |    |         |
+// | EtcdClusterHealthy             |         | x   |    |    |    |         |
+// | ControlPlaneComponentsHealthy  |         | x   |    |    |    |         |
+// | NodeHealthy                    |         |     |    |    |    | x       |
+// | NodeReady                      |         |     |    |    |    | x       |
+// | EtcdPodHealthy                 |         |     |    |    |    | x       |
+// | EtcdMemberHealthy              |         |     |    |    |    | x       |
+// | APIServerPodHealthy            |         |     |    |    |    | x       |
+// | ControllerManagerPodHealthy    |         |     |    |    |    | x       |
+// | SchedulerPodHealthy            |         |     |    |    |    | x       |
+// | HealthCheckSucceeded           |         |     |    |    |    | x       |
+// | OwnerRemediated                |         |     |    |    |    | x       |
+// | -- Operations --               |         |     |    |    |    |         |
+// | TopologyReconciled             | x       |     |    |    |    |         |
+// | RollingOut                     | x       | x   | x  |    | x  |         |
+// | Remediating                    | x       | x   | x  | x  | x  |         |
+// | ScalingDown                    | x       | x   | x  | x  | x  |         |
+// | ScalingUp                      | x       | x   | x  | x  | x  |         |
+// | -- Aggregated from Machines -- |         |     |    |    |    |         |
+// | MachinesReady                  |         | x   | x  | x  | x  |         |
+// | ControlPlaneMachinesReady      | x       |     |    |    |    |         |
+// | WorkerMachinesReady            | x       |     |    |    |    |         |
+// | MachinesUpToDate               |         | x   | x  | x  | x  |         |
+// | ControlPlaneMachinesUpToDate   | x       |     |    |    |    |         |
+// | WorkerMachinesUpToDate         | x       |     |    |    |    |         |
+// | -- From other controllers --   |         |     |    |    |    |         |
+// | Readiness/Availability gates   | x       |     |    |    |    | x       |
+// | -- Misc --                     |         |     |    |    |    |         |
+// | Paused                         | x       | x   | x  | x  | x  | x       |
+// | Deleting                       | x       | x   | x  | x  | x  | x       |
+// .
+var order = []string{
+	clusterv1.AvailableV1Beta2Condition,
+	clusterv1.ReadyV1Beta2Condition,
+	clusterv1.MachineUpToDateV1Beta2Condition,
+	clusterv1.ClusterRemoteConnectionProbeV1Beta2Condition,
+	clusterv1.BootstrapConfigReadyV1Beta2Condition,
+	clusterv1.InfrastructureReadyV1Beta2Condition,
+	clusterv1.ClusterControlPlaneInitializedV1Beta2Condition,
+	clusterv1.ClusterControlPlaneAvailableV1Beta2Condition,
+	clusterv1.ClusterWorkersAvailableV1Beta2Condition,
+	kubeadmControlPlaneCertificatesAvailableV1Beta2Condition,
+	kubeadmControlPlaneInitializedV1Beta2Condition,
+	kubeadmControlPlaneEtcdClusterHealthyV1Beta2Condition,
+	kubeadmControlPlaneControlPlaneComponentsHealthyV1Beta2Condition,
+	clusterv1.MachineNodeHealthyV1Beta2Condition,
+	clusterv1.MachineNodeReadyV1Beta2Condition,
+	kubeadmControlPlaneMachineEtcdPodHealthyV1Beta2Condition,
+	kubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Condition,
+	kubeadmControlPlaneMachineAPIServerPodHealthyV1Beta2Condition,
+	kubeadmControlPlaneMachineControllerManagerPodHealthyV1Beta2Condition,
+	kubeadmControlPlaneMachineSchedulerPodHealthyV1Beta2Condition,
+	clusterv1.MachineHealthCheckSucceededV1Beta2Condition,
+	clusterv1.MachineOwnerRemediatedV1Beta2Condition,
+	clusterv1.ClusterTopologyReconciledV1Beta2Condition,
+	clusterv1.RollingOutV1Beta2Condition,
+	clusterv1.RemediatingV1Beta2Condition,
+	clusterv1.ScalingDownV1Beta2Condition,
+	clusterv1.ScalingUpV1Beta2Condition,
+	clusterv1.MachinesReadyV1Beta2Condition,
+	clusterv1.ClusterControlPlaneMachinesReadyV1Beta2Condition,
+	clusterv1.ClusterWorkerMachinesReadyV1Beta2Condition,
+	clusterv1.MachinesUpToDateV1Beta2Condition,
+	clusterv1.ClusterControlPlaneMachinesUpToDateV1Beta2Condition,
+	clusterv1.ClusterWorkerMachinesUpToDateV1Beta2Condition,
+	readinessAndAvailabilityGates,
+	clusterv1.PausedV1Beta2Condition,
+	clusterv1.DeletingV1Beta2Condition,
+}
+
+// Constants defining a placeholder for readiness and availability gates.
+const (
+	readinessAndAvailabilityGates = ""
+)
+
+// Constants inlined for ordering (we want to avoid importing the KCP API package).
+const (
+	kubeadmControlPlaneCertificatesAvailableV1Beta2Condition              = "CertificatesAvailable"
+	kubeadmControlPlaneInitializedV1Beta2Condition                        = "Initialized"
+	kubeadmControlPlaneEtcdClusterHealthyV1Beta2Condition                 = "EtcdClusterHealthy"
+	kubeadmControlPlaneControlPlaneComponentsHealthyV1Beta2Condition      = "ControlPlaneComponentsHealthy"
+	kubeadmControlPlaneMachineAPIServerPodHealthyV1Beta2Condition         = "APIServerPodHealthy"
+	kubeadmControlPlaneMachineControllerManagerPodHealthyV1Beta2Condition = "ControllerManagerPodHealthy"
+	kubeadmControlPlaneMachineSchedulerPodHealthyV1Beta2Condition         = "SchedulerPodHealthy"
+	kubeadmControlPlaneMachineEtcdPodHealthyV1Beta2Condition              = "EtcdPodHealthy"
+	kubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Condition           = "EtcdMemberHealthy"
+)

--- a/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/summary.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/conditions/v1beta2/summary.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// SummaryOption is some configuration that modifies options for a summary call.
+type SummaryOption interface {
+	// ApplyToSummary applies this configuration to the given summary options.
+	ApplyToSummary(*SummaryOptions)
+}
+
+// SummaryOptions allows to set options for the summary operation.
+type SummaryOptions struct {
+	mergeStrategy                  MergeStrategy
+	conditionTypes                 []string
+	negativePolarityConditionTypes []string
+	ignoreTypesIfMissing           []string
+	overrideConditions             []ConditionWithOwnerInfo
+}
+
+// ApplyOptions applies the given list options on these options,
+// and then returns itself (for convenient chaining).
+func (o *SummaryOptions) ApplyOptions(opts []SummaryOption) *SummaryOptions {
+	for _, opt := range opts {
+		opt.ApplyToSummary(o)
+	}
+	return o
+}
+
+// NewSummaryCondition creates a new condition by summarizing a set of conditions from an object; the list of
+// types of the conditions to be summarized must be provided with the ForConditionTypes option;
+// conditions types with negative polarity, should be indicated with the NegativePolarityConditionTypes option.
+//
+// If any of the condition in scope does not exist in the source object, missing conditions are considered Unknown, reason NotYetReported.
+// Use the IgnoreTypesIfMissing to exclude types from this option.
+//
+// Additionally, it is possible to inject custom merge strategies using the CustomMergeStrategy option or
+// to add a step counter to the generated message by using the StepCounter option.
+func NewSummaryCondition(sourceObj Getter, targetConditionType string, opts ...SummaryOption) (*metav1.Condition, error) {
+	summarizeOpt := &SummaryOptions{}
+	summarizeOpt.ApplyOptions(opts)
+	if summarizeOpt.mergeStrategy == nil {
+		// Note. Summary always assume the target condition type has positive polarity.
+		summarizeOpt.mergeStrategy = DefaultMergeStrategy(GetPriorityFunc(GetDefaultMergePriorityFunc(summarizeOpt.negativePolarityConditionTypes...)))
+	}
+
+	if len(summarizeOpt.conditionTypes) == 0 {
+		return nil, errors.New("option ForConditionTypes not provided or empty")
+	}
+
+	for _, conditionType := range summarizeOpt.conditionTypes {
+		if conditionType == targetConditionType {
+			return nil, errors.Errorf("option ForConditionTypes cannot include %s (target condition type)", targetConditionType)
+		}
+	}
+
+	expectedConditionTypes := sets.New[string](summarizeOpt.conditionTypes...)
+	ignoreTypesIfMissing := sets.New[string](summarizeOpt.ignoreTypesIfMissing...)
+	existingConditionTypes := sets.New[string]()
+
+	conditions := getConditionsWithOwnerInfo(sourceObj)
+
+	conditionsByType := map[string]ConditionWithOwnerInfo{}
+	for _, c := range conditions {
+		conditionsByType[c.Type] = c
+	}
+	overrideConditionsByType := map[string]ConditionWithOwnerInfo{}
+	for _, c := range summarizeOpt.overrideConditions {
+		if _, ok := overrideConditionsByType[c.Type]; ok {
+			return nil, errors.Errorf("override condition %s specified multiple times", c.Type)
+		}
+
+		overrideConditionsByType[c.Type] = c
+
+		if _, ok := conditionsByType[c.Type]; !ok {
+			return nil, errors.Errorf("override condition %s must exist in source object", c.Type)
+		}
+	}
+
+	conditionsInScope := make([]ConditionWithOwnerInfo, 0, len(expectedConditionTypes))
+	for _, condition := range conditions {
+		// Drops all the conditions not in scope for the merge operation
+		if !expectedConditionTypes.Has(condition.Type) {
+			continue
+		}
+
+		if overrideCondition, ok := overrideConditionsByType[condition.Type]; ok {
+			conditionsInScope = append(conditionsInScope, overrideCondition)
+		} else {
+			conditionsInScope = append(conditionsInScope, condition)
+		}
+
+		existingConditionTypes.Insert(condition.Type)
+	}
+
+	// Add the expected conditions which do not exist, so we are compliant with K8s guidelines
+	// (all missing conditions should be considered unknown).
+
+	diff := expectedConditionTypes.Difference(existingConditionTypes).Difference(ignoreTypesIfMissing).UnsortedList()
+	if len(diff) > 0 {
+		conditionOwner := getConditionOwnerInfo(sourceObj)
+
+		for _, c := range diff {
+			conditionsInScope = append(conditionsInScope, ConditionWithOwnerInfo{
+				OwnerResource: conditionOwner,
+				Condition: metav1.Condition{
+					Type:    c,
+					Status:  metav1.ConditionUnknown,
+					Reason:  NotYetReportedReason,
+					Message: "Condition not yet reported",
+					// NOTE: LastTransitionTime and ObservedGeneration are not relevant for merge.
+				},
+			})
+		}
+	}
+
+	if len(conditionsInScope) == 0 {
+		return nil, errors.New("summary can't be performed when the list of conditions to be summarized is empty")
+	}
+
+	status, reason, message, err := summarizeOpt.mergeStrategy.Merge(conditionsInScope, summarizeOpt.conditionTypes)
+	if err != nil {
+		return nil, err
+	}
+
+	return &metav1.Condition{
+		Type:    targetConditionType,
+		Status:  status,
+		Reason:  reason,
+		Message: message,
+		// NOTE: LastTransitionTime and ObservedGeneration will be set when this condition is added to an object by calling Set.
+	}, nil
+}
+
+// SetSummaryCondition is a convenience method that calls NewSummaryCondition to create a summary condition from the source object,
+// and then calls Set to add the new condition to the target object.
+func SetSummaryCondition(sourceObj Getter, targetObj Setter, targetConditionType string, opts ...SummaryOption) error {
+	summaryCondition, err := NewSummaryCondition(sourceObj, targetConditionType, opts...)
+	if err != nil {
+		return err
+	}
+	Set(targetObj, *summaryCondition)
+	return nil
+}


### PR DESCRIPTION
This PR adds the MAPI-CAPI migration controllers, resposible for handling the authoritativeness switching between MAPI and CAPI.