### PR TITLE
OCPBUGS-56805: fix: patch status instead of updating it to avoid failed loop

### DIFF
--- a/pkg/operatorstatus/operator_status.go
+++ b/pkg/operatorstatus/operator_status.go
@@ -161,12 +161,14 @@ func (r *ClusterOperatorStatusClient) GetOrCreateClusterOperator(ctx context.Con
 
 // SyncStatus applies the new condition to the ClusterOperator object.
 func (r *ClusterOperatorStatusClient) SyncStatus(ctx context.Context, co *configv1.ClusterOperator, conds []configv1.ClusterOperatorStatusCondition) error {
+	patchBase := client.MergeFrom(co.DeepCopy())
+
 	for _, c := range conds {
 		v1helpers.SetStatusCondition(&co.Status.Conditions, c, clock.RealClock{})
 	}
 
-	if err := r.Client.Status().Update(ctx, co); err != nil {
-		return fmt.Errorf("failed to update cluster operator status: %w", err)
+	if err := r.Client.Status().Patch(ctx, co, patchBase); err != nil {
+		return fmt.Errorf("failed to patch cluster operator status: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
At the moment the `cluster-capi-operator` manager is running in a hot loop trying to Update() the ClusterOperator status with the most recent conditions.

```
E0527 19:07:44.303923       1 controller.go:316] "Reconciler error" err="failed to set conditions for InfraCluster controller: failed to sync status: failed to update cluster operator status: Operation cannot be fulfilled on clusteroperators.config.openshift.io \"cluster-api\": the object has been modified; please apply your changes to the latest version and try again" controller="InfraClusterController" controllerGroup="config.openshift.io" controllerKind="ClusterOperator" ClusterOperator="cluster-api" namespace="" name="cluster-api" reconcileID="434ea0cf-83d3-442c-bde6-1fedddf4ffef"
...
E0527 19:07:44.357363       1 controller.go:316] "Reconciler error" err="failed to set status available: failed to update cluster operator status: Operation cannot be fulfilled on clusteroperators.config.openshift.io \"cluster-api\": the object has been modified; please apply your changes to the latest version and try again" controller="CoreClusterController" controllerGroup="config.openshift.io" controllerKind="ClusterOperator" ClusterOperator="cluster-api" namespace="" name="cluster-api" reconcileID="9f4c2c13-ede1-4981-8761-988bfb4f66bb"
...
E0527 19:07:44.443030       1 controller.go:316] "Reconciler error" err="failed to set conditions for CAPI Installer Controller: failed to sync status: failed to update cluster operator status: Operation cannot be fulfilled on clusteroperators.config.openshift.io \"cluster-api\": the object has been modified; please apply your changes to the latest version and try again" controller="CapiInstallerController" controllerGroup="config.openshift.io" controllerKind="ClusterOperator" ClusterOperator="cluster-api" namespace="" name="cluster-api" reconcileID="eded91df-8801-4313-ab1e-321813387601"
```
(more logs [here](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_cluster-capi-operator/299/pull-ci-openshift-cluster-capi-operator-main-e2e-aws-capi-techpreview/1927428378592284672/artifacts/e2e-aws-capi-techpreview/gather-extra/artifacts/pods/openshift-cluster-api_cluster-capi-operator-84f4597b4b-2h2b8_cluster-capi-operator.log))

This should instead be using a Patch() to do so to avoid conflicts on all the non relevant fields.

This is a short term fix until we reintroduce a more refined status updating mechanism + SSA which was originally merged with: https://github.com/openshift/cluster-capi-operator/pull/256 but got reverted by https://github.com/openshift/cluster-capi-operator/pull/273