### PR TITLE
NO-JIRA: Expand CAPI to Cluster API and MAPI to Machine API

### DIFF
--- a/cmd/cluster-capi-operator/main.go
+++ b/cmd/cluster-capi-operator/main.go
@@ -107,12 +107,12 @@ func main() {
 	managedNamespace := flag.String(
 		"namespace",
 		controllers.DefaultManagedNamespace,
-		"The namespace where CAPI components will run.",
+		"The namespace where Cluster API components will run.",
 	)
 	imagesFile := flag.String(
 		"images-json",
 		defaultImagesLocation,
-		"The location of images file to use by operator for managed CAPI binaries.",
+		"The location of images file to use by operator for managed Cluster API binaries.",
 	)
 	webhookPort := flag.Int(
 		"webhook-port",

--- a/cmd/machine-api-migration/main.go
+++ b/cmd/machine-api-migration/main.go
@@ -88,12 +88,12 @@ func main() {
 	capiManagedNamespace := flag.String(
 		"capi-namespace",
 		controllers.DefaultManagedNamespace,
-		"The namespace where CAPI components will run.",
+		"The namespace where Cluster API components will run.",
 	)
 	mapiManagedNamespace := flag.String(
 		"mapi-namespace",
 		controllers.DefaultMAPIManagedNamespace,
-		"The namespace to watch for MAPI resources.",
+		"The namespace to watch for Machine API resources.",
 	)
 
 	logToStderr := flag.Bool(

--- a/e2e/aws_test.go
+++ b/e2e/aws_test.go
@@ -241,7 +241,7 @@ func getCAPICreatedInstance(awsClient *ec2.EC2, msName string) ec2.Instance {
 }
 
 func compareInstances(awsClient *ec2.EC2, mapiMsName, capiMsName string) {
-	By("Comparing instances created by MAPI and CAPI")
+	By("Comparing instances created by Machine API and Cluster API")
 	mapiEC2Instance := getMAPICreatedInstance(awsClient, mapiMsName)
 	capiEC2Instance := getCAPICreatedInstance(awsClient, capiMsName)
 
@@ -287,6 +287,6 @@ func compareInstances(awsClient *ec2.EC2, mapiMsName, capiMsName string) {
 	}
 
 	if !cmp.Equal(mapiEC2Instance, capiEC2Instance, cmpOpts...) {
-		GinkgoWriter.Print("Instances created by MAPI and CAPI are not equal\n" + cmp.Diff(mapiEC2Instance, capiEC2Instance, cmpOpts...))
+		GinkgoWriter.Print("Instances created by Machine API and Cluster API are not equal\n" + cmp.Diff(mapiEC2Instance, capiEC2Instance, cmpOpts...))
 	}
 }

--- a/pkg/controllers/capiinstaller/capi_installer_controller.go
+++ b/pkg/controllers/capiinstaller/capi_installer_controller.go
@@ -123,7 +123,7 @@ func (r *CapiInstallerController) reconcile(ctx context.Context, log logr.Logger
 
 	// Process each one of the desired providers.
 	for providerConfigMapLabelTypeVal, providerConfigMapLabelNameVal := range providerConfigMapLabels {
-		log.Info("reconciling CAPI provider", "name", providerConfigMapLabelNameVal)
+		log.Info("reconciling Cluster API provider", "name", providerConfigMapLabelNameVal)
 
 		// Get a List all the ConfigMaps matching the desired provider labels.
 		configMapList := &corev1.ConfigMapList{}
@@ -137,14 +137,14 @@ func (r *CapiInstallerController) reconcile(ctx context.Context, log logr.Logger
 				return ctrl.Result{}, fmt.Errorf("failed to set conditions for CAPI Installer controller: %w", err)
 			}
 
-			return ctrl.Result{}, fmt.Errorf("unable to list CAPI provider %q ConfigMaps: %w", providerConfigMapLabelNameVal, err)
+			return ctrl.Result{}, fmt.Errorf("unable to list Cluster API provider %q ConfigMaps: %w", providerConfigMapLabelNameVal, err)
 		}
 
 		// Extract the provider manifests stored each of the matching ConfigMaps.
 		var providerComponents []string
 
 		for _, cm := range configMapList.Items {
-			log.Info("processing CAPI provider ConfigMap", "configmapName", cm.Name, "providerType", cm.Labels[providerConfigMapLabelTypeKey],
+			log.Info("processing Cluster API provider ConfigMap", "configmapName", cm.Name, "providerType", cm.Labels[providerConfigMapLabelTypeKey],
 				"providerName", cm.Labels[providerConfigMapLabelNameKey], "providerVersion", cm.Labels[providerConfigMapLabelVersionKey])
 
 			partialComponents, err := r.extractProviderComponents(cm)
@@ -153,7 +153,7 @@ func (r *CapiInstallerController) reconcile(ctx context.Context, log logr.Logger
 					return ctrl.Result{}, fmt.Errorf("failed to set conditions for CAPI Installer controller: %w", err)
 				}
 
-				return ctrl.Result{}, fmt.Errorf("error extracting CAPI provider components from ConfigMap %q/%q: %w", cm.Namespace, cm.Name, err)
+				return ctrl.Result{}, fmt.Errorf("error extracting Cluster API provider components from ConfigMap %q/%q: %w", cm.Namespace, cm.Name, err)
 			}
 
 			providerComponents = append(providerComponents, partialComponents...)
@@ -165,10 +165,10 @@ func (r *CapiInstallerController) reconcile(ctx context.Context, log logr.Logger
 				return ctrl.Result{}, fmt.Errorf("failed to set conditions for CAPI Installer controller: %w", err)
 			}
 
-			return ctrl.Result{}, fmt.Errorf("error applying CAPI provider %q components: %w", providerConfigMapLabelNameVal, err)
+			return ctrl.Result{}, fmt.Errorf("error applying Cluster API provider %q components: %w", providerConfigMapLabelNameVal, err)
 		}
 
-		log.Info("finished reconciling CAPI provider", "name", providerConfigMapLabelNameVal)
+		log.Info("finished reconciling Cluster API provider", "name", providerConfigMapLabelNameVal)
 	}
 
 	return ctrl.Result{}, nil
@@ -201,7 +201,7 @@ func (r *CapiInstallerController) applyProviderComponents(ctx context.Context, c
 
 		obj, err := yamlToRuntimeObject(r.Scheme, deploymentManifest)
 		if err != nil {
-			return fmt.Errorf("error parsing CAPI provider deployment manifets %q: %w", d, err)
+			return fmt.Errorf("error parsing Cluster API provider deployment manifets %q: %w", d, err)
 		}
 
 		// TODO: Deployments State/Conditions should influence the overall ClusterOperator Status.
@@ -217,7 +217,7 @@ func (r *CapiInstallerController) applyProviderComponents(ctx context.Context, c
 			deployment,
 			resourcemerge.ExpectedDeploymentGeneration(deployment, nil),
 		); err != nil {
-			return fmt.Errorf("error applying CAPI provider deployment %q: %w", deployment.Name, err)
+			return fmt.Errorf("error applying Cluster API provider deployment %q: %w", deployment.Name, err)
 		}
 	}
 
@@ -225,7 +225,7 @@ func (r *CapiInstallerController) applyProviderComponents(ctx context.Context, c
 
 	for i, r := range res {
 		if r.Error != nil {
-			errs = errors.Join(errs, fmt.Errorf("error applying CAPI provider component %q at position %d: %w", r.File, i, r.Error))
+			errs = errors.Join(errs, fmt.Errorf("error applying Cluster API provider component %q at position %d: %w", r.File, i, r.Error))
 		}
 	}
 

--- a/pkg/controllers/infracluster/azure.go
+++ b/pkg/controllers/infracluster/azure.go
@@ -35,7 +35,7 @@ import (
 )
 
 var (
-	errUnableToGetAzureMAPIProviderSpec = errors.New("unable to get Azure MAPI ProviderSpec")
+	errUnableToGetAzureMAPIProviderSpec = errors.New("unable to get Azure Machine API ProviderSpec")
 	errUnableToGetAzureClientID         = errors.New("unable to get Azure Client ID")
 	errUnableToGetAzureTenantID         = errors.New("unable to get Azure Tenant ID")
 	errPlatformStatusNil                = errors.New("platform status should not be nil")
@@ -79,12 +79,12 @@ func (r *InfraClusterController) ensureAzureCluster(ctx context.Context, log log
 func getAzureMAPIProviderSpec(ctx context.Context, cl client.Client) (*mapiv1beta1.AzureMachineProviderSpec, error) {
 	rawProviderSpec, err := getRawMAPIProviderSpec(ctx, cl)
 	if err != nil {
-		return nil, fmt.Errorf("unable to obtain MAPI ProviderSpec: %w", err)
+		return nil, fmt.Errorf("unable to obtain Machine API ProviderSpec: %w", err)
 	}
 
 	providerSpec := &mapiv1beta1.AzureMachineProviderSpec{}
 	if err := yaml.Unmarshal(rawProviderSpec, providerSpec); err != nil {
-		return nil, fmt.Errorf("unable to unmarshal MAPI ProviderSpec: %w", err)
+		return nil, fmt.Errorf("unable to unmarshal Machine API ProviderSpec: %w", err)
 	}
 
 	return providerSpec, nil

--- a/pkg/controllers/infracluster/gcp.go
+++ b/pkg/controllers/infracluster/gcp.go
@@ -109,12 +109,12 @@ func (r *InfraClusterController) ensureGCPCluster(ctx context.Context, log logr.
 func getGCPMAPIProviderSpec(ctx context.Context, cl client.Client) (*mapiv1beta1.GCPMachineProviderSpec, error) {
 	rawProviderSpec, err := getRawMAPIProviderSpec(ctx, cl)
 	if err != nil {
-		return nil, fmt.Errorf("unable to obtain MAPI ProviderSpec: %w", err)
+		return nil, fmt.Errorf("unable to obtain Machine API ProviderSpec: %w", err)
 	}
 
 	providerSpec := &mapiv1beta1.GCPMachineProviderSpec{}
 	if err := yaml.Unmarshal(rawProviderSpec, providerSpec); err != nil {
-		return nil, fmt.Errorf("unable to unmarshal MAPI ProviderSpec: %w", err)
+		return nil, fmt.Errorf("unable to unmarshal Machine API ProviderSpec: %w", err)
 	}
 
 	return providerSpec, nil
@@ -126,7 +126,7 @@ func (r *InfraClusterController) getGCPProjectID(ctx context.Context) (string, e
 		// Devise GCP Project ID via MAPI providerSpec.
 		machineSpec, err := getGCPMAPIProviderSpec(ctx, r.Client)
 		if err != nil || machineSpec == nil {
-			return "", fmt.Errorf("unable to get GCP MAPI ProviderSpec: %w", err)
+			return "", fmt.Errorf("unable to get GCP Machine API ProviderSpec: %w", err)
 		}
 
 		return machineSpec.ProjectID, nil

--- a/pkg/controllers/infracluster/infracluster_controller.go
+++ b/pkg/controllers/infracluster/infracluster_controller.go
@@ -67,7 +67,7 @@ var (
 	errPlatformNotSupported        = errors.New("infrastructure platform is not supported")
 	errCouldNotDeepCopyInfraObject = errors.New("unable to create a deep copy of InfraCluster object")
 	errUnableToListMachineSets     = errors.New("unable to list MachineSets")
-	errUnableToFindMachineSets     = errors.New("unable to find any MachineSets to extract a MAPI ProviderSpec from")
+	errUnableToFindMachineSets     = errors.New("unable to find any MachineSets to extract a Machine API ProviderSpec from")
 )
 
 // InfraClusterController is a controller that manages infrastructure cluster objects.
@@ -123,7 +123,7 @@ func (r *InfraClusterController) reconcileInfraCluster(ctx context.Context, log 
 		// This means, by definition, that the object is directly managed by CAPI infrastructure providers.
 		// No action should be taken by this controller.
 		log.Info(fmt.Sprintf("InfraCluster '%s/%s' does not have the externally managed-by annotation"+
-			" - skipping as this is managed directly by the CAPI infrastructure provider",
+			" - skipping as this is managed directly by the Cluster API infrastructure provider",
 			infraCluster.GetNamespace(), infraCluster.GetName()))
 
 		return ctrl.Result{}, nil

--- a/pkg/controllers/infracluster/powervs.go
+++ b/pkg/controllers/infracluster/powervs.go
@@ -79,7 +79,7 @@ func (r *InfraClusterController) ensureIBMPowerVSCluster(ctx context.Context, lo
 
 	machineSpec, err := getPowerVSMAPIProviderSpec(ctx, r.Client)
 	if err != nil {
-		return nil, fmt.Errorf("unable to get PowerVS MAPI ProviderSpec: %w", err)
+		return nil, fmt.Errorf("unable to get PowerVS Machine API ProviderSpec: %w", err)
 	}
 
 	serviceInstance, err := getPowerVSServiceInstance(machineSpec.ServiceInstance)
@@ -125,12 +125,12 @@ func (r *InfraClusterController) ensureIBMPowerVSCluster(ctx context.Context, lo
 func getPowerVSMAPIProviderSpec(ctx context.Context, cl client.Client) (*mapiv1.PowerVSMachineProviderConfig, error) {
 	rawProviderSpec, err := getRawMAPIProviderSpec(ctx, cl)
 	if err != nil {
-		return nil, fmt.Errorf("unable to obtain MAPI ProviderSpec: %w", err)
+		return nil, fmt.Errorf("unable to obtain Machine API ProviderSpec: %w", err)
 	}
 
 	providerSpec := &mapiv1.PowerVSMachineProviderConfig{}
 	if err := yaml.Unmarshal(rawProviderSpec, providerSpec); err != nil {
-		return nil, fmt.Errorf("unable to unmarshal MAPI ProviderSpec: %w", err)
+		return nil, fmt.Errorf("unable to unmarshal Machine API ProviderSpec: %w", err)
 	}
 
 	return providerSpec, nil

--- a/pkg/controllers/infracluster/vsphere.go
+++ b/pkg/controllers/infracluster/vsphere.go
@@ -50,7 +50,7 @@ func (r *InfraClusterController) ensureVSphereCluster(ctx context.Context, log l
 
 	// First make sure the CAPI VSphere credentials secret exists.
 	if err := r.ensureVSphereSecret(ctx, vsphereServerAddr); err != nil {
-		return nil, fmt.Errorf("unable to ensure CAPI VSphere credentials secret: %w", err)
+		return nil, fmt.Errorf("unable to ensure Cluster API VSphere credentials secret: %w", err)
 	}
 
 	target := &vspherev1.VSphereCluster{ObjectMeta: metav1.ObjectMeta{
@@ -117,12 +117,12 @@ func (r *InfraClusterController) ensureVSphereCluster(ctx context.Context, log l
 func getVSphereMAPIProviderSpec(ctx context.Context, cl client.Client) (*mapiv1beta1.VSphereMachineProviderSpec, error) {
 	rawProviderSpec, err := getRawMAPIProviderSpec(ctx, cl)
 	if err != nil {
-		return nil, fmt.Errorf("unable to obtain MAPI ProviderSpec: %w", err)
+		return nil, fmt.Errorf("unable to obtain Machine API ProviderSpec: %w", err)
 	}
 
 	providerSpec := &mapiv1beta1.VSphereMachineProviderSpec{}
 	if err := yaml.Unmarshal(rawProviderSpec, providerSpec); err != nil {
-		return nil, fmt.Errorf("unable to unmarshal MAPI ProviderSpec: %w", err)
+		return nil, fmt.Errorf("unable to unmarshal Machine API ProviderSpec: %w", err)
 	}
 
 	return providerSpec, nil
@@ -138,7 +138,7 @@ func (r *InfraClusterController) ensureVSphereSecret(ctx context.Context, vspher
 	}
 
 	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(vSphereSecret), vSphereSecret); err != nil && !cerrors.IsNotFound(err) {
-		return fmt.Errorf("failed to get CAPI VSphere credentials secret: %w", err)
+		return fmt.Errorf("failed to get Cluster API VSphere credentials secret: %w", err)
 	} else if err == nil {
 		// The secret already exists.
 		return nil
@@ -155,7 +155,7 @@ func (r *InfraClusterController) ensureVSphereSecret(ctx context.Context, vspher
 	}
 
 	if err := r.Client.Create(ctx, vSphereSecret); err != nil && !cerrors.IsAlreadyExists(err) {
-		return fmt.Errorf("unable to create CAPI VSphere credentials secret: %w", err)
+		return fmt.Errorf("unable to create Cluster API VSphere credentials secret: %w", err)
 	}
 
 	return nil
@@ -190,7 +190,7 @@ func (r *InfraClusterController) getVSphereServerAddr(ctx context.Context) (stri
 		// Devise VSphere server addr via MAPI providerSpec.
 		machineSpec, err := getVSphereMAPIProviderSpec(ctx, r.Client)
 		if err != nil {
-			return "", fmt.Errorf("unable to get VSphere MAPI ProviderSpec: %w", err)
+			return "", fmt.Errorf("unable to get VSphere Machine API ProviderSpec: %w", err)
 		}
 
 		return machineSpec.Workspace.Server, nil

--- a/pkg/controllers/machinesetsync/machineset_sync_controller_test.go
+++ b/pkg/controllers/machinesetsync/machineset_sync_controller_test.go
@@ -215,7 +215,7 @@ var _ = Describe("With a running MachineSetSync controller", func() {
 								HaveField("Type", Equal(consts.SynchronizedCondition)),
 								HaveField("Status", Equal(corev1.ConditionTrue)),
 								HaveField("Reason", Equal("ResourceSynchronized")),
-								HaveField("Message", Equal("Successfully synchronized MAPI MachineSet to CAPI")),
+								HaveField("Message", Equal("Successfully synchronized Machine API MachineSet to Cluster API")),
 							))),
 					)
 				})
@@ -234,7 +234,7 @@ var _ = Describe("With a running MachineSetSync controller", func() {
 								HaveField("Type", Equal(consts.SynchronizedCondition)),
 								HaveField("Status", Equal(corev1.ConditionTrue)),
 								HaveField("Reason", Equal("ResourceSynchronized")),
-								HaveField("Message", Equal("Successfully synchronized MAPI MachineSet to CAPI")),
+								HaveField("Message", Equal("Successfully synchronized Machine API MachineSet to Cluster API")),
 							))),
 					)
 				})
@@ -380,7 +380,7 @@ var _ = Describe("With a running MachineSetSync controller", func() {
 								HaveField("Type", Equal(consts.SynchronizedCondition)),
 								HaveField("Status", Equal(corev1.ConditionTrue)),
 								HaveField("Reason", Equal("ResourceSynchronized")),
-								HaveField("Message", Equal("Successfully synchronized MAPI MachineSet to CAPI")),
+								HaveField("Message", Equal("Successfully synchronized Machine API MachineSet to Cluster API")),
 							))),
 					)
 				})
@@ -496,7 +496,7 @@ var _ = Describe("With a running MachineSetSync controller", func() {
 								HaveField("Type", Equal(consts.SynchronizedCondition)),
 								HaveField("Status", Equal(corev1.ConditionTrue)),
 								HaveField("Reason", Equal("ResourceSynchronized")),
-								HaveField("Message", Equal("Successfully synchronized MAPI MachineSet to CAPI")),
+								HaveField("Message", Equal("Successfully synchronized Machine API MachineSet to Cluster API")),
 							))),
 					)
 				})
@@ -520,7 +520,7 @@ var _ = Describe("With a running MachineSetSync controller", func() {
 								HaveField("Type", Equal(consts.SynchronizedCondition)),
 								HaveField("Status", Equal(corev1.ConditionTrue)),
 								HaveField("Reason", Equal("ResourceSynchronized")),
-								HaveField("Message", Equal("Successfully synchronized MAPI MachineSet to CAPI")),
+								HaveField("Message", Equal("Successfully synchronized Machine API MachineSet to Cluster API")),
 							))),
 					)
 				})
@@ -576,7 +576,7 @@ var _ = Describe("With a running MachineSetSync controller", func() {
 								HaveField("Type", Equal(consts.SynchronizedCondition)),
 								HaveField("Status", Equal(corev1.ConditionTrue)),
 								HaveField("Reason", Equal("ResourceSynchronized")),
-								HaveField("Message", Equal("Successfully synchronized MAPI MachineSet to CAPI")),
+								HaveField("Message", Equal("Successfully synchronized Machine API MachineSet to Cluster API")),
 							))),
 					)
 				})
