### PR TITLE
OCPBUGS-54705: mapi2capi: Create new machine template when changing MAPI providerSpec

### DIFF
--- a/e2e/aws_test.go
+++ b/e2e/aws_test.go
@@ -24,7 +24,8 @@ import (
 )
 
 const (
-	awsMachineTemplateName = "aws-machine-template"
+	awsMachineTemplateName      = "aws-machine-template"
+	machineSetOpenshiftLabelKey = "machine.openshift.io/cluster-api-machineset"
 )
 
 var _ = Describe("Cluster API AWS MachineSet", Ordered, func() {
@@ -189,7 +190,7 @@ func getMAPICreatedInstance(awsClient *ec2.EC2, msName string) ec2.Instance {
 	Expect(msName).ToNot(BeEmpty())
 	mapiMachineList := &mapiv1.MachineList{}
 	Expect(cl.List(ctx, mapiMachineList, client.InNamespace(framework.MAPINamespace), client.MatchingLabels{
-		"machine.openshift.io/cluster-api-machineset": msName,
+		machineSetOpenshiftLabelKey: msName,
 	})).To(Succeed())
 	Expect(len(mapiMachineList.Items)).To(BeNumerically(">", 0))
 
@@ -221,7 +222,7 @@ func getCAPICreatedInstance(awsClient *ec2.EC2, msName string) ec2.Instance {
 	capiMachineList := &awsv1.AWSMachineList{}
 
 	Expect(cl.List(ctx, capiMachineList, client.InNamespace(framework.CAPINamespace), client.MatchingLabels{
-		"machine.openshift.io/cluster-api-machineset": msName,
+		machineSetOpenshiftLabelKey: msName,
 	})).To(Succeed())
 	Expect(capiMachineList.Items).To(HaveLen(1))
 

--- a/e2e/framework/machineset.go
+++ b/e2e/framework/machineset.go
@@ -22,6 +22,8 @@ type machineSetParams struct {
 	userDataSecret    string
 }
 
+const machineSetOpenshiftLabelKey = "machine.openshift.io/cluster-api-machineset"
+
 // NewMachineSetParams returns a new machineSetParams object.
 func NewMachineSetParams(msName, clusterName, failureDomain string, replicas int32, infrastructureRef corev1.ObjectReference, userDataSecretName string) machineSetParams {
 	Expect(msName).ToNot(BeEmpty())
@@ -58,15 +60,15 @@ func CreateMachineSet(cl client.Client, params machineSetParams) *clusterv1.Mach
 			ClusterName: params.clusterName,
 			Selector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"machine.openshift.io/cluster-api-cluster":    params.clusterName,
-					"machine.openshift.io/cluster-api-machineset": params.msName,
+					"machine.openshift.io/cluster-api-cluster": params.clusterName,
+					machineSetOpenshiftLabelKey:                params.msName,
 				},
 			},
 			Template: clusterv1.MachineTemplateSpec{
 				ObjectMeta: clusterv1.ObjectMeta{
 					Labels: map[string]string{
-						"machine.openshift.io/cluster-api-cluster":    params.clusterName,
-						"machine.openshift.io/cluster-api-machineset": params.msName,
+						"machine.openshift.io/cluster-api-cluster": params.clusterName,
+						machineSetOpenshiftLabelKey:                params.msName,
 					},
 				},
 				Spec: clusterv1.MachineSpec{

--- a/pkg/controllers/common_consts.go
+++ b/pkg/controllers/common_consts.go
@@ -46,4 +46,7 @@ const (
 
 	// ReasonAuthoritativeAPIChanged indicates that sync state is stale due to a change of authoritativeAPI.
 	ReasonAuthoritativeAPIChanged = "AuthoritativeAPIChanged"
+
+	// MachineSetOpenshiftLabelKey is the key for label referring to a Machine API MachineSet.
+	MachineSetOpenshiftLabelKey = "machine.openshift.io/cluster-api-machineset"
 )

--- a/pkg/controllers/machinesetsync/machineset_sync_controller.go
+++ b/pkg/controllers/machinesetsync/machineset_sync_controller.go
@@ -34,12 +34,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/go-test/deep"
 	machinev1applyconfigs "github.com/openshift/client-go/machine/applyconfigurations/machine/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
@@ -61,6 +63,9 @@ var (
 
 	// errUnexpectedInfraMachineTemplateType is returned when we receive an unexpected InfraMachineTemplate type.
 	errUnexpectedInfraMachineTemplateType = errors.New("unexpected InfraMachineTemplate type")
+
+	// errUnexpectedInfraMachineTemplateListType is returned when we receive an unexpected InfraStructureMachineTemplateList type.
+	errUnexpectedInfraMachineTemplateListType = errors.New("unexpected InfraMachineTemplateList type")
 
 	// errUnexpectedInfraClusterType is returned when we receive an unexpected InfraCluster type.
 	errUnexpectedInfraClusterType = errors.New("unexpected InfraCluster type")
@@ -135,7 +140,7 @@ func (r *MachineSetSyncReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		).
 		Watches(
 			infraMachineTemplate,
-			handler.EnqueueRequestsFromMapFunc(util.ResolveCAPIMachineSetFromObject(r.MAPINamespace)),
+			handler.EnqueueRequestsFromMapFunc(util.ResolveCAPIMachineSetFromInfraMachineTemplate(r.MAPINamespace)),
 			builder.WithPredicates(util.FilterNamespace(r.CAPINamespace)),
 		).
 		Complete(r); err != nil {
@@ -329,30 +334,137 @@ func (r *MachineSetSyncReconciler) reconcileMAPIMachineSetToCAPIMachineSet(ctx c
 
 	copyCapiObjectMeta(capiMachineSet, newCAPIMachineSet, r.CAPINamespace, authoritativeAPI, clusterOwnerRefence)
 
-	if result, err := r.ensureCAPIInfraMachineTemplate(ctx, mapiMachineSet, newCAPIMachineSet, newCAPIInfraMachineTemplate, clusterOwnerRefence); err != nil {
-		return result, fmt.Errorf("unable to ensure CAPI infra machine template: %w", err)
+	if err := r.ensureCAPIInfraMachineTemplate(ctx, mapiMachineSet, newCAPIMachineSet, newCAPIInfraMachineTemplate, clusterOwnerRefence); err != nil {
+		return ctrl.Result{}, fmt.Errorf("unable to ensure CAPI infra machine template: %w", err)
 	}
 
-	if result, err := r.createOrUpdateCAPIMachineSet(ctx, mapiMachineSet, capiMachineSet, newCAPIMachineSet); err != nil {
-		return result, fmt.Errorf("unable to ensure CAPI machine set: %w", err)
+	if err := r.createOrUpdateCAPIMachineSet(ctx, mapiMachineSet, capiMachineSet, newCAPIMachineSet); err != nil {
+		return ctrl.Result{}, fmt.Errorf("unable to ensure CAPI machine set: %w", err)
+	}
+
+	if err := r.deleteOutdatedCAPIInfraMachineTemplates(ctx, mapiMachineSet, newCAPIInfraMachineTemplate); err != nil {
+		return ctrl.Result{}, fmt.Errorf("unable to delete outdated Cluster API infrastructure machine templates: %w", err)
 	}
 
 	return ctrl.Result{}, r.applySynchronizedConditionWithPatch(ctx, mapiMachineSet, corev1.ConditionTrue,
 		controllers.ReasonResourceSynchronized, messageSuccessfullySynchronizedMAPItoCAPI, &mapiMachineSet.Generation)
 }
 
+// filterOutdatedInfraMachineTemplates takes infraMachineTemplatesList and constructs a slice of InfraMachineTemplates without newInfraMachineTemplate.
+func filterOutdatedInfraMachineTemplates(infraMachineTemplateList client.ObjectList, newInfraMachineTemplate client.Object) ([]client.Object, error) {
+	outdatedTemplates := []client.Object{}
+
+	switch list := infraMachineTemplateList.(type) {
+	case *awsv1.AWSMachineTemplateList:
+		for _, template := range list.Items {
+			if template.GetName() != newInfraMachineTemplate.GetName() {
+				outdatedTemplates = append(outdatedTemplates, &template)
+			}
+		}
+	case *ibmpowervsv1.IBMPowerVSMachineTemplateList:
+		for _, template := range list.Items {
+			if template.GetName() != newInfraMachineTemplate.GetName() {
+				outdatedTemplates = append(outdatedTemplates, &template)
+			}
+		}
+	default:
+		return nil, fmt.Errorf("%w: got unknown type %T", errUnexpectedInfraMachineTemplateListType, list)
+	}
+
+	return outdatedTemplates, nil
+}
+
+// deleteOutdatedCAPIInfraMachineTemplates deletes infra machine templates that have MAPI machine label of the current MachineSet and don't have the current computed hash.
+func (r *MachineSetSyncReconciler) deleteOutdatedCAPIInfraMachineTemplates(ctx context.Context, mapiMachineSet *machinev1beta1.MachineSet, newCAPIInfraMachineTemplate client.Object) error {
+	logger := log.FromContext(ctx)
+
+	machineSetMAPILabelSelector := labels.SelectorFromSet(map[string]string{controllers.MachineSetOpenshiftLabelKey: mapiMachineSet.Name})
+
+	listOptions := []client.ListOption{
+		client.InNamespace(r.CAPINamespace),
+		client.MatchingLabelsSelector{Selector: machineSetMAPILabelSelector},
+	}
+
+	infraTemplateList, _, err := initInfraMachineTemplateListAndInfraClusterListFromProvider(r.Platform)
+	if err != nil {
+		return fmt.Errorf("failed to get infrastructure machine template list from platform: %w", err)
+	}
+
+	if err := r.List(ctx, infraTemplateList, listOptions...); err != nil {
+		logger.Error(err, "Failed to list Cluster API infrastructure machine templates")
+		return fmt.Errorf("failed to list Cluster API infrastructure machine templates: %w", err)
+	}
+
+	outdatedTemplates, err := filterOutdatedInfraMachineTemplates(infraTemplateList, newCAPIInfraMachineTemplate)
+	if err != nil {
+		return fmt.Errorf("failed to filter outdated Cluster API infrastructure machine templates: %w", err)
+	}
+
+	if len(outdatedTemplates) == 0 {
+		logger.Info("No outdated Cluster API infrastructure machine templates to delete")
+		return nil
+	}
+
+	infraMachineTemplateNames := []string{}
+	for _, outdatedTemplate := range outdatedTemplates {
+		infraMachineTemplateNames = append(infraMachineTemplateNames, outdatedTemplate.GetName())
+	}
+
+	logger.Info("Found outdated Cluster API infrastructure machine templates. Proceeding to delete", "infraMachineTemplateNames", infraMachineTemplateNames)
+
+	if err := r.deleteAllOutdatedCAPIInfraMachineTemplates(ctx, mapiMachineSet, newCAPIInfraMachineTemplate.GetName()); err != nil {
+		return fmt.Errorf("failed to delete outdated Cluster API infrastructure machine templates: %w", err)
+	}
+
+	return nil
+}
+
+// deleteAllOutdatedCAPIInfraMachineTemplates deletes infra machine templates that have MAPI machine set label that of the current machine set and are not newCAPIInfraMachineTemplateName.
+func (r *MachineSetSyncReconciler) deleteAllOutdatedCAPIInfraMachineTemplates(ctx context.Context, mapiMachineSet *machinev1beta1.MachineSet, newCAPIInfraMachineTemplateName string) error {
+	logger := log.FromContext(ctx)
+
+	notNewCAPIInfraMachineTemplateNameFieldSelector := fields.OneTermNotEqualSelector("metadata.name", newCAPIInfraMachineTemplateName)
+	machineSetMAPILabelSelector := labels.SelectorFromSet(map[string]string{controllers.MachineSetOpenshiftLabelKey: mapiMachineSet.Name})
+
+	deleteAllOption := []client.DeleteAllOfOption{
+		client.InNamespace(r.CAPINamespace),
+		client.MatchingFieldsSelector{Selector: notNewCAPIInfraMachineTemplateNameFieldSelector},
+		client.MatchingLabelsSelector{Selector: machineSetMAPILabelSelector},
+	}
+
+	infraMachineTemplate, _, err := controllers.InitInfraMachineTemplateAndInfraClusterFromProvider(r.Platform)
+	if err != nil {
+		return fmt.Errorf("failed to get infrastructure machine template from Platform: %w", err)
+	}
+
+	if err := r.DeleteAllOf(ctx, infraMachineTemplate, deleteAllOption...); err != nil {
+		logger.Error(err, "Failed to delete outdated Cluster API infrastructure machine templates")
+
+		updateErr := fmt.Errorf("failed to delete outdated Cluster API infrastructure machine templates: %w", err)
+
+		if condErr := r.applySynchronizedConditionWithPatch(
+			ctx, mapiMachineSet, corev1.ConditionFalse, reasonFailedToUpdateCAPIInfraMachineTemplate, updateErr.Error(), nil); condErr != nil {
+			return utilerrors.NewAggregate([]error{updateErr, condErr})
+		}
+	}
+
+	logger.Info("Successfully deleted outdated Cluster API infrastructure machine templates")
+
+	return nil
+}
+
 // ensureCAPIInfraMachineTemplate ensures the CAPI InfraMachineTemplate is created or updated from the MAPI MachineSet.
-func (r *MachineSetSyncReconciler) ensureCAPIInfraMachineTemplate(ctx context.Context, mapiMachineSet *machinev1beta1.MachineSet, newCAPIMachineSet *clusterv1.MachineSet, newCAPIInfraMachineTemplate client.Object, clusterOwnerRefence metav1.OwnerReference) (ctrl.Result, error) {
+func (r *MachineSetSyncReconciler) ensureCAPIInfraMachineTemplate(ctx context.Context, mapiMachineSet *machinev1beta1.MachineSet, newCAPIMachineSet *clusterv1.MachineSet, newCAPIInfraMachineTemplate client.Object, clusterOwnerRefence metav1.OwnerReference) error {
 	_, infraMachineTemplate, err := r.fetchCAPIInfraResources(ctx, newCAPIMachineSet)
 	if err != nil && !apierrors.IsNotFound(err) {
 		fetchErr := fmt.Errorf("failed to fetch CAPI infra resources: %w", err)
 
 		if condErr := r.applySynchronizedConditionWithPatch(
 			ctx, mapiMachineSet, corev1.ConditionFalse, reasonFailedToGetCAPIInfraResources, fetchErr.Error(), nil); condErr != nil {
-			return ctrl.Result{}, utilerrors.NewAggregate([]error{fetchErr, condErr})
+			return utilerrors.NewAggregate([]error{fetchErr, condErr})
 		}
 
-		return ctrl.Result{}, fetchErr
+		return fetchErr
 	}
 
 	if !util.IsNilObject(infraMachineTemplate) {
@@ -371,11 +483,13 @@ func (r *MachineSetSyncReconciler) ensureCAPIInfraMachineTemplate(ctx context.Co
 		annotations.AddAnnotations(newCAPIInfraMachineTemplate, map[string]string{clusterv1.PausedAnnotation: ""})
 	}
 
-	if result, err := r.createOrUpdateCAPIInfraMachineTemplate(ctx, mapiMachineSet, infraMachineTemplate, newCAPIInfraMachineTemplate); err != nil {
-		return result, fmt.Errorf("unable to ensure CAPI infra machine template: %w", err)
+	newCAPIInfraMachineTemplate.SetLabels(map[string]string{controllers.MachineSetOpenshiftLabelKey: mapiMachineSet.Name})
+
+	if err := r.createOrUpdateCAPIInfraMachineTemplate(ctx, mapiMachineSet, infraMachineTemplate, newCAPIInfraMachineTemplate); err != nil {
+		return fmt.Errorf("unable to ensure Cluster API infrastructure machine template: %w", err)
 	}
 
-	return ctrl.Result{}, nil
+	return nil
 }
 
 // reconcileCAPIMachineSetToMAPIMachineSet reconciles a CAPI MachineSet to a
@@ -569,66 +683,54 @@ func (r *MachineSetSyncReconciler) applySynchronizedConditionWithPatch(ctx conte
 }
 
 // createOrUpdateCAPIInfraMachineTemplate creates a CAPI infra machine template from a MAPI machine set, or updates if it exists and it is out of date.
-func (r *MachineSetSyncReconciler) createOrUpdateCAPIInfraMachineTemplate(ctx context.Context, mapiMachineSet *machinev1beta1.MachineSet, infraMachineTemplate client.Object, newCAPIInfraMachineTemplate client.Object) (ctrl.Result, error) { //nolint:unparam
+func (r *MachineSetSyncReconciler) createOrUpdateCAPIInfraMachineTemplate(ctx context.Context, mapiMachineSet *machinev1beta1.MachineSet, infraMachineTemplate client.Object, newCAPIInfraMachineTemplate client.Object) error {
 	logger := log.FromContext(ctx)
 
-	if infraMachineTemplate == nil {
-		if err := r.Create(ctx, newCAPIInfraMachineTemplate); err != nil {
-			logger.Error(err, "Failed to create CAPI infra machine template")
-			createErr := fmt.Errorf("failed to create CAPI infra machine template: %w", err)
+	if infraMachineTemplate != nil {
+		capiInfraMachineTemplatesDiff, err := compareCAPIInfraMachineTemplates(r.Platform, infraMachineTemplate, newCAPIInfraMachineTemplate)
+		if err != nil {
+			logger.Error(err, "Failed to check CAPI infra machine template diff")
+			updateErr := fmt.Errorf("failed to check CAPI infra machine template diff: %w", err)
 
-			if condErr := r.applySynchronizedConditionWithPatch(ctx, mapiMachineSet, corev1.ConditionFalse, reasonFailedToCreateCAPIInfraMachineTemplate, createErr.Error(), nil); condErr != nil {
-				return ctrl.Result{}, utilerrors.NewAggregate([]error{createErr, condErr})
+			if condErr := r.applySynchronizedConditionWithPatch(
+				ctx, mapiMachineSet, corev1.ConditionFalse, reasonFailedToUpdateCAPIInfraMachineTemplate, updateErr.Error(), nil); condErr != nil {
+				return utilerrors.NewAggregate([]error{updateErr, condErr})
 			}
 
-			return ctrl.Result{}, createErr
+			return updateErr
 		}
 
-		logger.Info("Successfully created CAPI infra machine template")
+		if len(capiInfraMachineTemplatesDiff) == 0 {
+			logger.Info("No changes detected for CAPI infra machine template")
+			return nil
+		}
 
-		return ctrl.Result{}, nil
+		logger.Info("Changes detected for CAPI infra machine template. Updating it", "diff", fmt.Sprintf("%+v", capiInfraMachineTemplatesDiff))
 	}
 
-	capiInfraMachineTemplatesDiff, err := compareCAPIInfraMachineTemplates(r.Platform, infraMachineTemplate, newCAPIInfraMachineTemplate)
-	if err != nil {
-		logger.Error(err, "Failed to check CAPI infra machine template diff")
-		updateErr := fmt.Errorf("failed to check CAPI infra machine template diff: %w", err)
+	if err := r.Patch(ctx, newCAPIInfraMachineTemplate, client.Apply, &client.PatchOptions{
+		FieldManager: controllerName,
+		Force:        ptr.To(true),
+	}); err != nil {
+		logger.Error(err, "Failed to apply CAPI infrastructure machine template")
+
+		updateErr := fmt.Errorf("failed to apply CAPI infrastructure machine template: %w", err)
 
 		if condErr := r.applySynchronizedConditionWithPatch(
 			ctx, mapiMachineSet, corev1.ConditionFalse, reasonFailedToUpdateCAPIInfraMachineTemplate, updateErr.Error(), nil); condErr != nil {
-			return ctrl.Result{}, utilerrors.NewAggregate([]error{updateErr, condErr})
+			return utilerrors.NewAggregate([]error{updateErr, condErr})
 		}
 
-		return ctrl.Result{}, updateErr
+		return updateErr
 	}
 
-	if len(capiInfraMachineTemplatesDiff) == 0 {
-		logger.Info("No changes detected for CAPI infra machine template")
-		return ctrl.Result{}, nil
-	}
+	logger.Info("Successfully created Cluster API infrastructure machine template", "name", newCAPIInfraMachineTemplate.GetName())
 
-	logger.Info("Changes detected for CAPI infra machine template. Updating it", "diff", fmt.Sprintf("%+v", capiInfraMachineTemplatesDiff))
-
-	if err := r.Update(ctx, newCAPIInfraMachineTemplate); err != nil {
-		logger.Error(err, "Failed to update CAPI infra machine template")
-
-		updateErr := fmt.Errorf("failed to update CAPI infra machine template: %w", err)
-
-		if condErr := r.applySynchronizedConditionWithPatch(
-			ctx, mapiMachineSet, corev1.ConditionFalse, reasonFailedToUpdateCAPIInfraMachineTemplate, updateErr.Error(), nil); condErr != nil {
-			return ctrl.Result{}, utilerrors.NewAggregate([]error{updateErr, condErr})
-		}
-
-		return ctrl.Result{}, updateErr
-	}
-
-	logger.Info("Successfully updated CAPI infra machine template")
-
-	return ctrl.Result{}, nil
+	return nil
 }
 
 // createOrUpdateCAPIMachineSet creates a CAPI machine set from a MAPI one, or updates if it exists and it is out of date.
-func (r *MachineSetSyncReconciler) createOrUpdateCAPIMachineSet(ctx context.Context, mapiMachineSet *machinev1beta1.MachineSet, capiMachineSet *clusterv1.MachineSet, newCAPIMachineSet *clusterv1.MachineSet) (ctrl.Result, error) { //nolint:unparam
+func (r *MachineSetSyncReconciler) createOrUpdateCAPIMachineSet(ctx context.Context, mapiMachineSet *machinev1beta1.MachineSet, capiMachineSet *clusterv1.MachineSet, newCAPIMachineSet *clusterv1.MachineSet) error {
 	logger := log.FromContext(ctx)
 
 	if capiMachineSet == nil {
@@ -638,22 +740,22 @@ func (r *MachineSetSyncReconciler) createOrUpdateCAPIMachineSet(ctx context.Cont
 			createErr := fmt.Errorf("failed to create CAPI machine set: %w", err)
 			if condErr := r.applySynchronizedConditionWithPatch(
 				ctx, mapiMachineSet, corev1.ConditionFalse, reasonFailedToCreateCAPIMachineSet, createErr.Error(), nil); condErr != nil {
-				return ctrl.Result{}, utilerrors.NewAggregate([]error{createErr, condErr})
+				return utilerrors.NewAggregate([]error{createErr, condErr})
 			}
 
-			return ctrl.Result{}, createErr
+			return createErr
 		}
 
-		logger.Info("Successfully created CAPI machine set")
+		logger.Info("Successfully created CAPI machine set", "name", newCAPIMachineSet.Name, "infraMachineTemplate", newCAPIMachineSet.Spec.Template.Spec.InfrastructureRef.Name)
 
-		return ctrl.Result{}, nil
+		return nil
 	}
 
 	capiMachineSetsDiff := compareCAPIMachineSets(capiMachineSet, newCAPIMachineSet)
 
 	if len(capiMachineSetsDiff) == 0 {
 		logger.Info("No changes detected for CAPI machine set")
-		return ctrl.Result{}, nil
+		return nil
 	}
 
 	logger.Info("Changes detected for CAPI machine set. Updating it", "diff", fmt.Sprintf("%+v", capiMachineSetsDiff))
@@ -664,15 +766,15 @@ func (r *MachineSetSyncReconciler) createOrUpdateCAPIMachineSet(ctx context.Cont
 		updateErr := fmt.Errorf("failed to update CAPI machine set: %w", err)
 
 		if condErr := r.applySynchronizedConditionWithPatch(ctx, mapiMachineSet, corev1.ConditionFalse, reasonFailedToUpdateCAPIMachineSet, updateErr.Error(), nil); condErr != nil {
-			return ctrl.Result{}, utilerrors.NewAggregate([]error{updateErr, condErr})
+			return utilerrors.NewAggregate([]error{updateErr, condErr})
 		}
 
-		return ctrl.Result{}, updateErr
+		return updateErr
 	}
 
 	logger.Info("Successfully updated CAPI machine set")
 
-	return ctrl.Result{}, nil
+	return nil
 }
 
 // ensureSyncFinalizer ensures the sync finalizer is present across mapi and capi machine sets.
@@ -821,6 +923,19 @@ func (r *MachineSetSyncReconciler) reconcileCAPItoMAPIMachineSetDeletion(ctx con
 	}
 
 	return true, nil
+}
+
+// initInfraMachineTemplateListAndInfraClusterListFromProvider returns the correct InfraMachineTemplateList and InfraClusterList implementation
+// for a given provider.
+func initInfraMachineTemplateListAndInfraClusterListFromProvider(platform configv1.PlatformType) (client.ObjectList, client.ObjectList, error) {
+	switch platform {
+	case configv1.AWSPlatformType:
+		return &awsv1.AWSMachineTemplateList{}, &awsv1.AWSClusterList{}, nil
+	case configv1.PowerVSPlatformType:
+		return &ibmpowervsv1.IBMPowerVSMachineTemplateList{}, &ibmpowervsv1.IBMPowerVSClusterList{}, nil
+	default:
+		return nil, nil, fmt.Errorf("%w: %s", errPlatformNotSupported, platform)
+	}
 }
 
 // compareCAPIInfraMachineTemplates compares CAPI infra machine templates a and b, and returns a list of differences, or none if there are none.

--- a/pkg/controllers/machinesetsync/machineset_sync_controller_test.go
+++ b/pkg/controllers/machinesetsync/machineset_sync_controller_test.go
@@ -18,6 +18,7 @@ package machinesetsync
 
 import (
 	"context"
+	"encoding/json"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -38,6 +39,8 @@ import (
 	"github.com/openshift/cluster-api-actuator-pkg/testutils"
 	consts "github.com/openshift/cluster-capi-operator/pkg/controllers"
 	"github.com/openshift/cluster-capi-operator/pkg/controllers/machinesync"
+	"github.com/openshift/cluster-capi-operator/pkg/conversion/mapi2capi"
+	"github.com/openshift/cluster-capi-operator/pkg/util"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -73,6 +76,18 @@ var _ = Describe("With a running MachineSetSync controller", func() {
 	var capiCluster *clusterv1.Cluster
 	var capiClusterOwnerReference []metav1.OwnerReference
 
+	eventuallyCAPIMachineSetShouldHaveAWSMachineTemplateRefThatExists := func() {
+		capiMachineSet = capiv1resourcebuilder.MachineSet().WithName(mapiMachineSet.Name).WithNamespace(capiNamespace.Name).Build()
+		Eventually(func() error {
+			if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(capiMachineSet), capiMachineSet); err != nil {
+				return err
+			}
+			awsMachineTemplate := capav1builder.AWSMachineTemplate().WithName(capiMachineSet.Spec.Template.Spec.InfrastructureRef.Name).WithNamespace(capiNamespace.Name).Build()
+
+			return k.Get(awsMachineTemplate)()
+		}).Should(Succeed())
+	}
+
 	startManager := func(mgr *manager.Manager) (context.CancelFunc, chan struct{}) {
 		mgrCtx, mgrCancel := context.WithCancel(context.Background())
 		mgrDone := make(chan struct{})
@@ -94,6 +109,8 @@ var _ = Describe("With a running MachineSetSync controller", func() {
 	}
 
 	BeforeEach(func() {
+		var err error
+
 		By("Setting up a namespaces for the test")
 		syncControllerNamespace = corev1resourcebuilder.Namespace().
 			WithGenerateName("machineset-sync-controller-").Build()
@@ -157,7 +174,6 @@ var _ = Describe("With a running MachineSetSync controller", func() {
 			WithClusterName(infrastructureName)
 
 		By("Setting up a manager and controller")
-		var err error
 		mgr, err = ctrl.NewManager(cfg, ctrl.Options{
 			Scheme: testScheme,
 			Controller: config.Controller{
@@ -233,9 +249,21 @@ var _ = Describe("With a running MachineSetSync controller", func() {
 					Eventually(k.Get(capiMachineSet)).Should(Succeed())
 					Expect(capiMachineSet.OwnerReferences).To(Equal(capiClusterOwnerReference))
 
-					capaMachineTemplate := capav1builder.AWSMachineTemplate().WithName(mapiMachineSet.Name).WithNamespace(capiNamespace.Name).Build()
-					Eventually(k.Get(capaMachineTemplate)).Should(Succeed())
-					Expect(capaMachineTemplate.OwnerReferences).To(Equal(capiClusterOwnerReference))
+					By("Checking the CAPI infra machine template")
+					newCAPAMachineTemplate := capav1builder.AWSMachineTemplate().WithName(capiMachineSet.Spec.Template.Spec.InfrastructureRef.Name).WithNamespace(capiNamespace.Name).Build()
+					Eventually(k.Get(newCAPAMachineTemplate)).Should(Succeed())
+
+					By("Checking the CAPI infra machine template has the expected name")
+					generateName, err := util.GenerateInfraMachineTemplateNameWithSpecHash(capiMachineSet.Name, newCAPAMachineTemplate.Spec.Template.Spec)
+					Expect(err).To(BeNil())
+					Expect(newCAPAMachineTemplate.Name).To(Equal(generateName))
+
+					By("Checking the CAPI infra machine template has the expected owner reference")
+					Expect(newCAPAMachineTemplate.OwnerReferences).To(Equal(capiClusterOwnerReference))
+				})
+
+				It("should not delete the old CAPI infra machine template without MAPI machine set label", func() {
+					Consistently(k.Get(capaMachineTemplate)).Should(Succeed())
 				})
 
 				It("should update the synchronized condition on the MAPI machine set to True", func() {
@@ -287,12 +315,13 @@ var _ = Describe("With a running MachineSetSync controller", func() {
 
 				It("should update MachineSet and InfraMachineTemplate with CAPI Cluster OwnerReference", func() {
 					capiMachineSet := capiv1resourcebuilder.MachineSet().WithName(mapiMachineSet.Name).WithNamespace(capiNamespace.Name).Build()
-					capaMachineTemplate := capav1builder.AWSMachineTemplate().WithName(mapiMachineSet.Name).WithNamespace(capiNamespace.Name).Build()
 
 					Eventually(k.Object(capiMachineSet), timeout).Should(
 						HaveField("OwnerReferences", Equal(capiClusterOwnerReference)),
 					)
 
+					Eventually(k.Get(capiMachineSet)).Should(Succeed())
+					capaMachineTemplate := capav1builder.AWSMachineTemplate().WithName(capiMachineSet.Spec.Template.Spec.InfrastructureRef.Name).WithNamespace(capiNamespace.Name).Build()
 					Eventually(k.Object(capaMachineTemplate), timeout).Should(
 						HaveField("OwnerReferences", Equal(capiClusterOwnerReference)),
 					)
@@ -696,10 +725,7 @@ var _ = Describe("With a running MachineSetSync controller", func() {
 					Eventually(k.Get(capiMachineSet)).Should(Succeed())
 				})
 
-				It("should create the CAPI infra machine template", func() {
-					capiInfraMachineTemplate := capav1builder.AWSMachineTemplate().WithName(mapiMachineSet.Name).WithNamespace(capiNamespace.Name).Build()
-					Eventually(k.Get(capiInfraMachineTemplate)).Should(Succeed())
-				})
+				It("should create the CAPI infra machine template", eventuallyCAPIMachineSetShouldHaveAWSMachineTemplateRefThatExists)
 
 				It("should update the synchronized condition on the MAPI machine set to True", func() {
 					Eventually(k.Object(mapiMachineSet), timeout).Should(
@@ -712,6 +738,58 @@ var _ = Describe("With a running MachineSetSync controller", func() {
 							))),
 					)
 				})
+
+				Context("when the MAPI machine set is updated", func() {
+					var oldMachineTemplate *awsv1.AWSMachineTemplate
+					BeforeEach(func() {
+						capiMachineSet = capiv1resourcebuilder.MachineSet().WithName(mapiMachineSet.Name).WithNamespace(capiNamespace.Name).Build()
+						Eventually(func() error {
+							if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(capiMachineSet), capiMachineSet); err != nil {
+								return err
+							}
+
+							oldMachineTemplate = capav1builder.AWSMachineTemplate().WithName(capiMachineSet.Spec.Template.Spec.InfrastructureRef.Name).WithNamespace(capiNamespace.Name).Build()
+
+							return k.Get(oldMachineTemplate)()
+						}).Should(Succeed())
+						// Update the MAPI machine set instance type
+						providerSpec, err := mapi2capi.AWSProviderSpecFromRawExtension(mapiMachineSet.Spec.Template.Spec.ProviderSpec.Value)
+						Expect(err).NotTo(HaveOccurred())
+						providerSpec.InstanceType = "new-instance-type"
+						updatedProviderSpec, err := json.Marshal(providerSpec)
+						Expect(err).NotTo(HaveOccurred())
+
+						Eventually(k.Update(mapiMachineSet, func() {
+							mapiMachineSet.Spec.Template.Spec.ProviderSpec.Value.Raw = updatedProviderSpec
+						})).Should(Succeed())
+					})
+
+					It("should create new CAPI infra machine template with updated instance type", func() {
+						capiMachineSet = capiv1resourcebuilder.MachineSet().WithName(mapiMachineSet.Name).WithNamespace(capiNamespace.Name).Build()
+						Eventually(func() (client.Object, error) {
+							_ = k8sClient.Get(ctx, client.ObjectKeyFromObject(capiMachineSet), capiMachineSet)
+							awsMachineTemplate := capav1builder.AWSMachineTemplate().WithName(capiMachineSet.Spec.Template.Spec.InfrastructureRef.Name).WithNamespace(capiNamespace.Name).Build()
+
+							return k.Object(awsMachineTemplate)()
+						}).Should(HaveField("Spec.Template.Spec.InstanceType", Equal("new-instance-type")))
+					})
+
+					It("should update the synchronized condition on the MAPI machine set to True", func() {
+						Eventually(k.Object(mapiMachineSet), timeout).Should(
+							HaveField("Status.Conditions", ContainElement(
+								SatisfyAll(
+									HaveField("Type", Equal(consts.SynchronizedCondition)),
+									HaveField("Status", Equal(corev1.ConditionTrue)),
+									HaveField("Reason", Equal("ResourceSynchronized")),
+									HaveField("Message", Equal("Successfully synchronized MAPI MachineSet to CAPI")),
+								))),
+						)
+					})
+
+					It("should delete the old CAPI infra machine template", func() {
+						Eventually(k.Get(oldMachineTemplate)).ShouldNot(Succeed())
+					})
+				})
 			})
 
 			Context("when the CAPI machine set does exist", func() {
@@ -720,10 +798,7 @@ var _ = Describe("With a running MachineSetSync controller", func() {
 					Expect(k8sClient.Create(ctx, capiMachineSet)).Should(Succeed())
 				})
 
-				It("should create the CAPI infra machine template", func() {
-					capiInfraMachineTemplate := capav1builder.AWSMachineTemplate().WithName(mapiMachineSet.Name).WithNamespace(capiNamespace.Name).Build()
-					Eventually(k.Get(capiInfraMachineTemplate)).Should(Succeed())
-				})
+				It("should create the CAPI infra machine template", eventuallyCAPIMachineSetShouldHaveAWSMachineTemplateRefThatExists)
 
 				It("should update the synchronized condition on the MAPI machine set to True", func() {
 					Eventually(k.Object(mapiMachineSet), timeout).Should(
@@ -776,10 +851,7 @@ var _ = Describe("With a running MachineSetSync controller", func() {
 					Expect(k8sClient.Create(ctx, capiMachineSet)).Should(Succeed())
 				})
 
-				It("should create the CAPI infra machine template", func() {
-					capiInfraMachineTemplate := capav1builder.AWSMachineTemplate().WithName(mapiMachineSet.Name).WithNamespace(capiNamespace.Name).Build()
-					Eventually(k.Get(capiInfraMachineTemplate)).Should(Succeed())
-				})
+				It("should create the CAPI infra machine template", eventuallyCAPIMachineSetShouldHaveAWSMachineTemplateRefThatExists)
 
 				It("should update the synchronized condition on the MAPI machine set to True", func() {
 					Eventually(k.Object(mapiMachineSet), timeout).Should(

--- a/pkg/controllers/machinesync/machine_sync_controller_test.go
+++ b/pkg/controllers/machinesync/machine_sync_controller_test.go
@@ -277,8 +277,13 @@ var _ = Describe("With a running MachineSync Reconciler", func() {
 			Context("when the MAPI machine providerSpec gets updated", func() {
 				BeforeEach(func() {
 					By("Updating the MAPI machine providerSpec")
+					modifiedMAPIMachineBuilder := machinev1resourcebuilder.Machine().
+						WithNamespace(mapiNamespace.GetName()).
+						WithName(mapiMachine.Name).
+						WithProviderSpecBuilder(machinev1resourcebuilder.AWSProviderSpec().WithLoadBalancers(nil).WithInstanceType("m6i.2xlarge")).Build()
+
 					Eventually(k.Update(mapiMachine, func() {
-						mapiMachine.Spec.ProviderSpec.Value = machinev1resourcebuilder.AWSProviderSpec().WithLoadBalancers(nil).WithInstanceType("m6i.2xlarge").BuildRawExtension()
+						mapiMachine.Spec.ProviderSpec = modifiedMAPIMachineBuilder.Spec.ProviderSpec
 					})).Should(Succeed())
 				})
 

--- a/pkg/util/hash.go
+++ b/pkg/util/hash.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package util
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"hash/fnv"
+)
+
+// GenerateInfraMachineTemplateNameWithSpecHash generates hash infra machine spec and combines it with infra machine name.
+// Resulting name is "<name>-<hash>" where <hash> is a hex string of 8 characters.
+// The hash function is FNV-1a 32-bit.
+func GenerateInfraMachineTemplateNameWithSpecHash(name string, spec interface{}) (string, error) {
+	jsonSpec, err := json.Marshal(spec)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal spec when creating infrastructure machine template: %w", err)
+	}
+
+	hasher := fnv.New32a()
+	if _, err := hasher.Write(jsonSpec); err != nil {
+		return "", fmt.Errorf("failed to write to hash: %w", err)
+	}
+
+	hashBytes := hasher.Sum(nil) // 32 bits make 8 hex digits
+
+	return fmt.Sprintf("%s-%s", name, hex.EncodeToString(hashBytes)), nil
+}


### PR DESCRIPTION
This PR adds missing logic when updating MAPI MachineSet that is AuthorativeAPI=MachineAPI.

Because CAPI Infrastructure machine templates are immutable, we need to recreate it.

The logic is as follows:
1. Create a new infrastructure machine template with hash of spec in its name to avoid name conflict.
2. Modify the CAPI machineSet to use the new machine template.
3. Delete old infrastructure machine template.

This PR also adds the `machine.openshift.io/cluster-api-machineset` label to infrastructure machine templates converted from MAPI. This label serves 2 purposes.

- It allows listing old infrastructure machine templates that were created from conversion and should be deleted. When the reconcile fails at step 3. Without the label, the CAPI machineSet after step 2 no longer points to the old infrastructure machine template, and it would get orphaned.
- We can implement admission webhook that ensures only the machineSet matching the label can use the template. This restriction will prevent use of converted templates, that could be deleted when MAPI machineset is updated, by other CAPI machine sets.

I think we should treat the admission webhook as a feature rather than this bug.