### PR TITLE
OCPCLOUD-2648: Machine sync controller deletion logic

### DIFF
--- a/pkg/controllers/machinemigration/machine_migration_controller.go
+++ b/pkg/controllers/machinemigration/machine_migration_controller.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
@@ -89,8 +90,11 @@ func (r *MachineMigrationReconciler) Reconcile(ctx context.Context, req reconcil
 	defer logger.V(1).Info("Finished reconciling machine")
 
 	mapiMachine := &machinev1beta1.Machine{}
-	if err := r.Get(ctx, client.ObjectKey{Namespace: req.Namespace, Name: req.Name}, mapiMachine); err != nil {
+	if err := r.Get(ctx, client.ObjectKey{Namespace: req.Namespace, Name: req.Name}, mapiMachine); err != nil && !apierrors.IsNotFound(err) {
 		return ctrl.Result{}, fmt.Errorf("failed to get MAPI machine: %w", err)
+	} else if apierrors.IsNotFound(err) {
+		logger.Info("Machine has been deleted. Migration not required")
+		return ctrl.Result{}, nil
 	}
 
 	if mapiMachine.Spec.AuthoritativeAPI == mapiMachine.Status.AuthoritativeAPI {

--- a/pkg/controllers/machinesync/machine_sync_controller.go
+++ b/pkg/controllers/machinesync/machine_sync_controller.go
@@ -70,17 +70,20 @@ const (
 	reasonFailedToUpdateMAPIMachine           = "FailedToUpdateMAPIMachine"
 	reasonProgressingToCreateCAPIInfraMachine = "ProgressingToCreateCAPIInfraMachine"
 
-	capiNamespace  string = "openshift-cluster-api"
-	machineKind    string = "Machine"
-	machineSetKind string = "MachineSet"
-	cpmsKind       string = "ControlPlaneMachineSet"
-	controllerName string = "MachineSyncController"
-	mapiNamespace  string = "openshift-machine-api"
+	capiNamespace                  string = "openshift-cluster-api"
+	machineKind                    string = "Machine"
+	machineSetKind                 string = "MachineSet"
+	cpmsKind                       string = "ControlPlaneMachineSet"
+	controllerName                 string = "MachineSyncController"
+	mapiNamespace                  string = "openshift-machine-api"
+	capiInfraCommonFinalizerSuffix string = ".cluster.x-k8s.io"
 
 	messageSuccessfullySynchronizedCAPItoMAPI = "Successfully synchronized CAPI Machine to MAPI"
 	messageSuccessfullySynchronizedMAPItoCAPI = "Successfully synchronized MAPI Machine to CAPI"
 	progressingToSynchronizeMAPItoCAPI        = "Progressing to synchronize MAPI Machine to CAPI"
 
+	// SyncFinalizer is the finalizer set to coordinate deletion of mirrored
+	// resources.
 	SyncFinalizer = "sync.machine.openshift.io/finalizer"
 )
 
@@ -114,7 +117,6 @@ var (
 
 	// errUnsupportedCPMSOwnedMachineConversion is returned when attempting to convert ControlPlaneMachineSet owned machines.
 	errUnsupportedCPMSOwnedMachineConversion = errors.New("conversion of control plane machines owned by control plane machine set is currently not supported")
-	errUnableToAssertClientObject            = errors.New("unable to assert client.Object after deepcopy")
 )
 
 // MachineSyncReconciler reconciles CAPI and MAPI machines.
@@ -255,7 +257,7 @@ func (r *MachineSyncReconciler) Reconcile(ctx context.Context, req reconcile.Req
 
 // reconcileCAPIMachinetoMAPIMachine reconciles a CAPI Machine to a MAPI Machine.
 //
-//nolint:gocognit,funlen
+//nolint:gocognit,funlen, cyclop
 func (r *MachineSyncReconciler) reconcileCAPIMachinetoMAPIMachine(ctx context.Context, capiMachine *capiv1beta1.Machine, mapiMachine *machinev1beta1.Machine) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
@@ -268,6 +270,35 @@ func (r *MachineSyncReconciler) reconcileCAPIMachinetoMAPIMachine(ctx context.Co
 		}
 
 		return ctrl.Result{}, errCAPIMachineNotFound
+	}
+
+	infraCluster, infraMachine, err := r.fetchCAPIInfraResources(ctx, capiMachine)
+	if err != nil {
+		fetchErr := fmt.Errorf("failed to fetch Cluster API infra resources: %w", err)
+
+		if mapiMachine == nil {
+			r.Recorder.Event(capiMachine, corev1.EventTypeWarning, "SynchronizationWarning", fetchErr.Error())
+			return ctrl.Result{}, fetchErr
+		}
+
+		if condErr := r.applySynchronizedConditionWithPatch(
+			ctx, mapiMachine, corev1.ConditionFalse, reasonFailedToGetCAPIInfraResources, fetchErr.Error(), nil); condErr != nil {
+			return ctrl.Result{}, utilerrors.NewAggregate([]error{fetchErr, condErr})
+		}
+
+		return ctrl.Result{}, fetchErr
+	}
+
+	if shouldRequeue, err := r.reconcileCAPItoMAPIMachineDeletion(ctx, capiMachine, infraMachine, mapiMachine); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to reconcile Cluster API to Machine API machine deletion: %w", err)
+	} else if shouldRequeue {
+		return ctrl.Result{}, nil
+	}
+
+	if shouldRequeue, err := r.ensureSyncFinalizer(ctx, mapiMachine, capiMachine, infraMachine); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to ensure sync finalizer: %w", err)
+	} else if shouldRequeue {
+		return ctrl.Result{}, nil
 	}
 
 	newMAPIOwnerReferences, err := r.convertCAPIMachineOwnerReferencesToMAPI(ctx, capiMachine)
@@ -287,23 +318,6 @@ func (r *MachineSyncReconciler) reconcileCAPIMachinetoMAPIMachine(ctx context.Co
 		}
 
 		return ctrl.Result{}, fmt.Errorf("failed to convert Cluster API machine owner references to Machine API: %w", err)
-	}
-
-	infraCluster, infraMachine, err := r.fetchCAPIInfraResources(ctx, capiMachine)
-	if err != nil {
-		fetchErr := fmt.Errorf("failed to fetch Cluster API infra resources: %w", err)
-
-		if mapiMachine == nil {
-			r.Recorder.Event(capiMachine, corev1.EventTypeWarning, "SynchronizationWarning", fetchErr.Error())
-			return ctrl.Result{}, fetchErr
-		}
-
-		if condErr := r.applySynchronizedConditionWithPatch(
-			ctx, mapiMachine, corev1.ConditionFalse, reasonFailedToGetCAPIInfraResources, fetchErr.Error(), nil); condErr != nil {
-			return ctrl.Result{}, utilerrors.NewAggregate([]error{fetchErr, condErr})
-		}
-
-		return ctrl.Result{}, fetchErr
 	}
 
 	newMapiMachine, warns, err := r.convertCAPIToMAPIMachine(capiMachine, infraMachine, infraCluster)
