### PR TITLE
NO-JIRA: Update version variable in generate-ocp-manifests hook script

### DIFF
--- a/hack/rebasebot-hook-scripts/generate-ocp-manifests.sh
+++ b/hack/rebasebot-hook-scripts/generate-ocp-manifests.sh
@@ -29,8 +29,8 @@ main(){
         exit 1
     fi
 
-    # Remove the leading 'v' from REBASEBOT_SOURCE
-    export PROVIDER_VERSION="${REBASEBOT_SOURCE#v}"
+    # Set PROVIDER_VERSION using the REBASEBOT_SOURCE tag, which corresponds to the provider's version number  
+    export PROVIDER_VERSION="${REBASEBOT_SOURCE}"
 
     pushd openshift
     make ocp-manifests


### PR DESCRIPTION
When writing this script, I thought the version should be passed without the leading 'v'. 

This was a mistake introduced in Azure provider manifest-gen tooling. All other platforms use the version directly with the leading 'v'.

This change is safe as there is nothing using the version tag, and we are on tech preview.