@@ -702,7 +702,7 @@ var _ = Describe("applySynchronizedConditionWithPatch", func() {
 						HaveField("Type", Equal(consts.SynchronizedCondition)),
 						HaveField("Status", Equal(corev1.ConditionTrue)),
 						HaveField("Reason", Equal(consts.ReasonResourceSynchronized)),
-						HaveField("Message", Equal("Successfully synchronized MAPI MachineSet to CAPI")),
+						HaveField("Message", Equal("Successfully synchronized Machine API MachineSet to Cluster API")),
 						HaveField("Severity", Equal(machinev1beta1.ConditionSeverityNone)),
 					))),
 			)

--- a/pkg/controllers/machinesync/machine_sync_controller_test.go
+++ b/pkg/controllers/machinesync/machine_sync_controller_test.go
@@ -209,7 +209,7 @@ var _ = Describe("With a running MachineSync Reconciler", func() {
 								HaveField("Type", Equal(consts.SynchronizedCondition)),
 								HaveField("Status", Equal(corev1.ConditionTrue)),
 								HaveField("Reason", Equal("ResourceSynchronized")),
-								HaveField("Message", Equal("Successfully synchronized MAPI Machine to CAPI")),
+								HaveField("Message", Equal("Successfully synchronized Machine API Machine to Cluster API")),
 							))),
 					)
 				})
