### PR TITLE
TRT-2048: Revert "OCPCLOUD-2792: corecluster: set controller level conditions + tests"

### DIFF
--- a/pkg/controllers/capiinstaller/capi_installer_controller.go
+++ b/pkg/controllers/capiinstaller/capi_installer_controller.go
@@ -286,7 +286,7 @@ func (r *CapiInstallerController) setAvailableCondition(ctx context.Context, log
 
 	log.V(2).Info("CAPI Installer Controller is Available")
 
-	if err := r.SyncStatus(ctx, controllerName, co, conds); err != nil {
+	if err := r.SyncStatus(ctx, co, conds); err != nil {
 		return fmt.Errorf("failed to sync status: %w", err)
 	}
 
@@ -311,7 +311,7 @@ func (r *CapiInstallerController) setDegradedCondition(ctx context.Context, log 
 
 	log.Info("CAPI Installer Controller is Degraded")
 
-	if err := r.SyncStatus(ctx, controllerName, co, conds); err != nil {
+	if err := r.SyncStatus(ctx, co, conds); err != nil {
 		return fmt.Errorf("failed to sync status: %w", err)
 	}
 

--- a/pkg/controllers/clusteroperator/clusteroperator_controller.go
+++ b/pkg/controllers/clusteroperator/clusteroperator_controller.go
@@ -54,11 +54,6 @@ func (r *ClusterOperatorController) Reconcile(ctx context.Context, req ctrl.Requ
 	} else {
 		// TODO: wrap this into status aggregation logic to get these conditions conform,
 		// to the meaningful aggregation of all the other controllers ones.
-		//
-		// TODO: set a time period where if one of the controllers conditions has been degraded=true (reduced QoS)
-		// for an extended period of time (eg. 30mins, degrade top level) we set the overall operator degraded=true.
-		// For any controller available=false condition instead (e.g. when the CAPI components are failing to run),
-		// we should immediately set the overall operator available=false immediately.
 		if err := r.ClusterOperatorStatusClient.SetStatusAvailable(ctx, ""); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to set conditions for %q ClusterObject: %w", controllers.ClusterOperatorName, err)
 		}

--- a/pkg/controllers/infracluster/infracluster_controller.go
+++ b/pkg/controllers/infracluster/infracluster_controller.go
@@ -245,7 +245,7 @@ func (r *InfraClusterController) setAvailableCondition(ctx context.Context, log 
 
 	log.V(2).Info("InfraCluster Controller is Available")
 
-	if err := r.SyncStatus(ctx, controllerName, co, conds); err != nil {
+	if err := r.SyncStatus(ctx, co, conds); err != nil {
 		return fmt.Errorf("failed to sync status: %w", err)
 	}
 

--- a/pkg/controllers/secretsync/secret_sync_controller.go
+++ b/pkg/controllers/secretsync/secret_sync_controller.go
@@ -203,7 +203,7 @@ func (r *UserDataSecretController) setAvailableCondition(ctx context.Context, lo
 
 	log.Info("user Data Secret Controller is available")
 
-	if err := r.SyncStatus(ctx, controllerName, co, conds); err != nil {
+	if err := r.SyncStatus(ctx, co, conds); err != nil {
 		return fmt.Errorf("failed to sync status: %w", err)
 	}
 
@@ -227,7 +227,7 @@ func (r *UserDataSecretController) setDegradedCondition(ctx context.Context, log
 
 	log.Info("user Data Secret Controller is degraded")
 
-	if err := r.SyncStatus(ctx, controllerName, co, conds); err != nil {
+	if err := r.SyncStatus(ctx, co, conds); err != nil {
 		return fmt.Errorf("failed to sync status: %w", err)
 	}
 

--- a/pkg/operatorstatus/operator_status.go
+++ b/pkg/operatorstatus/operator_status.go
@@ -30,9 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	configv1 "github.com/openshift/api/config/v1"
-	configv1applyconfigs "github.com/openshift/client-go/config/applyconfigurations/config/v1"
 	"github.com/openshift/cluster-capi-operator/pkg/controllers"
-	"github.com/openshift/cluster-capi-operator/pkg/util"
 	"github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
 )
 
@@ -82,7 +80,7 @@ func (r *ClusterOperatorStatusClient) SetStatusAvailable(ctx context.Context, av
 
 	if co, shouldUpdate := clusterObjectNeedsUpdating(co, conds, r.operandVersions(), r.relatedObjects()); shouldUpdate {
 		log.V(2).Info("syncing status: available")
-		return r.SyncStatus(ctx, "cluster-operator-status-client", co, conds)
+		return r.SyncStatus(ctx, co, conds)
 	}
 
 	return nil
@@ -111,7 +109,8 @@ func (r *ClusterOperatorStatusClient) SetStatusDegraded(ctx context.Context, rec
 	}
 
 	conds := []configv1.ClusterOperatorStatusCondition{
-		NewClusterOperatorStatusCondition(configv1.OperatorDegraded, configv1.ConditionTrue, ReasonSyncFailed, message),
+		NewClusterOperatorStatusCondition(configv1.OperatorDegraded, configv1.ConditionTrue,
+			ReasonSyncFailed, message),
 		NewClusterOperatorStatusCondition(configv1.OperatorUpgradeable, configv1.ConditionFalse, ReasonAsExpected, ""),
 	}
 
@@ -121,7 +120,7 @@ func (r *ClusterOperatorStatusClient) SetStatusDegraded(ctx context.Context, rec
 			r.Recorder.Eventf(co, corev1.EventTypeWarning, "Status degraded", reconcileErr.Error())
 			log.V(2).Info("syncing status: degraded", "message", message)
 
-			return r.SyncStatus(ctx, "cluster-operator-status-client", co, conds)
+			return r.SyncStatus(ctx, co, conds)
 		}
 	}
 
@@ -158,88 +157,14 @@ func (r *ClusterOperatorStatusClient) GetOrCreateClusterOperator(ctx context.Con
 	return co, nil
 }
 
-// SyncControllerConditions syncs the controller conditions to the ClusterOperator object status.
-func (r *ClusterOperatorStatusClient) SyncControllerConditions(ctx context.Context, co *configv1.ClusterOperator, controllerName string, conditions *[]configv1.ClusterOperatorStatusCondition, expectedConditionTypes []string) error {
-	// Mark the conditions not present as Unknown.
-	for _, v := range getMissingConditionTypes(conditions, expectedConditionTypes) {
-		co.Status.Conditions = append(co.Status.Conditions, NewClusterOperatorStatusCondition(configv1.ClusterStatusConditionType(v), configv1.ConditionUnknown, "Unknown", ""))
+// SyncStatus applies the new condition to the ClusterOperator object.
+func (r *ClusterOperatorStatusClient) SyncStatus(ctx context.Context, co *configv1.ClusterOperator, conds []configv1.ClusterOperatorStatusCondition) error {
+	for _, c := range conds {
+		v1helpers.SetStatusCondition(&co.Status.Conditions, c)
 	}
 
-	if err := r.SyncStatus(ctx, controllerName, co, *conditions); err != nil {
-		return fmt.Errorf("failed to sync cluster operator status: %w", err)
-	}
-
-	return nil
-}
-
-func getMissingConditionTypes(conditions *[]configv1.ClusterOperatorStatusCondition, expectedConditionTypes []string) []string {
-	missing := []string{}
-
-	for _, e := range expectedConditionTypes {
-		found := false
-
-		for _, c := range *conditions {
-			if c.Type == configv1.ClusterStatusConditionType(e) {
-				found = true
-				break
-			}
-		}
-
-		if !found {
-			missing = append(missing, e)
-		}
-	}
-
-	return missing
-}
-
-// SyncStatus syncs the updated status to the ClusterOperator object.
-func (r *ClusterOperatorStatusClient) SyncStatus(ctx context.Context, fieldOwner string, co *configv1.ClusterOperator, conds []configv1.ClusterOperatorStatusCondition) error {
-	// Convert conditions to applyConfig ones.
-	conditionsAc := make([]*configv1applyconfigs.ClusterOperatorStatusConditionApplyConfiguration, len(conds))
-	for i, c := range conds {
-		conditionsAc[i] = configv1applyconfigs.
-			ClusterOperatorStatusCondition().
-			WithType(c.Type).
-			WithStatus(c.Status).
-			WithReason(c.Reason).
-			WithMessage(c.Message).
-			WithLastTransitionTime(c.LastTransitionTime)
-	}
-
-	// Convert OperatorVersion to applyConfig.
-	versionsAc := make([]*configv1applyconfigs.OperandVersionApplyConfiguration, len(co.Status.Versions))
-	for i, v := range co.Status.Versions {
-		versionsAc[i] = &configv1applyconfigs.OperandVersionApplyConfiguration{
-			Name:    &v.Name,
-			Version: &v.Version,
-		}
-	}
-
-	// Convert RelatedObjects to applyConfig.
-	relatedObjectsAc := make([]*configv1applyconfigs.ObjectReferenceApplyConfiguration, len(co.Status.RelatedObjects))
-	for i, o := range co.Status.RelatedObjects {
-		relatedObjectsAc[i] = &configv1applyconfigs.ObjectReferenceApplyConfiguration{
-			Group:     &o.Group,
-			Name:      &o.Name,
-			Namespace: &o.Namespace,
-			Resource:  &o.Resource,
-		}
-	}
-
-	// Define the applyConfig to use as a patch.
-	coAc := configv1applyconfigs.
-		ClusterOperator(co.Name).
-		WithStatus(
-			configv1applyconfigs.ClusterOperatorStatus().
-				WithConditions(conditionsAc...).
-				WithRelatedObjects(relatedObjectsAc...).
-				WithVersions(versionsAc...),
-		)
-
-	// Apply the patch using ServerSideApply.
-	if err := r.Status().Patch(ctx, co, util.ApplyConfigPatch(coAc), client.ForceOwnership, client.FieldOwner(fieldOwner)); err != nil {
-		return fmt.Errorf("failed to patch cluster operator status with conditions: %w", err)
+	if err := r.Client.Status().Update(ctx, co); err != nil {
+		return fmt.Errorf("failed to update cluster operator status: %w", err)
 	}
 
 	return nil
@@ -273,35 +198,6 @@ func NewClusterOperatorStatusCondition(conditionType configv1.ClusterStatusCondi
 	}
 }
 
-// SetCondition updates or appends a condition to the conditions slice.
-// If the condition doesn't exist, it will be appended as a new entry,
-// otherwise if a condition of the same type already exists, it will be updated.
-// It also handles the condition LastTransitionTime.
-func SetCondition(conditions *[]configv1.ClusterOperatorStatusCondition, conditionType configv1.ClusterStatusConditionType,
-	conditionStatus configv1.ConditionStatus, reason string, message string) {
-	newCond := NewClusterOperatorStatusCondition(conditionType, conditionStatus, reason, message)
-
-	// Try to find and update existing condition.
-	for i := range *conditions {
-		if (*conditions)[i].Type == newCond.Type {
-			// The condition already exists.
-			if (*conditions)[i].Status == newCond.Status {
-				// The condition status hasn't changed, retain the previous lastTransitionTime.
-				newCond.LastTransitionTime = (*conditions)[i].LastTransitionTime
-			}
-
-			// Override the existing condition with the new one.
-			(*conditions)[i] = newCond
-
-			// Return early as we found and updated the condition in the slice.
-			return
-		}
-	}
-
-	// If we get here, condition wasn't found, so append it.
-	*conditions = append(*conditions, newCond)
-}
-
 func printOperandVersions(versions []configv1.OperandVersion) string {
 	versionsOutput := []string{}
 	for _, operand := range versions {
@@ -331,19 +227,4 @@ func clusterObjectNeedsUpdating(co *configv1.ClusterOperator, conds []configv1.C
 	}
 
 	return co, shouldUpdate
-}
-
-// FilterOwnedConditions returns filters the list of provided conditions based on whether they have an expected condition type.
-func FilterOwnedConditions(conditions []configv1.ClusterOperatorStatusCondition, expectedConditionTypes []string) *[]configv1.ClusterOperatorStatusCondition {
-	filtered := []configv1.ClusterOperatorStatusCondition{}
-
-	for _, e := range expectedConditionTypes {
-		for _, c := range conditions {
-			if c.Type == configv1.ClusterStatusConditionType(e) {
-				filtered = append(filtered, c)
-			}
-		}
-	}
-
-	return &filtered
 }

--- a/pkg/operatorstatus/operator_status.go
+++ b/pkg/operatorstatus/operator_status.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/clock"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -160,7 +161,7 @@ func (r *ClusterOperatorStatusClient) GetOrCreateClusterOperator(ctx context.Con
 // SyncStatus applies the new condition to the ClusterOperator object.
 func (r *ClusterOperatorStatusClient) SyncStatus(ctx context.Context, co *configv1.ClusterOperator, conds []configv1.ClusterOperatorStatusCondition) error {
 	for _, c := range conds {
-		v1helpers.SetStatusCondition(&co.Status.Conditions, c)
+		v1helpers.SetStatusCondition(&co.Status.Conditions, c, clock.RealClock{})
 	}
 
 	if err := r.Client.Status().Update(ctx, co); err != nil {


### PR DESCRIPTION
Reverts openshift/cluster-capi-operator#256; tracked by https://issues.redhat.com/browse/OCPBUGS-52848

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

This PR has caused samples operator to fail during installation starting from this payload: https://sippy.dptools.openshift.org/sippy-ng/release/4.19/tags/4.19.0-0.nightly-2025-03-05-232901/pull_requests

Slack thread: https://redhat-internal.slack.com/archives/C01CQA76KMX/p1741634385702679

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of (job/X or job/X, test/Y tuple) to confirm the fix has corrected the problem:

/payload-job periodic-ci-openshift-release-master-ci-4.19-e2e-gcp-ovn-techpreview-serial

CC: @damdo 