@@ -365,14 +379,15 @@ func (r *MachineSyncReconciler) reconcileCAPIMachinetoMAPIMachine(ctx context.Co
 
 // reconcileMAPIMachinetoCAPIMachine a MAPI Machine to a CAPI Machine.
 //
-// it assumes the mapiMachine passed is not nil, as the switch above currently enforces this.
+// it assumes the mapiMachine passed is not nil, as the switch above currently
+// enforces this.
 //
-//nolint:funlen
+//nolint:funlen, cyclop
 func (r *MachineSyncReconciler) reconcileMAPIMachinetoCAPIMachine(ctx context.Context, mapiMachine *machinev1beta1.Machine, capiMachine *capiv1beta1.Machine) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
 	_, infraMachine, err := r.fetchCAPIInfraResources(ctx, capiMachine)
-	if err != nil && !apierrors.IsNotFound(err) {
+	if err != nil {
 		fetchErr := fmt.Errorf("failed to fetch Cluster API infra resources: %w", err)
 
 		if condErr := r.applySynchronizedConditionWithPatch(
@@ -384,13 +399,13 @@ func (r *MachineSyncReconciler) reconcileMAPIMachinetoCAPIMachine(ctx context.Co
 	}
 
 	if shouldRequeue, err := r.reconcileMAPItoCAPIMachineDeletion(ctx, mapiMachine, capiMachine, infraMachine); err != nil {
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("failed to reconcile Machine API to Cluster API machine deletion: %w", err)
 	} else if shouldRequeue {
 		return ctrl.Result{}, nil
 	}
 
 	if shouldRequeue, err := r.ensureSyncFinalizer(ctx, mapiMachine, capiMachine, infraMachine); err != nil {
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("failed to ensure sync finalizer: %w", err)
 	} else if shouldRequeue {
 		return ctrl.Result{}, nil
 	}
@@ -557,6 +572,7 @@ func (r *MachineSyncReconciler) createOrUpdateCAPIInfraMachine(ctx context.Conte
 
 	alreadyExists := false
 
+	//nolint: nestif
 	if util.IsNilObject(infraMachine) {
 		if err := r.Create(ctx, newCAPIInfraMachine); err != nil && !apierrors.IsAlreadyExists(err) {
 			logger.Error(err, "Failed to create Cluster API infra machine")
@@ -569,7 +585,7 @@ func (r *MachineSyncReconciler) createOrUpdateCAPIInfraMachine(ctx context.Conte
 			return ctrl.Result{}, syncronizationIsProgressing, createErr
 		} else if apierrors.IsAlreadyExists(err) {
 			// this handles the case where the CAPI Machine is not present, so we can't resolve the
-			// infraMachine ref from it - but the InfraMachine exists. (e.g a user deletes the CAPI machine manaully).
+			// infraMachine ref from it - but the InfraMachine exists. (e.g a user deletes the CAPI machine manually).
 			//  This would lead to the call to fetchCAPIInfraResources returning nil for the infraMachine.
 			alreadyExists = true
 		} else {
@@ -769,8 +785,9 @@ func (r *MachineSyncReconciler) shouldMirrorCAPIMachineToMAPIMachine(ctx context
 	logger.V(4).WithName("shouldMirrorCAPIMachineToMAPIMachine").
 		Info("Checking if Cluster API machine should be mirrored", "machine", machine.GetName())
 
-	// Handles when the CAPI machine is deleting, and we don't have a MAPI machine
-	// See (https://github.com/openshift/cluster-capi-operator/pull/281#discussion_r2029362674)
+	// Handles when the CAPI machine is deleting, and we don't have a MAPI
+	// machine. See
+	// (https://github.com/openshift/cluster-capi-operator/pull/281#discussion_r2029362674)
 	if !machine.GetDeletionTimestamp().IsZero() {
 		return false, nil
 	}
@@ -905,6 +922,7 @@ func (r *MachineSyncReconciler) convertCAPIMachineOwnerReferencesToMAPI(ctx cont
 }
 
 // fetchCAPIInfraResources fetches the provider specific infrastructure resources depending on which provider is set.
+// If the InfraMachine is not found, we will just return nil. If the InfraCluster is not found, we error.
 func (r *MachineSyncReconciler) fetchCAPIInfraResources(ctx context.Context, capiMachine *capiv1beta1.Machine) (client.Object, client.Object, error) {
 	if capiMachine == nil {
 		return nil, nil, nil
@@ -932,60 +950,74 @@ func (r *MachineSyncReconciler) fetchCAPIInfraResources(ctx context.Context, cap
 		return nil, nil, fmt.Errorf("failed to get Cluster API infrastructure cluster: %w", err)
 	}
 
-	if err := r.Get(ctx, infraMachineKey, infraMachine); err != nil {
+	if err := r.Get(ctx, infraMachineKey, infraMachine); err != nil && !apierrors.IsNotFound(err) {
 		return nil, nil, fmt.Errorf("failed to get Cluster API infrastructure machine: %w", err)
+	} else if apierrors.IsNotFound(err) {
+		infraMachine = nil
 	}
 
 	return infraCluster, infraMachine, nil
 }
 
+//nolint:funlen,gocognit,cyclop
 func (r *MachineSyncReconciler) reconcileMAPItoCAPIMachineDeletion(ctx context.Context, mapiMachine *machinev1beta1.Machine, capiMachine *capiv1beta1.Machine, infraMachine client.Object) (bool, error) {
 	if mapiMachine.DeletionTimestamp.IsZero() {
 		return false, nil
 	}
 
+	logger := log.FromContext(ctx)
+
 	if capiMachine == nil && util.IsNilObject(infraMachine) {
+		logger.Info("Cluster API machine and infra machine do not exist, removing corresponding Machine API machine sync finalizer")
 		// We don't have  a capi machine or infra resouorces to clean up we can
-		// just let the MAPI operators function as normal, and remove our own sync finalizer.
+		// just let the MAPI operators function as normal, and remove our own sync
+		// finalizer.
 		_, err := util.RemoveFinalizer(ctx, r.Client, mapiMachine, SyncFinalizer)
 
-		return false, err
+		return false, fmt.Errorf("failed to remove finalizer: %w", err)
 	}
 
-	// propagate the deletion timestamp mapi -> capi,
 	if capiMachine.DeletionTimestamp.IsZero() {
-		if err := r.Client.Delete(ctx, capiMachine); err != nil {
-			return false, err
-		}
+		logger.Info("Machine API machine is being deleted, issuing deletion to corresponding Cluster API machine")
 
+		if err := r.Client.Delete(ctx, capiMachine); err != nil {
+			return false, fmt.Errorf("failed delete Cluster API machine: %w", err)
+		}
 	}
 
 	if !util.IsNilObject(infraMachine) {
 		if infraMachine.GetDeletionTimestamp().IsZero() {
+			logger.Info("Machine API machine is being deleted, issuing deletion to corresponding Cluster API infra machine")
+
 			if err := r.Client.Delete(ctx, infraMachine); err != nil {
-				return false, err
+				return false, fmt.Errorf("failed to remove finalizer: %w", err)
 			}
 		}
 	}
 
-	// wait until the machinev1.MachineFinalizer is removed before removing the capi finalizer we've set above,
-	// as well as our own. This ensures the CAPI mirror resource doesn't dissapear before
-	// the MAPI controller is done deleting the infra resource.
+	// Wait until the machinev1.MachineFinalizer is removed before removing the
+	// CAPI finalizer we've set above, as well as our own. This ensures the CAPI
+	// mirror resource doesn't disappear before the MAPI controller is done
+	// deleting the infra resource.
 	if slices.Contains(mapiMachine.Finalizers, machinev1beta1.MachineFinalizer) {
-		// We wait
-		// Requeue, the event of the mapiMachine having its finalizer removed will get us to re-reconcile.
+		logger.Info("Waiting on Machine API machine specific finalizer to be removed")
+
 		return true, nil
 	}
 
-	// MAPI finalizer removed, we can clean up the finalizers on the capi machine & infra machine.
+	// MAPI finalizer removed, we can clean up the finalizers on the capi machine
+	// & infra machine.
+	//nolint:nestif
 	if !util.IsNilObject(infraMachine) {
 		finalizers := infraMachine.GetFinalizers()
 		hasChanged := false
 
 		for _, finalizer := range finalizers {
-			if strings.HasSuffix(finalizer, ".cluster.x-k8s.io") {
+			if strings.HasSuffix(finalizer, capiInfraCommonFinalizerSuffix) {
+				logger.Info("Removing Cluster API infra machine specific finalizer")
+
 				if changed, err := util.RemoveFinalizer(ctx, r.Client, infraMachine, finalizer); err != nil {
-					return false, err
+					return false, fmt.Errorf("failed to remove finalizer: %w", err)
 				} else if changed {
 					hasChanged = true
 				}
@@ -998,27 +1030,118 @@ func (r *MachineSyncReconciler) reconcileMAPItoCAPIMachineDeletion(ctx context.C
 	}
 
 	if changed, err := util.RemoveFinalizer(ctx, r.Client, capiMachine, capiv1beta1.MachineFinalizer); err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to remove finalizer: %w", err)
 	} else if changed {
+		logger.Info("Removing Cluster API machine specific finalizer")
+
 		return true, nil
 	}
 
 	// We want to remove the SyncFinalizer in one reconcile
 	hasChanged := false
+
 	if changed, err := util.RemoveFinalizer(ctx, r.Client, capiMachine, SyncFinalizer); err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to remove finalizer: %w", err)
 	} else if changed {
+		logger.Info("Removing Cluster API machine sync finalizer")
+
 		hasChanged = true
 	}
 
 	if changed, err := util.RemoveFinalizer(ctx, r.Client, infraMachine, SyncFinalizer); err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to remove finalizer: %w", err)
 	} else if changed {
+		logger.Info("Removing Cluster API infra machine sync finalizer")
+
 		hasChanged = true
 	}
 
 	if changed, err := util.RemoveFinalizer(ctx, r.Client, mapiMachine, SyncFinalizer); err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to remove finalizer: %w", err)
+	} else if changed {
+		logger.Info("Removing Machine API machine sync finalizer")
+
+		hasChanged = true
+	}
+
+	return hasChanged, nil
+}
+
+//nolint:funlen
+func (r *MachineSyncReconciler) reconcileCAPItoMAPIMachineDeletion(ctx context.Context, capiMachine *capiv1beta1.Machine, infraMachine client.Object, mapiMachine *machinev1beta1.Machine) (bool, error) {
+	logger := log.FromContext(ctx)
+
+	if capiMachine.DeletionTimestamp.IsZero() {
+		return false, nil
+	}
+
+	if mapiMachine == nil {
+		logger.Info("Machine API machine does not exist, removing corresponding Cluster API machine sync finalizer")
+		// We don't have  a MAPI machine just let the CAPI operators function as
+		// normal, and remove our own sync finalizer.
+		_, err := util.RemoveFinalizer(ctx, r.Client, capiMachine, SyncFinalizer)
+
+		return false, fmt.Errorf("failed to remove finalizer: %w", err)
+	}
+
+	if mapiMachine.DeletionTimestamp.IsZero() {
+		logger.Info("Cluster API machine is being deleted, issuing deletion to corresponding Machine API machine")
+
+		if err := r.Client.Delete(ctx, mapiMachine); err != nil {
+			return false, fmt.Errorf("failed to delete Machine API machine: %w", err)
+		}
+	}
+
+	// The CAPI InfraMachine must go away completely in order for the CAPI
+	// Machine Finalizer to be removed by the CAPI Controllers.
+	if !util.IsNilObject(infraMachine) {
+		if slices.ContainsFunc(infraMachine.GetFinalizers(),
+			func(s string) bool { return strings.HasSuffix(s, capiInfraCommonFinalizerSuffix) }) {
+			logger.Info("Waiting on Cluster API infra machine specific finalizer to be removed")
+
+			return true, nil
+		}
+	}
+
+	logger.Info("Removing Cluster API infra machine sync finalizer")
+
+	if _, err := util.RemoveFinalizer(ctx, r.Client, infraMachine, SyncFinalizer); err != nil {
+		return false, fmt.Errorf("failed to remove finalizer: %w", err)
+	}
+
+	// Wait until the capiv1beta1.MachineFinalizer is removed before removing the
+	// MAPI finalizer we've set above, as well as our own. This ensures the MAPI
+	// mirror resource doesn't disappear before the CAPI controller is done
+	// deleting the infra resources.
+	if slices.Contains(capiMachine.Finalizers, capiv1beta1.MachineFinalizer) {
+		logger.Info("Waiting on Cluster API machine specific finalizer to be removed")
+
+		return true, nil
+	}
+
+	logger.Info("Removing Machine API machine specific finalizer")
+
+	if changed, err := util.RemoveFinalizer(ctx, r.Client, mapiMachine, machinev1beta1.MachineFinalizer); err != nil {
+		return false, fmt.Errorf("failed to remove finalizer: %w", err)
+	} else if changed {
+		return true, nil
+	}
+
+	logger.Info("Removing Machine API machine sync finalizer")
+
+	// We want to remove the SyncFinalizer in one reconcile
+	hasChanged := false
+
+	if changed, err := util.RemoveFinalizer(ctx, r.Client, mapiMachine, SyncFinalizer); err != nil {
+		return false, fmt.Errorf("failed to remove finalizer: %w", err)
+	} else if changed {
+		hasChanged = true
+	}
+
+	logger.Info("Removing Cluster API machine sync finalizer")
+
+	if changed, err := util.RemoveFinalizer(ctx, r.Client, capiMachine, SyncFinalizer); err != nil {
+		return false, fmt.Errorf("failed to remove finalizer: %w", err)
 	} else if changed {
 		hasChanged = true
 	}
@@ -1026,27 +1149,31 @@ func (r *MachineSyncReconciler) reconcileMAPItoCAPIMachineDeletion(ctx context.C
 	return hasChanged, nil
 }
 
-// ensureSyncFinalizer ensures the sync finalizer is present across the mapi machine, capi machine and capi infra machine.
+// ensureSyncFinalizer ensures the sync finalizer is present across the mapi
+// machine, capi machine and capi infra machine.
 func (r *MachineSyncReconciler) ensureSyncFinalizer(ctx context.Context, mapiMachine *machinev1beta1.Machine, capiMachine *capiv1beta1.Machine, infraMachine client.Object) (bool, error) {
 	var shouldRequeue bool
+
 	var errors []error
 
-	if mapiMachine.DeletionTimestamp.IsZero() {
-		didSet, err := util.EnsureFinalizer(ctx, r.Client, mapiMachine, SyncFinalizer)
-		if err != nil {
-			errors = append(errors, err)
-		}
+	//nolint: nestif
+	if mapiMachine != nil {
+		if mapiMachine.DeletionTimestamp.IsZero() {
+			didSet, err := util.EnsureFinalizer(ctx, r.Client, mapiMachine, SyncFinalizer)
+			if err != nil {
+				errors = append(errors, err)
+			}
 
-		if didSet {
-			//Patching the finalizer triggers a re-reconcile.
-			shouldRequeue = true
+			if didSet {
+				shouldRequeue = true
+			}
 		}
-
-		// Finalizer was not set, continue
 	}
 
-	// This will add the finalizer in the scenario where the capiMachine does not exist yet too,
-	// as the creation of the machine triggers a reconcile where this code path will run.
+	// This will add the finalizer in the scenario where the capiMachine does not
+	// exist yet too, as the creation of the machine triggers a reconcile where
+	// this code path will run.
+	//nolint: nestif
 	if capiMachine != nil {
 		if capiMachine.DeletionTimestamp.IsZero() {
 			didSet, err := util.EnsureFinalizer(ctx, r.Client, capiMachine, SyncFinalizer)
@@ -1060,12 +1187,14 @@ func (r *MachineSyncReconciler) ensureSyncFinalizer(ctx context.Context, mapiMac
 		}
 	}
 
-	if infraMachine != nil {
+	//nolint:nestif
+	if !util.IsNilObject(infraMachine) {
 		if infraMachine.GetDeletionTimestamp().IsZero() {
 			didSet, err := util.EnsureFinalizer(ctx, r.Client, infraMachine, SyncFinalizer)
 			if err != nil {
 				errors = append(errors, err)
 			}
+
 			if didSet {
 				shouldRequeue = true
 			}

--- a/pkg/util/finalizer.go
+++ b/pkg/util/finalizer.go
@@ -31,6 +31,9 @@ var (
 
 // EnsureFinalizer ensures that the specified finalizer is added to the given object using a Patch operation.
 func EnsureFinalizer(ctx context.Context, c client.Client, obj client.Object, finalizer string) (bool, error) {
+	if IsNilObject(obj) {
+		return false, fmt.Errorf("failed to ensure finalizer: object passed is nil")
+	}
 	// Create a deep copy of the original object.
 	originalObj, ok := obj.DeepCopyObject().(client.Object)
 	if !ok {
@@ -54,6 +57,10 @@ func EnsureFinalizer(ctx context.Context, c client.Client, obj client.Object, fi
 
 // RemoveFinalizer ensures that the specified finalizer is removed from the given object using a Patch operation.
 func RemoveFinalizer(ctx context.Context, c client.Client, obj client.Object, finalizer string) (bool, error) {
+	if IsNilObject(obj) {
+		return false, nil
+	}
+
 	// Create a deep copy of the original object.
 	originalObj, ok := obj.DeepCopyObject().(client.Object)
 	if !ok {

--- a/pkg/util/finalizer.go
+++ b/pkg/util/finalizer.go
@@ -27,12 +27,13 @@ import (
 
 var (
 	errUnableToAssertClientObject = errors.New("unable to assert client.Object after deepcopy")
+	errObjectPassedIsNil          = errors.New("failed to ensure finalizer: object passed is nil")
 )
 
 // EnsureFinalizer ensures that the specified finalizer is added to the given object using a Patch operation.
 func EnsureFinalizer(ctx context.Context, c client.Client, obj client.Object, finalizer string) (bool, error) {
 	if IsNilObject(obj) {
-		return false, fmt.Errorf("failed to ensure finalizer: object passed is nil")
+		return false, errObjectPassedIsNil
 	}
 	// Create a deep copy of the original object.
 	originalObj, ok := obj.DeepCopyObject().(client.Object)


### PR DESCRIPTION
This change adds deletion logic for Machines. 

It introduces a sync finalizer to coordinate synchronization of mirrored resources.

If we are reconciling deletions MAPI -> CAPI, we ensure the MAPI specific finalizers are removed before removing our sync finalizer.

If we are reconciling deletions CAPI -> MAPI, we ensure that the CAPI InfraMachine has it's specific (per provider) finalizer removed by the CAPI controllers, before removing our sync finalizer. This must happen *before* the CAPI Machine controller will remove the CAPI machine deletion finalizer. Once we observe this, we remove our sync finalizer allowing deletion of mirrored objects. 

This has been tested in both directions on a live cluster. 