@@ -228,7 +228,7 @@ var _ = Describe("With a running MachineSync Reconciler", func() {
 								HaveField("Type", Equal(consts.SynchronizedCondition)),
 								HaveField("Status", Equal(corev1.ConditionTrue)),
 								HaveField("Reason", Equal("ResourceSynchronized")),
-								HaveField("Message", Equal("Successfully synchronized MAPI Machine to CAPI")),
+								HaveField("Message", Equal("Successfully synchronized Machine API Machine to Cluster API")),
 							))),
 					)
 				})
@@ -265,7 +265,7 @@ var _ = Describe("With a running MachineSync Reconciler", func() {
 								HaveField("Type", Equal(consts.SynchronizedCondition)),
 								HaveField("Status", Equal(corev1.ConditionTrue)),
 								HaveField("Reason", Equal("ResourceSynchronized")),
-								HaveField("Message", Equal("Successfully synchronized MAPI Machine to CAPI")),
+								HaveField("Message", Equal("Successfully synchronized Machine API Machine to Cluster API")),
 							))),
 					)
 				})
@@ -381,7 +381,7 @@ var _ = Describe("With a running MachineSync Reconciler", func() {
 								HaveField("Type", Equal(consts.SynchronizedCondition)),
 								HaveField("Status", Equal(corev1.ConditionTrue)),
 								HaveField("Reason", Equal("ResourceSynchronized")),
-								HaveField("Message", Equal("Successfully synchronized MAPI Machine to CAPI")),
+								HaveField("Message", Equal("Successfully synchronized Machine API Machine to Cluster API")),
 							))),
 					)
 				})
