### PR TITLE
NO-JIRA: Prevent caching CAPI objects across namespaces

### DIFF
--- a/cmd/machine-api-migration/main.go
+++ b/cmd/machine-api-migration/main.go
@@ -129,13 +129,7 @@ func main() {
 
 	syncPeriod := 10 * time.Minute
 
-	cacheOpts := cache.Options{
-		DefaultNamespaces: map[string]cache.Config{
-			*capiManagedNamespace: {},
-			*mapiManagedNamespace: {},
-		},
-		SyncPeriod: &syncPeriod,
-	}
+	cacheOpts := getDefaultCacheOptions(*capiManagedNamespace, *mapiManagedNamespace, syncPeriod)
 
 	cfg := ctrl.GetConfigOrDie()
 
@@ -314,4 +308,25 @@ func getProviderFromInfrastructure(infra *configv1.Infrastructure) (configv1.Pla
 	}
 
 	return "", errPlatformNotFound
+}
+
+func getDefaultCacheOptions(capiNamespace, mapiNamespace string, sync time.Duration) cache.Options {
+	return cache.Options{
+		DefaultNamespaces: map[string]cache.Config{
+			capiNamespace: {},
+		},
+		SyncPeriod: &sync,
+		ByObject: map[client.Object]cache.ByObject{
+			&mapiv1beta1.Machine{}: {
+				Namespaces: map[string]cache.Config{
+					mapiNamespace: {},
+				},
+			},
+			&mapiv1beta1.MachineSet{}: {
+				Namespaces: map[string]cache.Config{
+					mapiNamespace: {},
+				},
+			},
+		},
+	}
 }


### PR DESCRIPTION
We have seen lots of caching (Watches) being established on namespaces we don't actually care about. By default, controller runtime will cache all objects we fetch for all of the default namespaces.

For our controllers, we typically care about the managed namespace, and only want to fetch certain objects from other namespaces.

This PR splits out the specific objects that we watch from other namespaces so that we only cache those objects in the other namespaces and not every object we care about