### PR TITLE
OCPBUGS-56487: fix: watch CAPI resources in the migration controllers

### DIFF
--- a/cmd/machine-api-migration/main.go
+++ b/cmd/machine-api-migration/main.go
@@ -240,6 +240,9 @@ func main() {
 	}
 
 	machineMigrationReconciler := machinemigration.MachineMigrationReconciler{
+		Platform: provider,
+		Infra:    infra,
+
 		MAPINamespace: *mapiManagedNamespace,
 		CAPINamespace: *capiManagedNamespace,
 	}
@@ -250,6 +253,9 @@ func main() {
 	}
 
 	machineSetMigrationReconciler := machinesetmigration.MachineSetMigrationReconciler{
+		Platform: provider,
+		Infra:    infra,
+
 		MAPINamespace: *mapiManagedNamespace,
 		CAPINamespace: *capiManagedNamespace,
 	}

--- a/pkg/controllers/common.go
+++ b/pkg/controllers/common.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package controllers
+
+import (
+	"errors"
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	capav1beta2 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	capibmv1 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	// errPlatformNotSupported is returned when the platform is not supported.
+	errPlatformNotSupported = errors.New("error determining InfraMachine type, platform not supported")
+)
+
+// InitInfraMachineAndInfraClusterFromProvider returns the correct InfraMachine and InfraCluster implementation
+// for a given provider.
+//
+// As we implement other cloud providers, we'll need to update this list.
+func InitInfraMachineAndInfraClusterFromProvider(platform configv1.PlatformType) (client.Object, client.Object, error) {
+	switch platform {
+	case configv1.AWSPlatformType:
+		return &capav1beta2.AWSMachine{}, &capav1beta2.AWSCluster{}, nil
+	case configv1.PowerVSPlatformType:
+		return &capibmv1.IBMPowerVSMachine{}, &capibmv1.IBMPowerVSCluster{}, nil
+	default:
+		return nil, nil, fmt.Errorf("%w: %s", errPlatformNotSupported, platform)
+	}
+}
+
+// InitInfraMachineTemplateAndInfraClusterFromProvider returns the correct InfraMachineTemplate and InfraCluster implementation
+// for a given provider.
+//
+// As we implement other cloud providers, we'll need to update this list.
+func InitInfraMachineTemplateAndInfraClusterFromProvider(platform configv1.PlatformType) (client.Object, client.Object, error) {
+	switch platform {
+	case configv1.AWSPlatformType:
+		return &capav1beta2.AWSMachineTemplate{}, &capav1beta2.AWSCluster{}, nil
+	case configv1.PowerVSPlatformType:
+		return &capibmv1.IBMPowerVSMachineTemplate{}, &capibmv1.IBMPowerVSCluster{}, nil
+	default:
+		return nil, nil, fmt.Errorf("%w: %s", errPlatformNotSupported, platform)
+	}
+}

--- a/pkg/controllers/machinemigration/machine_migration_controller.go
+++ b/pkg/controllers/machinemigration/machine_migration_controller.go
@@ -33,12 +33,14 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	configv1 "github.com/openshift/api/config/v1"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	machinev1applyconfigs "github.com/openshift/client-go/machine/applyconfigurations/machine/v1beta1"
-	consts "github.com/openshift/cluster-capi-operator/pkg/controllers"
+	"github.com/openshift/cluster-capi-operator/pkg/controllers"
 	"github.com/openshift/cluster-capi-operator/pkg/util"
 )
 
@@ -47,27 +49,45 @@ const controllerName = "MachineMigrationController"
 // MachineMigrationReconciler reconciles Machine resources for migration.
 type MachineMigrationReconciler struct {
 	client.Client
-	Scheme        *runtime.Scheme
-	Recorder      record.EventRecorder
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
+
+	Infra         *configv1.Infrastructure
+	Platform      configv1.PlatformType
 	CAPINamespace string
 	MAPINamespace string
 }
 
 // SetupWithManager sets up the MachineMigration controller.
 func (r *MachineMigrationReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	infraMachine, _, err := controllers.InitInfraMachineAndInfraClusterFromProvider(r.Platform)
+	if err != nil {
+		return fmt.Errorf("failed to get infrastructure machine from Provider: %w", err)
+	}
+
 	// Allow the namespaces to be set externally for test purposes, when not set,
 	// default to the production namespaces.
 	if r.CAPINamespace == "" {
-		r.CAPINamespace = consts.DefaultManagedNamespace
+		r.CAPINamespace = controllers.DefaultManagedNamespace
 	}
 
 	if r.MAPINamespace == "" {
-		r.MAPINamespace = consts.DefaultMAPIManagedNamespace
+		r.MAPINamespace = controllers.DefaultMAPIManagedNamespace
 	}
 
 	if err := ctrl.NewControllerManagedBy(mgr).
 		Named(controllerName).
 		For(&machinev1beta1.Machine{}, builder.WithPredicates(util.FilterNamespace(r.MAPINamespace))).
+		Watches(
+			&capiv1beta1.Machine{},
+			handler.EnqueueRequestsFromMapFunc(util.RewriteNamespace(r.MAPINamespace)),
+			builder.WithPredicates(util.FilterNamespace(r.CAPINamespace)),
+		).
+		Watches(
+			infraMachine,
+			handler.EnqueueRequestsFromMapFunc(util.RewriteNamespace(r.MAPINamespace)),
+			builder.WithPredicates(util.FilterNamespace(r.CAPINamespace)),
+		).
 		Complete(r); err != nil {
 		return fmt.Errorf("failed to create controller: %w", err)
 	}
@@ -115,7 +135,7 @@ func (r *MachineMigrationReconciler) Reconcile(ctx context.Context, req reconcil
 
 	// Check if the Synchronized condition is set to True.
 	// If it is not, this indicates an unmigratable resource and therefore should take no action.
-	if cond, err := util.GetConditionStatus(mapiMachine, string(consts.SynchronizedCondition)); err != nil {
+	if cond, err := util.GetConditionStatus(mapiMachine, string(controllers.SynchronizedCondition)); err != nil {
 		return ctrl.Result{}, fmt.Errorf("unable to get synchronizedCondition for %s/%s: %w", mapiMachine.Namespace, mapiMachine.Name, err)
 	} else if cond != corev1.ConditionTrue {
 		logger.Info("Machine not synchronized with latest authoritative generation, will retry later")
@@ -374,7 +394,7 @@ func (r *MachineMigrationReconciler) setNewAuthoritativeAPIAndResetSynchronized(
 	var newConditions []*machinev1applyconfigs.ConditionApplyConfiguration
 
 	for _, cond := range m.Status.Conditions {
-		if cond.Type != consts.SynchronizedCondition {
+		if cond.Type != controllers.SynchronizedCondition {
 			newConditions = append(newConditions, &machinev1applyconfigs.ConditionApplyConfiguration{
 				LastTransitionTime: &cond.LastTransitionTime,
 				Message:            &cond.Message,


### PR DESCRIPTION
The CAPI resources were not being watched by the migration controllers (both the machine and the machineset ones).
This meant that if the status of the CAPI resource changed from Paused: True to Paused: False or vice-versa, this would not get detected by the migration controllers, which would stay waiting in `Requested pausing for authoritative machine set` when moving a MachineSet authoritativeness from CAPI to MAPI.