@@ -405,7 +405,7 @@ var _ = Describe("With a running MachineSync Reconciler", func() {
 								HaveField("Type", Equal(consts.SynchronizedCondition)),
 								HaveField("Status", Equal(corev1.ConditionTrue)),
 								HaveField("Reason", Equal("ResourceSynchronized")),
-								HaveField("Message", Equal("Successfully synchronized MAPI Machine to CAPI")),
+								HaveField("Message", Equal("Successfully synchronized Machine API Machine to Cluster API")),
 							))),
 					)
 				})
@@ -504,7 +504,7 @@ var _ = Describe("applySynchronizedConditionWithPatch", func() {
 						HaveField("Type", Equal(consts.SynchronizedCondition)),
 						HaveField("Status", Equal(corev1.ConditionUnknown)),
 						HaveField("Reason", Equal("ProgressingToCreateCAPIInfraMachine")),
-						HaveField("Message", Equal("Progressing to synchronize MAPI Machine to CAPI")),
+						HaveField("Message", Equal("Progressing to synchronize Machine API Machine to Cluster API")),
 						HaveField("Severity", Equal(machinev1beta1.ConditionSeverityInfo)),
 					))),
 			)
@@ -530,7 +530,7 @@ var _ = Describe("applySynchronizedConditionWithPatch", func() {
 						HaveField("Type", Equal(consts.SynchronizedCondition)),
 						HaveField("Status", Equal(corev1.ConditionTrue)),
 						HaveField("Reason", Equal(consts.ReasonResourceSynchronized)),
-						HaveField("Message", Equal("Successfully synchronized MAPI Machine to CAPI")),
+						HaveField("Message", Equal("Successfully synchronized Machine API Machine to Cluster API")),
 						HaveField("Severity", Equal(machinev1beta1.ConditionSeverityNone)),
 					))),
 			)

