### PR TITLE
OCPCLOUD-2880: label selector and labels conversion, fixes to sync controllers and conversions

### DIFF
--- a/pkg/controllers/machinesync/machine_sync_controller_test.go
+++ b/pkg/controllers/machinesync/machine_sync_controller_test.go
@@ -236,7 +236,7 @@ var _ = Describe("With a running MachineSync Reconciler", func() {
 			})
 
 			Context("when the CAPI machine does not exist", func() {
-				It("should create the CAPI machine", func() {
+				It("should create a paused CAPI machine", func() {
 					Eventually(k.Get(
 						capiv1resourcebuilder.Machine().WithName(mapiMachine.Name).WithNamespace(capiNamespace.Name).Build(),
 					)).Should(Succeed())

--- a/pkg/conversion/capi2mapi/aws_fuzz_test.go
+++ b/pkg/conversion/capi2mapi/aws_fuzz_test.go
@@ -29,11 +29,9 @@ import (
 	conversiontest "github.com/openshift/cluster-capi-operator/pkg/conversion/test/fuzz"
 
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	capav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -43,7 +41,7 @@ const (
 	capiNamespace        = "openshift-cluster-api"
 )
 
-var _ = Describe("AWS Fuzz (mapi2capi)", func() {
+var _ = Describe("AWS Fuzz (capi2mapi)", func() {
 	infra := &configv1.Infrastructure{
 		Spec: configv1.InfrastructureSpec{},
 		Status: configv1.InfrastructureStatus{
@@ -138,7 +136,6 @@ func awsMachineFuzzerFuncs(codecs runtimeserializer.CodecFactory) []interface{} 
 			for ami.ID == nil || *ami.ID == "" {
 				c.Fuzz(&ami.ID)
 			}
-
 			// Not required for our use case. Can be ignored.
 			ami.EKSOptimizedLookupType = nil
 		},
@@ -163,7 +160,6 @@ func awsMachineFuzzerFuncs(codecs runtimeserializer.CodecFactory) []interface{} 
 			spec.CloudInit = capav1.CloudInit{}
 			spec.UncompressedUserData = nil
 			spec.PrivateDNSName = nil
-
 			// We don't support this field since the externally managed annotation is added, so it's best to keep this nil.
 			spec.SecurityGroupOverrides = nil
 		},

--- a/pkg/conversion/capi2mapi/common.go
+++ b/pkg/conversion/capi2mapi/common.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package capi2mapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+// RawExtensionFromProviderSpec marshals the machine provider spec.
+func RawExtensionFromProviderSpec(spec interface{}) (*runtime.RawExtension, error) {
+	if spec == nil {
+		return &runtime.RawExtension{}, nil
+	}
+
+	rawBytes, err := json.Marshal(spec)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling providerSpec: %w", err)
+	}
+
+	return &runtime.RawExtension{
+		Raw: rawBytes,
+	}, nil
+}
+
+func convertCAPIMachineSetSelectorToMAPI(capiSelector metav1.LabelSelector) metav1.LabelSelector {
+	mapiSelector := capiSelector.DeepCopy()
+	mapiSelector.MatchLabels = convertCAPILabelsToMAPILabels(capiSelector.MatchLabels)
+
+	return *mapiSelector
+}
+
+func convertCAPILabelsToMAPILabels(capiLabels map[string]string) map[string]string {
+	if len(capiLabels) == 0 {
+		return nil
+	}
+
+	mapiLabels := make(map[string]string)
+
+	for k, v := range capiLabels {
+		// Transform specific node-role label.
+		if strings.HasPrefix(k, capiv1.NodeRoleLabelPrefix) {
+			if _, role, found := strings.Cut(k, "/"); found {
+				mapiLabels["machine.openshift.io/cluster-api-machine-type"] = role
+				mapiLabels["machine.openshift.io/cluster-api-machine-role"] = role
+
+				continue
+			} // Otherwise if it is a non conformant node-role label, fallthrough.
+		}
+
+		// Ignore CAPI-specific labels that are not explicitly handled.
+		if strings.Contains(k, "cluster.x-k8s.io/") {
+			continue
+		}
+
+		// Default case - copy over the label as-is to MAPI.
+		mapiLabels[k] = v
+	}
+
+	// On the original MAPI object some label fields are nil rather than empty.
+	// So return nil instead to avoid unnecessary diff being picked up by the diff checker.
+	if len(mapiLabels) == 0 {
+		return nil
+	}
+
+	return mapiLabels
+}
+
+func convertCAPIMachineLabelsToMAPIMachineSpecObjectMetaLabels(capiLabels map[string]string) map[string]string {
+	if len(capiLabels) == 0 {
+		return nil
+	}
+
+	mapiLabels := make(map[string]string)
+
+	for k, v := range capiLabels {
+		// Ignore CAPI-specific labels that are not explicitly handled.
+		if strings.Contains(k, "cluster.x-k8s.io/") {
+			continue
+		}
+
+		mapiLabels[k] = v
+	}
+
+	return mapiLabels
+}
+
+func convertCAPIMachineAnnotationsToMAPIMachineSpecObjectMetaAnnotations(capiAnnotations map[string]string) map[string]string {
+	if len(capiAnnotations) == 0 {
+		return nil
+	}
+
+	mapiAnnotations := make(map[string]string)
+
+	for k, v := range capiAnnotations {
+		// Ignore CAPI-specific annotations that are not explicitly handled.
+		if strings.Contains(k, "cluster.x-k8s.io/") {
+			continue
+		}
+
+		mapiAnnotations[k] = v
+	}
+
+	return mapiAnnotations
+}
+
+func convertCAPIAnnotationsToMAPIAnnotations(capiAnnotations map[string]string) map[string]string {
+	if len(capiAnnotations) == 0 {
+		return nil
+	}
+
+	mapiAnnotations := make(map[string]string)
+
+	toNotConvertAnnotations := sets.New(
+		// We want to skip the CAPI paused annotation to be copied over to MAPI.
+		capiv1.PausedAnnotation,
+	)
+
+	for k, v := range capiAnnotations {
+		if toNotConvertAnnotations.Has(k) {
+			// Skip this annotation.
+			continue
+		}
+
+		// Ignore CAPI-specific annotations that are not explicitly handled.
+		if strings.Contains(k, "cluster.x-k8s.io/") {
+			continue
+		}
+
+		mapiAnnotations[k] = v
+	}
+
+	return mapiAnnotations
+}

--- a/pkg/conversion/capi2mapi/powervs.go
+++ b/pkg/conversion/capi2mapi/powervs.go
@@ -115,8 +115,6 @@ func (m machineAndPowerVSMachineAndPowerVSCluster) ToMachine() (*mapiv1beta1.Mac
 }
 
 // ToMachineSet converts a capi2mapi MachineAndPowerVSMachineTemplate into a MAPI MachineSet.
-//
-//nolint:dupl
 func (m machineSetAndPowerVSMachineTemplateAndPowerVSCluster) ToMachineSet() (*mapiv1beta1.MachineSet, []string, error) {
 	if m.machineSet == nil || m.template == nil || m.powerVSCluster == nil || m.machineAndPowerVSMachineAndPowerVSCluster == nil {
 		return nil, nil, errCAPIMachineSetPowerVSMachineTemplatePowerVSClusterCannotBeNil

--- a/pkg/conversion/capi2mapi/powervs_fuzz_test.go
+++ b/pkg/conversion/capi2mapi/powervs_fuzz_test.go
@@ -41,7 +41,7 @@ const (
 	powerVSTemplateKind = "IBMPowerVSMachineTemplate"
 )
 
-var _ = Describe("Power VS Fuzz (capi2mapi)", func() {
+var _ = Describe("PowerVS Fuzz (capi2mapi)", func() {
 	infra := &configv1.Infrastructure{
 		Spec: configv1.InfrastructureSpec{},
 		Status: configv1.InfrastructureStatus{

--- a/pkg/conversion/mapi2capi/aws_test.go
+++ b/pkg/conversion/mapi2capi/aws_test.go
@@ -34,7 +34,7 @@ import (
 
 var _ = Describe("mapi2capi AWS conversion", func() {
 	var (
-		testValue                          = ptr.To[string]("test")
+		testValue                          = ptr.To("test")
 		blockDeviceMappingWithVirtualName  = &mapiv1.BlockDeviceMappingSpec{VirtualName: testValue}
 		blockDeviceMappingWithoutEBSConfig = &mapiv1.BlockDeviceMappingSpec{DeviceName: ptr.To("/dev/sdb")}
 

--- a/pkg/conversion/mapi2capi/machine_test.go
+++ b/pkg/conversion/mapi2capi/machine_test.go
@@ -86,17 +86,6 @@ var _ = Describe("mapi2capi Machine conversion", func() {
 			expectedWarnings: []string{},
 		}),
 
-		Entry("With unsupported non-CAPI managed labels", mapi2CAPIMachineConversionInput{
-			infraBuilder: infraBase,
-			machineBuilder: mapiMachineBase.WithMachineSpecObjectMeta(mapiv1.ObjectMeta{
-				Labels: map[string]string{
-					"custom.domain/label": "value",
-				},
-			}),
-			expectedErrors:   []string{"spec.metadata.labels[custom.domain/label]: Invalid value: \"value\": label propagation is not currently supported for this label"},
-			expectedWarnings: []string{},
-		}),
-
 		Entry("With unsupported spec.metadata.generateName set", mapi2CAPIMachineConversionInput{
 			machineBuilder: mapiMachineBase.WithMachineSpecObjectMeta(mapiv1.ObjectMeta{
 				GenerateName: "test-generate-",
@@ -121,20 +110,6 @@ var _ = Describe("mapi2capi Machine conversion", func() {
 				Namespace: "test-namespace",
 			}),
 			expectedErrors:   []string{"spec.metadata.namespace: Invalid value: \"test-namespace\": namespace is not supported"},
-			expectedWarnings: []string{},
-		}),
-
-		Entry("With unsupported spec.metadata.ownerReferences set", mapi2CAPIMachineConversionInput{
-			infraBuilder: infraBase,
-			machineBuilder: mapiMachineBase.WithMachineSpecObjectMeta(mapiv1.ObjectMeta{
-				OwnerReferences: []metav1.OwnerReference{{
-					APIVersion: "v1",
-					Kind:       "Pod",
-					Name:       "test-pod",
-					UID:        "test-uid",
-				}},
-			}),
-			expectedErrors:   []string{"spec.metadata.ownerReferences: Invalid value: []v1.OwnerReference{v1.OwnerReference{APIVersion:\"v1\", Kind:\"Pod\", Name:\"test-pod\", UID:\"test-uid\", Controller:(*bool)(nil), BlockOwnerDeletion:(*bool)(nil)}}: ownerReferences are not supported"},
 			expectedWarnings: []string{},
 		}),
 

--- a/pkg/conversion/mapi2capi/machineset_test.go
+++ b/pkg/conversion/mapi2capi/machineset_test.go
@@ -24,8 +24,6 @@ import (
 	machinebuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1beta1"
 
 	"github.com/openshift/cluster-capi-operator/pkg/conversion/test/matchers"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("mapi2capi MachineSet conversion", func() {
@@ -86,20 +84,6 @@ var _ = Describe("mapi2capi MachineSet conversion", func() {
 				Namespace: "test-namespace",
 			}),
 			expectedErrors:   []string{"spec.metadata.namespace: Invalid value: \"test-namespace\": namespace is not supported"},
-			expectedWarnings: []string{},
-		}),
-
-		Entry("With unsupported spec.metadata.ownerReferences set", mapi2CAPIMachinesetConversionInput{
-			infraBuilder: infraBase,
-			machineSetBuilder: mapiMachineSetBase.WithMachineSpecObjectMeta(mapiv1.ObjectMeta{
-				OwnerReferences: []metav1.OwnerReference{{
-					APIVersion: "v1",
-					Kind:       "Pod",
-					Name:       "test-pod",
-					UID:        "test-uid",
-				}},
-			}),
-			expectedErrors:   []string{"spec.metadata.ownerReferences: Invalid value: []v1.OwnerReference{v1.OwnerReference{APIVersion:\"v1\", Kind:\"Pod\", Name:\"test-pod\", UID:\"test-uid\", Controller:(*bool)(nil), BlockOwnerDeletion:(*bool)(nil)}}: ownerReferences are not supported"},
 			expectedWarnings: []string{},
 		}),
 	)

--- a/pkg/conversion/test/fuzz/fuzz.go
+++ b/pkg/conversion/test/fuzz/fuzz.go
@@ -19,18 +19,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"strings"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"time"
 
 	fuzz "github.com/google/gofuzz"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	configv1 "github.com/openshift/api/config/v1"
 	mapiv1 "github.com/openshift/api/machine/v1beta1"
 	"github.com/openshift/cluster-api-actuator-pkg/testutils"
 	"github.com/openshift/cluster-capi-operator/pkg/conversion/capi2mapi"
 	"github.com/openshift/cluster-capi-operator/pkg/conversion/mapi2capi"
+	"github.com/openshift/cluster-capi-operator/pkg/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	corev1 "k8s.io/api/core/v1"
@@ -80,6 +80,8 @@ type capiToMapiMachineFuzzInput struct {
 // It leverages fuzz testing to generate random CAPI objects and then converts them to MAPI objects and back to CAPI objects.
 // The test then compares the original CAPI object with the final CAPI object to ensure that the conversion is lossless.
 // Any lossy conversions must be accounted for within the fuzz functions passed in.
+//
+//nolint:funlen
 func CAPI2MAPIMachineRoundTripFuzzTest(scheme *runtime.Scheme, infra *configv1.Infrastructure, infraCluster, infraMachine client.Object, mapiConverter MAPI2CAPIMachineConverterConstructor, capiConverter CAPI2MAPIMachineConverterConstructor, fuzzerFuncs ...fuzzer.FuzzerFuncs) {
 	machineFuzzInputs := []TableEntry{}
 	fz := getFuzzer(scheme, fuzzerFuncs...)
@@ -108,7 +110,8 @@ func CAPI2MAPIMachineRoundTripFuzzTest(scheme *runtime.Scheme, infra *configv1.I
 		machineFuzzInputs = append(machineFuzzInputs, Entry(fmt.Sprintf("%d", i), in))
 	}
 
-	DescribeTable("should be able to roundtrip fuzzed Machines", func(in capiToMapiMachineFuzzInput) { //nolint:dupl
+	//nolint:dupl
+	DescribeTable("should be able to roundtrip fuzzed Machines", func(in capiToMapiMachineFuzzInput) {
 		capiConverter := in.capiConverterConstructor(in.machine, in.infraMachine, in.infraCluster)
 
 		mapiMachine, warnings, err := capiConverter.ToMachine()
@@ -178,7 +181,8 @@ func CAPI2MAPIMachineSetRoundTripFuzzTest(scheme *runtime.Scheme, infra *configv
 		machineFuzzInputs = append(machineFuzzInputs, Entry(fmt.Sprintf("%d", i), in))
 	}
 
-	DescribeTable("should be able to roundtrip fuzzed MachineSets", func(in capiToMapiMachineSetFuzzInput) { //nolint:dupl
+	//nolint:dupl
+	DescribeTable("should be able to roundtrip fuzzed MachineSets", func(in capiToMapiMachineSetFuzzInput) {
 		capiConverter := in.capiConverterConstructor(in.machineSet, in.infraMachineTemplate, in.infraCluster)
 
 		mapiMachineSet, warnings, err := capiConverter.ToMachineSet()
@@ -263,10 +267,10 @@ func MAPI2CAPIMachineRoundTripFuzzTest(scheme *runtime.Scheme, infra *configv1.I
 		// Do not match on status yet, we do not support status conversion.
 		// Expect(mapiMachine.Status).To(Equal(in.machine.Status))
 
-		Expect(mapiMachine.TypeMeta).To(Equal(in.machine.TypeMeta))
-		Expect(mapiMachine.ObjectMeta).To(Equal(in.machine.ObjectMeta))
-		Expect(mapiMachine.Spec).To(WithTransform(ignoreMachineProviderSpec, testutils.MatchViaJSON(ignoreMachineProviderSpec(in.machine.Spec))))
-		Expect(mapiMachine.Spec.ProviderSpec.Value.Raw).To(MatchJSON(in.machine.Spec.ProviderSpec.Value.Raw))
+		Expect(mapiMachine.TypeMeta).To(Equal(in.machine.TypeMeta), "converted MAPI machine should have matching .typeMeta")
+		Expect(mapiMachine.ObjectMeta).To(Equal(in.machine.ObjectMeta), "converted MAPI machine should have matching .metadata")
+		Expect(mapiMachine.Spec).To(WithTransform(ignoreMachineProviderSpec, testutils.MatchViaJSON(ignoreMachineProviderSpec(in.machine.Spec))), "converted MAPI machine should have matching .spec")
+		Expect(mapiMachine.Spec.ProviderSpec.Value.Raw).To(MatchJSON(in.machine.Spec.ProviderSpec.Value.Raw), "converted MAPI machine should have matching .spec.providerSpec")
 	}, machineFuzzInputs)
 }
 
@@ -320,10 +324,10 @@ func MAPI2CAPIMachineSetRoundTripFuzzTest(scheme *runtime.Scheme, infra *configv
 		// Do not match on status yet, we do not support status conversion.
 		// Expect(mapiMachineSet.Status).To(Equal(in.machineSet.Status))
 
-		Expect(mapiMachineSet.TypeMeta).To(Equal(in.machineSet.TypeMeta))
-		Expect(mapiMachineSet.ObjectMeta).To(Equal(in.machineSet.ObjectMeta))
-		Expect(mapiMachineSet.Spec).To(WithTransform(ignoreMachineSetProviderSpec, testutils.MatchViaJSON(ignoreMachineSetProviderSpec(in.machineSet.Spec))))
-		Expect(mapiMachineSet.Spec.Template.Spec.ProviderSpec.Value.Raw).To(MatchJSON(in.machineSet.Spec.Template.Spec.ProviderSpec.Value.Raw))
+		Expect(mapiMachineSet.TypeMeta).To(Equal(in.machineSet.TypeMeta), "converted MAPI machine set should have matching .typeMeta")
+		Expect(mapiMachineSet.ObjectMeta).To(Equal(in.machineSet.ObjectMeta), "converted MAPI machine set should have matching .metadata")
+		Expect(mapiMachineSet.Spec).To(WithTransform(ignoreMachineSetProviderSpec, testutils.MatchViaJSON(ignoreMachineSetProviderSpec(in.machineSet.Spec))), "converted MAPI machine set should have matching .spec")
+		Expect(mapiMachineSet.Spec.Template.Spec.ProviderSpec.Value.Raw).To(MatchJSON(in.machineSet.Spec.Template.Spec.ProviderSpec.Value.Raw), "converted MAPI machine set should have matching .spec.template.spec.providerSpec")
 	}, machineFuzzInputs)
 }
 
@@ -385,12 +389,12 @@ func ObjectMetaFuzzerFuncs(namespace string) fuzzer.FuzzerFuncs {
 				// Clear fields that are not currently supported in the conversion.
 				o.OwnerReferences = nil // Handled outside of the conversion library.
 
-				// Annotations and labels maps should be non-nil (Since the conversion initialises them).
-				if o.Annotations == nil {
-					o.Annotations = map[string]string{}
+				// Empty annotations and labels maps should be nil (Since the conversion nils them).
+				if len(o.Annotations) == 0 {
+					o.Annotations = nil
 				}
-				if o.Labels == nil {
-					o.Labels = map[string]string{}
+				if len(o.Labels) == 0 {
+					o.Labels = nil
 				}
 			},
 		}
@@ -421,12 +425,11 @@ func CAPIMachineFuzzerFuncs(providerIDFuzz StringFuzzer, infraKind, infraAPIVers
 				// Clear fields that are not supported in the machine spec.
 				m.Version = nil
 				m.ReadinessGates = nil
-
 				// Clear fields that are not yet supported in the conversion.
 				// TODO(OCPCLOUD-2715): Implement support for node draining options in MAPI.
 				m.NodeDrainTimeout = nil
 				m.NodeVolumeDetachTimeout = nil
-				m.NodeDeletionTimeout = nil
+				m.NodeDeletionTimeout = &metav1.Duration{Duration: time.Second * 10} // This is defaulted to 10s by default in CAPI.
 
 				// Clear fields that are zero valued.
 				if m.FailureDomain != nil && *m.FailureDomain == "" {
@@ -439,6 +442,11 @@ func CAPIMachineFuzzerFuncs(providerIDFuzz StringFuzzer, infraKind, infraAPIVers
 			},
 			func(m *capiv1.Machine, c fuzz.Continue) {
 				c.FuzzNoCustom(m)
+
+				if m.Labels == nil {
+					m.Labels = make(map[string]string)
+				}
+				m.Labels[capiv1.ClusterNameLabel] = clusterName
 
 				// The reference from a Machine to the InfraMachine should
 				// always use the same name and namespace as the Machine itself.
@@ -463,21 +471,33 @@ func CAPIMachineSetFuzzerFuncs(infraTemplateKind, infraAPIVersion, clusterName s
 			func(t *capiv1.MachineTemplateSpec, c fuzz.Continue) {
 				c.FuzzNoCustom(t)
 
-				// Annotations and labels maps should be non-nil (Since the conversion initialises them).
-				if t.Annotations == nil {
-					t.Annotations = map[string]string{}
+				if len(t.Annotations) == 0 {
+					t.Annotations = nil
 				}
+
 				if t.Labels == nil {
-					t.Labels = map[string]string{}
+					t.Labels = make(map[string]string)
 				}
+				t.Labels[capiv1.ClusterNameLabel] = clusterName
 			},
 			func(m *capiv1.MachineSetSpec, c fuzz.Continue) {
 				c.FuzzNoCustom(m)
 
 				m.ClusterName = clusterName
+
+				if m.Selector.MatchLabels == nil {
+					m.Selector.MatchLabels = map[string]string{}
+				}
+
+				fuzzCAPIMachineSetSpecDeletePolicy(&m.DeletePolicy, c)
 			},
 			func(m *capiv1.MachineSet, c fuzz.Continue) {
 				c.FuzzNoCustom(m)
+
+				if m.Labels == nil {
+					m.Labels = make(map[string]string)
+				}
+				m.Labels[capiv1.ClusterNameLabel] = clusterName
 
 				// The reference from a MachineSet to the InfraMachine should
 				// always use the same name and namespace as the Machine itself.
@@ -503,6 +523,20 @@ func MAPIMachineFuzzerFuncs(providerSpec runtime.Object, providerIDFuzz StringFu
 	return func(codecs runtimeserializer.CodecFactory) []interface{} {
 		return []interface{}{
 			// MAPI to CAPI conversion functions.
+			func(m *mapiv1.Machine, c fuzz.Continue) {
+				c.FuzzNoCustom(m)
+				// The conversion library while converting
+				// machine labels and annotations from MAPI->CAPI merges the
+				// MAPI machine.spec.metadata.labels/annotations and MAPI machine.metadata.labels/annotations
+				// into CAPI machine.metadata.labels/annotations as that's the only place for metadata that CAPI has.
+				// When they are back-converted from CAPI->MAPI
+				// the conversion library converts CAPI machine.metadata.labels copying them both to
+				// MAPI machine.spec.metadata.labels and MAPI machine.metadata.labels.
+				// So these should match when we generate the initial MAPI machine
+				// so we get the same MAPI machineer the roundtrip.
+				m.Spec.ObjectMeta.Annotations = util.DeepCopyMapStringString(m.Annotations)
+				m.Spec.ObjectMeta.Labels = util.DeepCopyMapStringString(m.Labels)
+			},
 			func(m *mapiv1.MachineSpec, c fuzz.Continue) {
 				c.FuzzNoCustom(m)
 				c.Fuzz(providerSpec)
@@ -525,23 +559,11 @@ func MAPIMachineFuzzerFuncs(providerSpec runtime.Object, providerIDFuzz StringFu
 				m.AuthoritativeAPI = ""
 
 				// Clear fields that are not yet supported in the conversion.
-				// TODO(OCPCLOUD-2680/2897): For labels
-				// TODO(OCPCLOUD-2860/2898): For annotations.
 				// TODO(OCPCLOUD-2861/2899): For taints.
-				m.ObjectMeta.Annotations = nil
 				m.Taints = nil
 
 				// Set the providerID to a valid providerID that will at least pass through the conversion.
 				m.ProviderID = ptr.To(providerIDFuzz(c))
-
-				// Labels to go onto the node have to have specific prefixes.
-				m.ObjectMeta.Labels = map[string]string{
-					"node-role.kubernetes.io/worker":                                                "",
-					"node-restriction.kubernetes.io/" + strings.ReplaceAll(c.RandString(), "/", ""): c.RandString(),
-					"node.cluster.x-k8s.io/" + strings.ReplaceAll(c.RandString(), "/", ""):          c.RandString(),
-					strings.ReplaceAll(c.RandString(), "/", "") + ".node-restriction.kubernetes.io": c.RandString(),
-					strings.ReplaceAll(c.RandString(), "/", "") + ".node.cluster.x-k8s.io":          c.RandString(),
-				}
 			},
 			func(hooks *mapiv1.LifecycleHooks, c fuzz.Continue) {
 				c.FuzzNoCustom(hooks)
@@ -574,10 +596,61 @@ func MAPIMachineSetFuzzerFuncs() fuzzer.FuzzerFuncs {
 				m.Template.ObjectMeta.GenerateName = ""
 				m.Template.ObjectMeta.Namespace = ""
 				m.Template.ObjectMeta.OwnerReferences = nil
+				// The conversion library while converting
+				// machineSet.template labels/annotations from MAPI->CAPI
+				// merges MAPI machineSet.template.spec.metadata.labels/annotations
+				// and MAPI machineSet.template.metadata.labels/annotations
+				// into CAPI machineSet.template.metadata.labels/annotations
+				// as that's the only place for metadata that CAPI has.
+				// When they are back-converted from CAPI->MAPI
+				// the conversion library converts CAPI machineSet.template.metadata.labels/annotations
+				// it does so to both to MAPI machineSet.template.spec.metadata.labels/annotations and
+				// MAPI machineSet.template.metadata.labels/annotations
+				// So these should match when we generate the initial MAPI MachineSet
+				// so we get the same MAPI MachineSet back after the roundtrip.
+				m.Template.Spec.ObjectMeta.Labels = util.DeepCopyMapStringString(m.Template.ObjectMeta.Labels)
+				m.Template.Spec.ObjectMeta.Annotations = util.DeepCopyMapStringString(m.Template.ObjectMeta.Annotations)
+
+				fuzzMAPIMachineSetSpecDeletePolicy(&m.DeletePolicy, c)
 
 				// Clear the authoritative API since that's not relevant for conversion.
 				m.AuthoritativeAPI = ""
 			},
 		}
 	}
+}
+
+func fuzzMAPIMachineSetSpecDeletePolicy(deletePolicy *string, c fuzz.Continue) {
+	switch c.Int31n(3) {
+	case 0:
+		*deletePolicy = string(mapiv1.RandomMachineSetDeletePolicy)
+	case 1:
+		*deletePolicy = string(mapiv1.NewestMachineSetDeletePolicy)
+	case 2:
+		*deletePolicy = string(mapiv1.OldestMachineSetDeletePolicy)
+		// case 3:
+		// 	*deletePolicy = "" // Do not fuzz MAPI MachineSetDeletePolicy to the empty value.
+		// It will otherwise get converted to CAPI RandomMachineSetDeletePolicy (default in CAPI) which
+		// if converted back to MAPI will become RandomMachineSetDeletePolicy,
+		// resulting in a known lossy rountrip conversion, which would make the test to fail.
+		// This is not an issue in real conditions as the defaults are the same for CAPI and MAPI (Random).
+	} //nolint:wsl
+}
+
+func fuzzCAPIMachineSetSpecDeletePolicy(deletePolicy *string, c fuzz.Continue) {
+	switch c.Int31n(3) {
+	case 0:
+		*deletePolicy = string(capiv1.RandomMachineSetDeletePolicy)
+	case 1:
+		*deletePolicy = string(capiv1.NewestMachineSetDeletePolicy)
+	case 2:
+		*deletePolicy = string(capiv1.OldestMachineSetDeletePolicy)
+		// case 3:
+		// 	*deletePolicy = "" // Do not fuzz CAPI MachineSetDeletePolicy to the empty value.
+		// It will otherwise get converted to CAPI RandomMachineSetDeletePolicy (default in CAPI) which
+		// if to MAPI will become RandomMachineSetDeletePolicy,
+		// and converted back to CAPI will become RandomMachineSetDeletePolicy,
+		// resulting in a known lossy rountrip conversion, which would make the test to fail.
+		// This is not an issue in real conditions as the defaults are the same for CAPI and MAPI (Random).
+	} //nolint:wsl
 }

--- a/pkg/util/maps.go
+++ b/pkg/util/maps.go
@@ -17,6 +17,10 @@ package util
 
 // MergeMaps merges two maps, with values from the second map taking precedence.
 func MergeMaps(m1, m2 map[string]string) map[string]string {
+	if len(m1) == 0 && len(m2) == 0 {
+		return nil
+	}
+
 	result := make(map[string]string, len(m1))
 	for k, v := range m1 {
 		result[k] = v
@@ -27,4 +31,19 @@ func MergeMaps(m1, m2 map[string]string) map[string]string {
 	}
 
 	return result
+}
+
+// DeepCopyMapStringString creates a deep copy of a map[string]string.
+func DeepCopyMapStringString(original map[string]string) map[string]string {
+	if original == nil {
+		return nil
+	}
+
+	copiedMap := make(map[string]string, len(original))
+
+	for key, value := range original {
+		copiedMap[key] = value
+	}
+
+	return copiedMap
 }

--- a/pkg/util/object.go
+++ b/pkg/util/object.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package util
+
+import (
+	"reflect"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// IsNilObject checks whether a client.Object is nil or not.
+func IsNilObject(obj client.Object) bool {
+	return obj == nil || reflect.ValueOf(obj).IsNil()
+}


### PR DESCRIPTION
This PR contains:
- assorted fixes to the sync controllers and the conversion libraries that I picked up while running the migration controllers doing full, real, back and forth MAPI->CAPI->MAPI migrations of machines and machine sets.
- full labels and annotations syncing between MAPI and CAPI, while also adding node labels and annotations propagation from CAPI machines down to their nodes
- machine sets selector bidirectional conversion
- improved diffing and diffs readability for machines and machine sets
- temporary hardcoded credentials secret conversion support for the default case to allow for migrations to momentarily work
- adds several `TODO(docs)` for lossy conversions that we might need to document (cc. @jeana-redhat)