### PR TITLE
OCPCLOUD-2716: Handle Machine owner references translation between MAPI and CAPI

### DIFF
--- a/pkg/conversion/capi2mapi/machine.go
+++ b/pkg/conversion/capi2mapi/machine.go
@@ -42,11 +42,11 @@ func fromCAPIMachineToMAPIMachine(capiMachine *capiv1.Machine) (*mapiv1.Machine,
 
 	mapiMachine := &mapiv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        capiMachine.Name,
-			Namespace:   mapiNamespace,
-			Labels:      capiMachine.Labels,
-			Annotations: capiMachine.Annotations,
-			// OwnerReferences: TODO(OCPCLOUD-2716): These need to be converted so that any MachineSet owning a Machine is represented with the correct owner reference between the two APIs.
+			Name:            capiMachine.Name,
+			Namespace:       mapiNamespace,
+			Labels:          capiMachine.Labels,
+			Annotations:     capiMachine.Annotations,
+			OwnerReferences: nil, // OwnerReferences not populated here. They are added later by the machineSync controller.
 		},
 		Spec: mapiv1.MachineSpec{
 			ObjectMeta: mapiv1.ObjectMeta{
@@ -62,16 +62,12 @@ func fromCAPIMachineToMAPIMachine(capiMachine *capiv1.Machine) (*mapiv1.Machine,
 		},
 	}
 
-	if len(capiMachine.OwnerReferences) > 0 {
-		// TODO(OCPCLOUD-2716): We should support converting CAPI MachineSet ORs to MAPI MachineSet ORs. NB working out the UID will be hard.
-		errs = append(errs, field.Invalid(field.NewPath("metadata", "ownerReferences"), capiMachine.OwnerReferences, "ownerReferences are not supported"))
-	}
-
 	// Make sure the machine has a label map.
 	mapiMachine.Spec.ObjectMeta.Labels = map[string]string{}
 	setCAPIManagedNodeLabelsToMAPINodeLabels(capiMachine.Labels, mapiMachine.Spec.ObjectMeta.Labels)
 
 	// Unusued fields - Below this line are fields not used from the CAPI Machine.
+	// capiMachine.ObjectMeta.OwnerReferences - handled by the machineSync controller.
 
 	// capiMachine.Spec.ClusterName - Ignore this as it can be reconstructed from the infra object.
 	// capiMachine.Spec.Bootstrap.ConfigRef - Ignore as we use DataSecretName for the MAPI side.

--- a/pkg/conversion/capi2mapi/machineset_test.go
+++ b/pkg/conversion/capi2mapi/machineset_test.go
@@ -21,8 +21,6 @@ import (
 	capibuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/cluster-api/core/v1beta1"
 	capabuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2"
 	"github.com/openshift/cluster-capi-operator/pkg/conversion/test/matchers"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("capi2mapi MachineSet conversion", func() {
@@ -53,11 +51,6 @@ var _ = Describe("capi2mapi MachineSet conversion", func() {
 		Entry("With a Base configuration", capi2MAPIMachinesetConversionInput{
 			machineSetBuilder: capiMachineSetBase,
 			expectedErrors:    []string{},
-			expectedWarnings:  []string{},
-		}),
-		Entry("With unsupported OwnerReferences", capi2MAPIMachinesetConversionInput{
-			machineSetBuilder: capiMachineSetBase.WithOwnerReferences([]metav1.OwnerReference{{Name: "a"}}),
-			expectedErrors:    []string{"metadata.ownerReferences: Invalid value: []v1.OwnerReference{v1.OwnerReference{APIVersion:\"\", Kind:\"\", Name:\"a\", UID:\"\", Controller:(*bool)(nil), BlockOwnerDeletion:(*bool)(nil)}}: ownerReferences are not supported"},
 			expectedWarnings:  []string{},
 		}),
 	)

--- a/pkg/conversion/mapi2capi/machine_test.go
+++ b/pkg/conversion/mapi2capi/machine_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openshift/cluster-capi-operator/pkg/conversion/test/matchers"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 var _ = Describe("mapi2capi Machine conversion", func() {
@@ -71,15 +72,17 @@ var _ = Describe("mapi2capi Machine conversion", func() {
 			expectedWarnings: []string{},
 		}),
 
-		Entry("With unsupported metadata.ownerReferences set", mapi2CAPIMachineConversionInput{
+		Entry("With machineSet owner reference", mapi2CAPIMachineConversionInput{
 			infraBuilder: infraBase,
 			machineBuilder: mapiMachineBase.WithOwnerReferences([]metav1.OwnerReference{{
-				APIVersion: "v1",
-				Kind:       "Pod",
-				Name:       "test-pod",
-				UID:        "test-uid",
+				APIVersion:         "machine.openshift.io/v1beta1",
+				Kind:               "MachineSet",
+				Name:               "test-machineset",
+				UID:                "test-uid",
+				Controller:         ptr.To(true),
+				BlockOwnerDeletion: ptr.To(true),
 			}}),
-			expectedErrors:   []string{"metadata.ownerReferences: Invalid value: []v1.OwnerReference{v1.OwnerReference{APIVersion:\"v1\", Kind:\"Pod\", Name:\"test-pod\", UID:\"test-uid\", Controller:(*bool)(nil), BlockOwnerDeletion:(*bool)(nil)}}: ownerReferences are not supported"},
+			expectedErrors:   []string{},
 			expectedWarnings: []string{},
 		}),
 

--- a/pkg/conversion/mapi2capi/machineset.go
+++ b/pkg/conversion/mapi2capi/machineset.go
@@ -30,11 +30,11 @@ func fromMAPIMachineSetToCAPIMachineSet(mapiMachineSet *mapiv1.MachineSet) (*cap
 
 	capiMachineSet := &capiv1.MachineSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        mapiMachineSet.Name,
-			Namespace:   mapiMachineSet.Namespace,
-			Labels:      mapiMachineSet.Labels,
-			Annotations: mapiMachineSet.Annotations,
-			// OwnerReferences - There shouldn't be any ownerreferences on a MachineSet.
+			Name:            mapiMachineSet.Name,
+			Namespace:       mapiMachineSet.Namespace,
+			Labels:          mapiMachineSet.Labels,
+			Annotations:     mapiMachineSet.Annotations,
+			OwnerReferences: nil, // OwnerReferences not populated here. They are added later by the machineSetSync controller.
 		},
 		Spec: capiv1.MachineSetSpec{
 			Selector: mapiMachineSet.Spec.Selector,
@@ -52,12 +52,9 @@ func fromMAPIMachineSetToCAPIMachineSet(mapiMachineSet *mapiv1.MachineSet) (*cap
 		},
 	}
 
-	if len(mapiMachineSet.OwnerReferences) > 0 {
-		// TODO(OCPCLOUD-2748): Users may already have OwnerReferences on their MachineSets, where they do have them, we should work out how to translate them.
-		errs = append(errs, field.Invalid(field.NewPath("metadata", "ownerReferences"), mapiMachineSet.OwnerReferences, "ownerReferences are not supported"))
-	}
-
 	// Unused fields - Below this line are fields not used from the MAPI MachineSet.
+
+	// metadata.OwnerReferences - handled by the machineSetSync controller.
 
 	errs = append(errs, handleUnsupportedMAPIObjectMetaFields(field.NewPath("spec", "template", "metadata"), mapiMachineSet.Spec.Template.ObjectMeta)...)
 

--- a/pkg/conversion/mapi2capi/machineset_test.go
+++ b/pkg/conversion/mapi2capi/machineset_test.go
@@ -62,13 +62,6 @@ var _ = Describe("mapi2capi MachineSet conversion", func() {
 			expectedWarnings:  []string{},
 		}),
 
-		Entry("With unsupported metadata.ownerReferences set", mapi2CAPIMachinesetConversionInput{
-			infraBuilder:      infraBase,
-			machineSetBuilder: mapiMachineSetBase.WithOwnerReferences([]metav1.OwnerReference{{Name: "a"}}),
-			expectedErrors:    []string{"metadata.ownerReferences: Invalid value: []v1.OwnerReference{v1.OwnerReference{APIVersion:\"\", Kind:\"\", Name:\"a\", UID:\"\", Controller:(*bool)(nil), BlockOwnerDeletion:(*bool)(nil)}}: ownerReferences are not supported"},
-			expectedWarnings:  []string{},
-		}),
-
 		Entry("With unsupported spec.metadata.generateName set", mapi2CAPIMachinesetConversionInput{
 			machineSetBuilder: mapiMachineSetBase.WithMachineSpecObjectMeta(mapiv1.ObjectMeta{
 				GenerateName: "test-generate-",

--- a/pkg/conversion/mapi2capi/util.go
+++ b/pkg/conversion/mapi2capi/util.go
@@ -26,18 +26,16 @@ import (
 )
 
 // fromMAPIMachineToCAPIMachine translates a MAPI Machine to its Core CAPI Machine correspondent.
-//
-//nolint:funlen
 func fromMAPIMachineToCAPIMachine(mapiMachine *mapiv1beta1.Machine, apiVersion, kind string) (*capiv1.Machine, field.ErrorList) {
 	var errs field.ErrorList
 
 	capiMachine := &capiv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        mapiMachine.Name,
-			Namespace:   capiNamespace,
-			Labels:      mapiMachine.Labels,
-			Annotations: mapiMachine.Annotations,
-			// OwnerReferences: TODO(OCPCLOUD-2716): These need to be converted so that any MachineSet owning a Machine is represented with the correct owner reference between the two APIs.
+			Name:            mapiMachine.Name,
+			Namespace:       capiNamespace,
+			Labels:          mapiMachine.Labels,
+			Annotations:     mapiMachine.Annotations,
+			OwnerReferences: nil, // OwnerReferences not populated here. They are added later by the machineSync controller.
 		},
 		Spec: capiv1.MachineSpec{
 			InfrastructureRef: corev1.ObjectReference{
@@ -78,13 +76,9 @@ func fromMAPIMachineToCAPIMachine(mapiMachine *mapiv1beta1.Machine, apiVersion, 
 
 	// Unused fields - Below this line are fields not used from the MAPI Machine.
 
-	if len(mapiMachine.OwnerReferences) > 0 {
-		// TODO(OCPCLOUD-2716): We should support converting CAPI MachineSet ORs to MAPI MachineSet ORs. NB working out the UID will be hard.
-		errs = append(errs, field.Invalid(field.NewPath("metadata", "ownerReferences"), mapiMachine.OwnerReferences, "ownerReferences are not supported"))
-	}
-
 	// mapiMachine.Spec.AuthoritativeAPI - Ignore as this is part of the conversion mechanism.
 
+	// metadata.OwnerReferences - needs special handling
 	// metadata.labels - needs special handling
 	// metadata.annotations - needs special handling
 

--- a/pkg/conversion/test/fuzz/fuzz.go
+++ b/pkg/conversion/test/fuzz/fuzz.go
@@ -383,7 +383,7 @@ func ObjectMetaFuzzerFuncs(namespace string) fuzzer.FuzzerFuncs {
 				o.ManagedFields = nil
 
 				// Clear fields that are not currently supported in the conversion.
-				o.OwnerReferences = nil // TODO(OCPCLOUD-2716)
+				o.OwnerReferences = nil // Handled outside of the conversion library.
 
 				// Annotations and labels maps should be non-nil (Since the conversion initialises them).
 				if o.Annotations == nil {


### PR DESCRIPTION
This PR adds support to MachineSync and MachineSetSync controller for converting OwnerReferences in mirrored MachineSets, Machines and InfraMachines have correct ownerReferences.