--- a/pkg/conversion/capi2mapi/powervs.go
+++ b/pkg/conversion/capi2mapi/powervs.go
@@ -230,7 +230,7 @@ func convertPowerVSNetworkToMAPI(fldPath *field.Path, network capibmv1.IBMPowerV
 		return networkResource, nil
 	}
 
-	return networkResource, field.Invalid(fldPath, network, "unable to convert network to MAPI")
+	return networkResource, field.Invalid(fldPath, network, "unable to convert network to Machine API")
 }
 
 func convertPowerVSImageToMAPI(fldPath *field.Path, image *capibmv1.IBMPowerVSResourceReference, imageRef *corev1.LocalObjectReference) (mapiv1.PowerVSResource, *field.Error) {
@@ -301,5 +301,5 @@ func convertPowerVSServiceInstanceToMAPI(fldPath *field.Path, serviceInstanceID 
 		return serviceInstanceResource, nil
 	}
 
-	return serviceInstanceResource, field.Invalid(fldPath, serviceInstance, "unable to convert service instance to MAPI")
+	return serviceInstanceResource, field.Invalid(fldPath, serviceInstance, "unable to convert service instance to Machine API")
 }

--- a/pkg/conversion/capi2mapi/powervs_test.go
+++ b/pkg/conversion/capi2mapi/powervs_test.go
@@ -147,7 +147,7 @@ var _ = Describe("capi2mapi PowerVS conversion", func() {
 				return &pvsMachine
 			},
 			powerVSCluster: powerVSCluster,
-			expectedErrors: []string{"spec.network: Invalid value: v1beta2.IBMPowerVSResourceReference{ID:(*string)(nil), Name:(*string)(nil), RegEx:(*string)(nil)}: unable to convert network to MAPI"},
+			expectedErrors: []string{"spec.network: Invalid value: v1beta2.IBMPowerVSResourceReference{ID:(*string)(nil), Name:(*string)(nil), RegEx:(*string)(nil)}: unable to convert network to Machine API"},
 		}),
 	)
 

