### PR TITLE
OCPCLOUD-2712: Update comments based on Security Group Investigation

### DIFF
--- a/pkg/conversion/capi2mapi/aws.go
+++ b/pkg/conversion/capi2mapi/aws.go
@@ -137,7 +137,7 @@ func (m machineAndAWSMachineAndAWSCluster) toProviderSpec() (*mapiv1.AWSMachineP
 		// DeviceIndex - OCPCLOUD-2707: Value must always be zero. No other values are valid in MAPA even though the value is configurable.
 		PublicIP:             m.awsMachine.Spec.PublicIP,
 		NetworkInterfaceType: mapiv1.AWSENANetworkInterfaceType,                                          // TODO(OCPCLOUD-2708) This is the default value for MAPA, but other values are not configurable in CAPA.
-		SecurityGroups:       convertAWSSecurityGroupstoMAPI(m.awsMachine.Spec.AdditionalSecurityGroups), // OCPCLOUD-2712: We need to ensure that this is the correct way to convert the security groups.
+		SecurityGroups:       convertAWSSecurityGroupstoMAPI(m.awsMachine.Spec.AdditionalSecurityGroups), // This is the way we want to convert security groups, as the AdditionalSecurity Groups are what gets added to MAPI SGs.
 		Subnet:               convertAWSResourceReferenceToMAPI(ptr.Deref(m.awsMachine.Spec.Subnet, capav1.AWSResourceReference{})),
 		Placement: mapiv1.Placement{
 			AvailabilityZone: ptr.Deref(m.machine.Spec.FailureDomain, ""),
@@ -480,7 +480,7 @@ func handleUnsupportedAWSMachineFields(fldPath *field.Path, spec capav1.AWSMachi
 	}
 
 	if len(spec.SecurityGroupOverrides) > 0 {
-		// TODO(OCPCLOUD-2712): Needs more investigation, we are converting additional security groups to MAPI SGs, this overrides the built-ins, need to explore at the behavioural level.
+		// We do not support SecurityGroupOverrides being used, because the externally managed annotation that we add updates the behaviour to stop this.
 		errs = append(errs, field.Invalid(fldPath.Child("securityGroupOverrides"), spec.SecurityGroupOverrides, "securityGroupOverrides are not supported"))
 	}
 

--- a/pkg/conversion/capi2mapi/aws_fuzz_test.go
+++ b/pkg/conversion/capi2mapi/aws_fuzz_test.go
@@ -164,8 +164,7 @@ func awsMachineFuzzerFuncs(codecs runtimeserializer.CodecFactory) []interface{} 
 			spec.UncompressedUserData = nil
 			spec.PrivateDNSName = nil
 
-			// Fields not yet supported for conversion.
-			// TODO(OCPCLOUD-2712): Security group overrides still need investigation.
+			// We don't support this field since the externally managed annotation is added, so it's best to keep this nil.
 			spec.SecurityGroupOverrides = nil
 		},
 		func(m *capav1.AWSMachine, c fuzz.Continue) {


### PR DESCRIPTION
Hello! This is a PR to update some of the comments left behind during the conversion work.
The investigation discovered that the current behaviour is what we want, so I just updated some comments to leave information for future reference.
Thanks!