### PR TITLE
OCPBUGS-55947: Should not use v1beta1 of the AdmissionRegistration API group

### DIFF
--- a/manifests-gen/customizations.go
+++ b/manifests-gen/customizations.go
@@ -341,7 +341,7 @@ func mergeMaps[K comparable, V any](maps ...map[K]V) map[K]V {
 func addInfraClusterProtectionPolicy(objs []unstructured.Unstructured, providerName string) []unstructured.Unstructured {
 	policy := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "admissionregistration.k8s.io/v1beta1",
+			"apiVersion": "admissionregistration.k8s.io/v1",
 			"kind":       "ValidatingAdmissionPolicy",
 			"metadata": map[string]interface{}{
 				"name": "openshift-cluster-api-protect-" + providerName + "cluster",
@@ -374,7 +374,7 @@ func addInfraClusterProtectionPolicy(objs []unstructured.Unstructured, providerN
 
 	binding := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "admissionregistration.k8s.io/v1beta1",
+			"apiVersion": "admissionregistration.k8s.io/v1",
 			"kind":       "ValidatingAdmissionPolicyBinding",
 			"metadata": map[string]interface{}{
 				"name": "openshift-cluster-api-protect-" + providerName + "cluster",

--- a/pkg/controllers/capiinstaller/capi_installer_controller.go
+++ b/pkg/controllers/capiinstaller/capi_installer_controller.go
@@ -26,7 +26,6 @@ import (
 	"github.com/go-logr/logr"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -338,8 +337,8 @@ func (r *CapiInstallerController) SetupWithManager(mgr ctrl.Manager) error {
 		{&appsv1.Deployment{}, r.ManagedNamespace},
 		{&admissionregistrationv1.ValidatingWebhookConfiguration{}, notNamespaced},
 		{&admissionregistrationv1.MutatingWebhookConfiguration{}, notNamespaced},
-		{&admissionregistrationv1beta1.ValidatingAdmissionPolicy{}, notNamespaced},
-		{&admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding{}, notNamespaced},
+		{&admissionregistrationv1.ValidatingAdmissionPolicy{}, notNamespaced},
+		{&admissionregistrationv1.ValidatingAdmissionPolicyBinding{}, notNamespaced},
 		{&corev1.Service{}, r.ManagedNamespace},
 		{&apiextensionsv1.CustomResourceDefinition{}, notNamespaced},
 		{&corev1.ServiceAccount{}, r.ManagedNamespace},


### PR DESCRIPTION
The API group was never meant to ship in openshift, we should be using v1 which has identical APIs