### PR TITLE
OCPCLOUD-2713: Handle credential fields in both mapi2capi and capi2mapi

### DIFF
--- a/hack/test.sh
+++ b/hack/test.sh
@@ -5,9 +5,10 @@ set -o pipefail
 
 REPO_ROOT=$(dirname "${BASH_SOURCE}")/..
 
-
-TEST_DIRS=$1
-TIMEOUT=$2
+# Use existing value of TEST_DIRS, or $1 if not set. Makes it easier to target suites.
+TEST_DIRS=${TEST_DIRS:-$1}
+# Use 2nd arg, or 5m.
+TIMEOUT=${2:-"5m"}
 
 OPENSHIFT_CI=${OPENSHIFT_CI:-""}
 ARTIFACT_DIR=${ARTIFACT_DIR:-""}

--- a/pkg/controllers/infracluster/aws.go
+++ b/pkg/controllers/infracluster/aws.go
@@ -30,6 +30,8 @@ import (
 )
 
 // ensureAWSCluster ensures the AWSCluster cluster object exists.
+//
+//nolint:funlen
 func (r *InfraClusterController) ensureAWSCluster(ctx context.Context, log logr.Logger) (client.Object, error) {
 	target := &awsv1.AWSCluster{ObjectMeta: metav1.ObjectMeta{
 		Name:      r.Infra.Status.InfrastructureName,
@@ -75,6 +77,14 @@ func (r *InfraClusterController) ensureAWSCluster(ctx context.Context, log logr.
 			ControlPlaneEndpoint: clusterv1.APIEndpoint{
 				Host: apiURL.Hostname(),
 				Port: int32(port),
+			},
+			// This default IdentityRef will be created by the controlleridentitycreator controller.
+			// Leaving it as nil works the same as this value, but fills the log with log messages
+			// about the field being nil. Setting it also makes it more obvious how CAPA's configured.
+			// We also hard-code this to be the ControllerIdentity since that's the only Identity method we support right now.
+			IdentityRef: &awsv1.AWSIdentityReference{
+				Kind: awsv1.ControllerIdentityKind,
+				Name: "default",
 			},
 		},
 	}

--- a/pkg/conversion/capi2mapi/aws_test.go
+++ b/pkg/conversion/capi2mapi/aws_test.go
@@ -220,6 +220,21 @@ var _ = Describe("capi2mapi AWS conversion", func() {
 			expectedWarnings: []string{},
 		}),
 
+		Entry("With unsupported role identityRef", awsCAPI2MAPIMachineConversionInput{
+			awsClusterBuilder: awsCAPIAWSClusterBase.
+				WithIdentityRef(&capav1.AWSIdentityReference{
+					Kind: capav1.ClusterRoleIdentityKind,
+					Name: "invalid",
+				}),
+			awsMachineBuilder: awsCAPIAWSMachineBase,
+			machineBuilder:    awsCAPIMachineBase,
+			expectedErrors: []string{
+				"spec.identityRef.kind: Invalid value: \"AWSClusterRoleIdentity\": kind \"AWSClusterRoleIdentity\" cannot be converted to CredentialsSecret",
+				"spec.identityRef.name: Invalid value: \"invalid\": name \"invalid\" must be \"default\" when using an AWSClusterControllerIdentity",
+			},
+			expectedWarnings: []string{},
+		}),
+
 		// Test case for multiple metadata-related fields
 		Entry("With multiple unsupported metadata options", awsCAPI2MAPIMachineConversionInput{
 			awsClusterBuilder: awsCAPIAWSClusterBase,

--- a/pkg/conversion/mapi2capi/aws_fuzz_test.go
+++ b/pkg/conversion/mapi2capi/aws_fuzz_test.go
@@ -213,6 +213,11 @@ func awsProviderSpecFuzzerFuncs(codecs runtimeserializer.CodecFactory) []interfa
 			// region must match the input AWSCluster so force it here.
 			ps.Placement.Region = "us-east-1"
 
+			// Only one value here is valid in terms of fuzzing, so it is hardcoded.
+			ps.CredentialsSecret = &corev1.LocalObjectReference{
+				Name: mapi2capi.DefaultCredentialsSecretName,
+			}
+
 			// Clear fields that are not supported in the provider spec.
 			ps.DeviceIndex = 0
 			ps.LoadBalancers = nil

--- a/pkg/conversion/mapi2capi/aws_test.go
+++ b/pkg/conversion/mapi2capi/aws_test.go
@@ -21,6 +21,7 @@ import (
 
 	mapiv1 "github.com/openshift/api/machine/v1beta1"
 	"github.com/openshift/cluster-capi-operator/pkg/conversion/test/matchers"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
@@ -247,6 +248,18 @@ var _ = Describe("mapi2capi AWS conversion", func() {
 			infra: infra,
 			expectedErrors: []string{
 				"spec.providerSpec.value.blockDevices[0].virtualName: Invalid value: \"test\": virtualName is not supported",
+			},
+			expectedWarnings: []string{},
+		}),
+		Entry("With non-default CredentialsSecret", awsMAPI2CAPIConversionInput{
+			machineBuilder: awsMAPIMachineBase.WithProviderSpecBuilder(
+				awsBaseProviderSpec.WithCredentialsSecret(&corev1.LocalObjectReference{
+					Name: "invalid",
+				}),
+			),
+			infra: infra,
+			expectedErrors: []string{
+				"spec.providerSpec.value.credentialsSecret: Invalid value: \"invalid\": credential secret does not match the default of \"aws-cloud-credentials\", manual conversion is necessary",
 			},
 			expectedWarnings: []string{},
 		}),


### PR DESCRIPTION
See individual commits for each piece of work.

Also modified the test.sh script so that I didn't have to run all test suites every time.