--- a/pkg/conversion/mapi2capi/aws.go
+++ b/pkg/conversion/mapi2capi/aws.go
@@ -364,11 +364,11 @@ func awsMachineToAWSMachineTemplate(awsMachine *capav1.AWSMachine, name string, 
 
 func convertAWSAMIResourceReferenceToCAPI(fldPath *field.Path, amiRef mapiv1.AWSResourceReference) (capav1.AMIReference, *field.Error) {
 	if amiRef.ARN != nil {
-		return capav1.AMIReference{}, field.Invalid(fldPath.Child("arn"), amiRef.ARN, "unable to convert AMI ARN reference. Not supported in CAPI")
+		return capav1.AMIReference{}, field.Invalid(fldPath.Child("arn"), amiRef.ARN, "unable to convert AMI ARN reference. Not supported in Cluster API")
 	}
 
 	if len(amiRef.Filters) > 0 {
-		return capav1.AMIReference{}, field.Invalid(fldPath.Child("filters"), amiRef.Filters, "unable to convert AMI Filters reference. Not supported in CAPI")
+		return capav1.AMIReference{}, field.Invalid(fldPath.Child("filters"), amiRef.Filters, "unable to convert AMI Filters reference. Not supported in Cluster API")
 	}
 
 	if amiRef.ID != nil {

--- a/pkg/conversion/mapi2capi/aws_test.go
+++ b/pkg/conversion/mapi2capi/aws_test.go
@@ -81,8 +81,8 @@ var _ = Describe("mapi2capi AWS conversion", func() {
 	var _ = DescribeTable("mapi2capi AWS convert MAPI Machine",
 		func(in awsMAPI2CAPIConversionInput) {
 			_, _, warns, err := FromAWSMachineAndInfra(in.machineBuilder.Build(), in.infra).ToMachineAndInfrastructureMachine()
-			Expect(err).To(matchers.ConsistOfMatchErrorSubstrings(in.expectedErrors), "should match expected errors while converting an AWS MAPI Machine to CAPI")
-			Expect(warns).To(matchers.ConsistOfSubstrings(in.expectedWarnings), "should match expected warnings while converting an AWS MAPI Machine to CAPI")
+			Expect(err).To(matchers.ConsistOfMatchErrorSubstrings(in.expectedErrors), "should match expected errors while converting an AWS Machine API Machine to Cluster API")
+			Expect(warns).To(matchers.ConsistOfSubstrings(in.expectedWarnings), "should match expected warnings while converting an AWS Machine API Machine to Cluster API")
 		},
 
 		// Base Case.
@@ -139,7 +139,7 @@ var _ = Describe("mapi2capi AWS conversion", func() {
 					" ResourceVersion:\"\", Generation:0, CreationTimestamp:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), DeletionTimestamp:<nil>," +
 					" DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil)," +
 					" OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ManagedFields:[]v1.ManagedFieldsEntry(nil)}: metadata is not supported",
-				"spec.providerSpec.value.ami.arn: Invalid value: \"arn:aws:ec2:us-east-1::image/ami-1234567890abcdef0\": unable to convert AMI ARN reference. Not supported in CAPI",
+				"spec.providerSpec.value.ami.arn: Invalid value: \"arn:aws:ec2:us-east-1::image/ami-1234567890abcdef0\": unable to convert AMI ARN reference. Not supported in Cluster API",
 			},
 			expectedWarnings: []string{},
 		}),
@@ -161,7 +161,7 @@ var _ = Describe("mapi2capi AWS conversion", func() {
 			),
 			infra: infra,
 			expectedErrors: []string{
-				"spec.providerSpec.value.ami.arn: Invalid value: \"arn:aws:ec2:us-east-1::image/ami-1234567890abcdef0\": unable to convert AMI ARN reference. Not supported in CAPI",
+				"spec.providerSpec.value.ami.arn: Invalid value: \"arn:aws:ec2:us-east-1::image/ami-1234567890abcdef0\": unable to convert AMI ARN reference. Not supported in Cluster API",
 			},
 			expectedWarnings: []string{},
 		}),
@@ -173,7 +173,7 @@ var _ = Describe("mapi2capi AWS conversion", func() {
 			),
 			infra: infra,
 			expectedErrors: []string{
-				"spec.providerSpec.value.ami.filters: Invalid value: []v1beta1.Filter{v1beta1.Filter{Name:\"name\", Values:[]string{\"test\"}}}: unable to convert AMI Filters reference. Not supported in CAPI",
+				"spec.providerSpec.value.ami.filters: Invalid value: []v1beta1.Filter{v1beta1.Filter{Name:\"name\", Values:[]string{\"test\"}}}: unable to convert AMI Filters reference. Not supported in Cluster API",
 			},
 			expectedWarnings: []string{},
 		}),
@@ -323,8 +323,8 @@ var _ = Describe("mapi2capi AWS conversion", func() {
 	var _ = DescribeTable("mapi2capi AWS convert MAPI MachineSet",
 		func(in awsMAPI2CAPIMachinesetConversionInput) {
 			_, _, warns, err := FromAWSMachineSetAndInfra(in.machineSetBuilder.Build(), in.infra).ToMachineSetAndMachineTemplate()
-			Expect(err).To(matchers.ConsistOfMatchErrorSubstrings(in.expectedErrors), "should match expected errors while converting an AWS MAPI MachineSet to CAPI")
-			Expect(warns).To(matchers.ConsistOfSubstrings(in.expectedWarnings), "should match expected warnings while converting an AWS MAPI MachineSet to CAPI")
+			Expect(err).To(matchers.ConsistOfMatchErrorSubstrings(in.expectedErrors), "should match expected errors while converting an AWS Machine API MachineSet to Cluster API")
+			Expect(warns).To(matchers.ConsistOfSubstrings(in.expectedWarnings), "should match expected warnings while converting an AWS Machine API MachineSet to Cluster API")
 		},
 
 		Entry("With a Base configuration", awsMAPI2CAPIMachinesetConversionInput{

--- a/pkg/conversion/mapi2capi/machineset_test.go
+++ b/pkg/conversion/mapi2capi/machineset_test.go
@@ -49,9 +49,9 @@ var _ = Describe("mapi2capi MachineSet conversion", func() {
 				in.infraBuilder.Build(),
 			).ToMachineSetAndMachineTemplate()
 			Expect(err).To(matchers.ConsistOfMatchErrorSubstrings(in.expectedErrors),
-				"should match expected errors while converting MAPI MachineSet to CAPI MachineSet")
+				"should match expected errors while converting Machine API MachineSet to Cluster API MachineSet")
 			Expect(warns).To(matchers.ConsistOfSubstrings(in.expectedWarnings),
-				"should match expected warnings while converting MAPI MachineSet to CAPI MachineSet")
+				"should match expected warnings while converting Machine API MachineSet to Cluster API MachineSet")
 		},
 
 		// Base Case

--- a/pkg/conversion/mapi2capi/powervs_test.go
+++ b/pkg/conversion/mapi2capi/powervs_test.go
@@ -77,7 +77,7 @@ var _ = Describe("mapi2capi PowerVS conversion", func() {
 		func(in powerVSMAPI2CAPIConversionInput) {
 			_, _, _, err := FromPowerVSMachineAndInfra(in.machineBuilder.Build(), in.infra).ToMachineAndInfrastructureMachine()
 			fmt.Println(err)
-			Expect(err).To(matchers.ConsistOfMatchErrorSubstrings(in.expectedErrors), "should match expected errors while converting an PowerVS MAPI Machine to CAPI")
+			Expect(err).To(matchers.ConsistOfMatchErrorSubstrings(in.expectedErrors), "should match expected errors while converting an PowerVS Machine API Machine to Cluster API")
 
 		},
 
@@ -144,7 +144,7 @@ var _ = Describe("mapi2capi PowerVS conversion", func() {
 	var _ = DescribeTable("mapi2capi PowerVS convert MAPI MachineSet",
 		func(in powerVSMAPI2CAPIMachineSetConversionInput) {
 			_, _, _, err := FromPowerVSMachineSetAndInfra(in.machineSetBuilder.Build(), in.infra).ToMachineSetAndMachineTemplate()
-			Expect(err).To(matchers.ConsistOfMatchErrorSubstrings(in.expectedErrors), "should match expected errors while converting an PowerVS MAPI MachineSet to CAPI")
+			Expect(err).To(matchers.ConsistOfMatchErrorSubstrings(in.expectedErrors), "should match expected errors while converting an PowerVS Machine API MachineSet to Cluster API")
 		},
 
 		Entry("With a Base configuration", powerVSMAPI2CAPIMachineSetConversionInput{

--- a/pkg/util/watch_filters.go
+++ b/pkg/util/watch_filters.go
@@ -71,7 +71,7 @@ func ResolveCAPIMachineSetFromObject(namespace string) func(context.Context, cli
 				continue
 			}
 
-			klog.V(4).Info("Object is owned by a CAPI machineset, enqueueing request",
+			klog.V(4).Info("Object is owned by a Cluster API machineset, enqueueing request",
 				"machine", obj.GetName(), "machineset", ref.Name)
 
 			requests = append(requests, reconcile.Request{


### PR DESCRIPTION
Expand CAPI to Cluster API and MAPI to Machine api in user facing strings. 

This should cover all occurrences, as I have generated this using sed a manually filtered test strings that don't have to follow this convention.