### PR TITLE
Revert "TRT-2048: Revert "OCPCLOUD-2792: corecluster: set controller level conditions + tests""

### DIFF
--- a/pkg/controllers/capiinstaller/capi_installer_controller.go
+++ b/pkg/controllers/capiinstaller/capi_installer_controller.go
@@ -286,7 +286,7 @@ func (r *CapiInstallerController) setAvailableCondition(ctx context.Context, log
 
 	log.V(2).Info("CAPI Installer Controller is Available")
 
-	if err := r.SyncStatus(ctx, co, conds); err != nil {
+	if err := r.SyncStatus(ctx, controllerName, co, conds); err != nil {
 		return fmt.Errorf("failed to sync status: %w", err)
 	}
 
@@ -311,7 +311,7 @@ func (r *CapiInstallerController) setDegradedCondition(ctx context.Context, log 
 
 	log.Info("CAPI Installer Controller is Degraded")
 
-	if err := r.SyncStatus(ctx, co, conds); err != nil {
+	if err := r.SyncStatus(ctx, controllerName, co, conds); err != nil {
 		return fmt.Errorf("failed to sync status: %w", err)
 	}
 

--- a/pkg/controllers/clusteroperator/clusteroperator_controller.go
+++ b/pkg/controllers/clusteroperator/clusteroperator_controller.go
@@ -54,6 +54,11 @@ func (r *ClusterOperatorController) Reconcile(ctx context.Context, req ctrl.Requ
 	} else {
 		// TODO: wrap this into status aggregation logic to get these conditions conform,
 		// to the meaningful aggregation of all the other controllers ones.
+		//
+		// TODO: set a time period where if one of the controllers conditions has been degraded=true (reduced QoS)
+		// for an extended period of time (eg. 30mins, degrade top level) we set the overall operator degraded=true.
+		// For any controller available=false condition instead (e.g. when the CAPI components are failing to run),
+		// we should immediately set the overall operator available=false immediately.
 		if err := r.ClusterOperatorStatusClient.SetStatusAvailable(ctx, ""); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to set conditions for %q ClusterObject: %w", controllers.ClusterOperatorName, err)
 		}

--- a/pkg/controllers/corecluster/corecluster_controller.go
+++ b/pkg/controllers/corecluster/corecluster_controller.go
@@ -46,6 +46,12 @@ const (
 	capiInfraClusterAPIVersionV1Beta1 = "infrastructure.cluster.x-k8s.io/v1beta1"
 	capiInfraClusterAPIVersionV1Beta2 = "infrastructure.cluster.x-k8s.io/v1beta2"
 	clusterOperatorName               = "cluster-api"
+
+	// CoreClusterControllerAvailableCondition is the condition type that indicates the CoreCluster controller is available.
+	CoreClusterControllerAvailableCondition = "CoreClusterControllerAvailable"
+
+	// CoreClusterControllerDegradedCondition is the condition type that indicates the CoreCluster controller is degraded.
+	CoreClusterControllerDegradedCondition = "CoreClusterControllerDegraded"
 )
 
 var (
@@ -53,6 +59,9 @@ var (
 	errUnsupportedPlatformType                     = errors.New("unsupported platform type")
 	errOpenshiftInfraShouldNotBeNil                = errors.New("infrastructure object should not be nil")
 	errOpenshiftInfrastructureNameShouldNotBeEmpty = errors.New("infrastructure object's infrastructureName should not be empty")
+
+	//nolint:gochecknoglobals
+	expectedConditionTypes = []string{CoreClusterControllerAvailableCondition, CoreClusterControllerDegradedCondition}
 )
 
 // CoreClusterController reconciles a Cluster object.
@@ -81,38 +90,73 @@ func (r *CoreClusterController) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 // Reconcile reconciles the core cluster object for the openshift-cluster-api namespace.
+//
+//nolint:funlen
 func (r *CoreClusterController) Reconcile(ctx context.Context, req reconcile.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx).WithName(controllerName)
 	logger.Info("Reconciling core cluster")
 	defer logger.Info("Finished reconciling core cluster")
 
+	var err error
+
+	co, err := r.GetOrCreateClusterOperator(ctx)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get or create cluster operator: %w", err)
+	}
+
+	// Populate conditions from the existing cluster operator status.
+	conditions := operatorstatus.FilterOwnedConditions(co.Status.Conditions, expectedConditionTypes)
+
+	defer func() {
+		// This function runs before every return, to ensure the controller conditions
+		// for that codepath are correctly synced to the cluster operator status.
+		if syncErr := r.SyncControllerConditions(ctx, co, controllerName, conditions, expectedConditionTypes); syncErr != nil {
+			if err != nil {
+				// The sync of the controller conditions failed but there is also a non nil reconcile error.
+				// Log the sync error and pass down the reconciler one.
+				logger.Error(syncErr, "failed to sync cluster operator status")
+			} else {
+				// If there is no reconcile error, but there is a sync error, then we want to propagate the
+				// sync error to be returned by the Reconcile function, so that it will cause an immediate requeue/retry.
+				err = syncErr
+			}
+		}
+	}()
+
 	ocpInfrastructureName, err := getOCPInfrastructureName(r.Infra)
 	if err != nil {
+		operatorstatus.SetCondition(conditions, CoreClusterControllerDegradedCondition, configv1.ConditionTrue,
+			operatorstatus.ReasonSyncFailed, fmt.Sprintf("controller is degraded: %s", err.Error()))
+
 		return ctrl.Result{}, fmt.Errorf("failed to obtain infrastructure name: %w", err)
 	}
 
 	cluster, err := r.ensureCoreCluster(ctx, client.ObjectKey{Namespace: r.ManagedNamespace, Name: ocpInfrastructureName}, logger)
 	if err != nil {
+		operatorstatus.SetCondition(conditions, CoreClusterControllerDegradedCondition, configv1.ConditionTrue,
+			operatorstatus.ReasonSyncFailed, fmt.Sprintf("controller is degraded: %s", err.Error()))
+
 		return ctrl.Result{}, fmt.Errorf("failed to ensure core cluster: %w", err)
 	}
 
 	if !cluster.DeletionTimestamp.IsZero() {
-		if err := r.SetStatusAvailable(ctx, ""); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to set status available: %w", err)
-		}
-
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, err
 	}
 
 	if err := r.ensureCoreClusterControlPlaneInitializedCondition(ctx, cluster); err != nil {
+		operatorstatus.SetCondition(conditions, CoreClusterControllerDegradedCondition, configv1.ConditionTrue,
+			operatorstatus.ReasonSyncFailed, fmt.Sprintf("controller is degraded: %s", err.Error()))
+
 		return ctrl.Result{}, fmt.Errorf("failed to ensure core cluster has the ControlPlaneInitializedCondition: %w", err)
 	}
 
-	if err := r.SetStatusAvailable(ctx, ""); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to set status available: %w", err)
-	}
+	operatorstatus.SetCondition(conditions, CoreClusterControllerDegradedCondition, configv1.ConditionFalse,
+		operatorstatus.ReasonAsExpected, "controller works as expected")
 
-	return ctrl.Result{}, nil
+	operatorstatus.SetCondition(conditions, CoreClusterControllerAvailableCondition, configv1.ConditionTrue,
+		operatorstatus.ReasonAsExpected, "controller is available")
+
+	return ctrl.Result{}, err
 }
 
 // ensureCoreCluster creates a cluster with the given name and returns the cluster object.

--- a/pkg/controllers/corecluster/corecluster_controller_test.go
+++ b/pkg/controllers/corecluster/corecluster_controller_test.go
@@ -35,6 +35,7 @@ import (
 	capabuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2"
 	configv1resourcebuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/config/v1"
 	corev1resourcebuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/core/v1"
+	"github.com/openshift/cluster-capi-operator/pkg/controllers"
 	"github.com/openshift/cluster-capi-operator/pkg/operatorstatus"
 )
 
@@ -100,7 +101,7 @@ var _ = Describe("Reconcile Core cluster", func() {
 		testNamespaceName = namespace.Name
 
 		By("Creating the testing ClusterOperator object")
-		cO := configv1resourcebuilder.ClusterOperator().WithName(clusterOperatorName).Build()
+		cO := configv1resourcebuilder.ClusterOperator().WithName(controllers.ClusterOperatorName).Build()
 		Expect(cl.Create(ctx, cO)).To(Succeed())
 	})
 
@@ -143,12 +144,22 @@ var _ = Describe("Reconcile Core cluster", func() {
 		Context("When there is no core cluster", func() {
 			Context("When there is no infra cluster", func() {
 				It("should not create core or infra cluster", func() {
-
 					testInfraCluster := capabuilder.AWSCluster().WithName(testInfraName).WithNamespace(testNamespaceName).Build()
 					Consistently(komega.Get(testInfraCluster)).Should(MatchError("awsclusters.infrastructure.cluster.x-k8s.io \"test-ocp-infrastructure-name\" not found"))
 
 					testCoreCluster := capibuilder.Cluster().WithName(testInfraName).WithNamespace(testNamespaceName).Build()
 					Consistently(komega.Get(testCoreCluster)).Should(MatchError("clusters.cluster.x-k8s.io \"test-ocp-infrastructure-name\" not found"))
+				})
+
+				It("should update the ClusterOperator status conditions with controller specific ones to reflect a degraded state", func() {
+					Eventually(komega.Object(configv1resourcebuilder.ClusterOperator().WithName(controllers.ClusterOperatorName).Build())).Should(
+						HaveField("Status.Conditions", SatisfyAll(
+							ContainElement(And(
+								HaveField("Type", BeEquivalentTo(CoreClusterControllerDegradedCondition)),
+								HaveField("Status", BeEquivalentTo(configv1.ConditionTrue)),
+							)),
+						)),
+					)
 				})
 			})
 
@@ -173,28 +184,19 @@ var _ = Describe("Reconcile Core cluster", func() {
 					)
 				})
 
-				Context("With a ClusterOperator", func() {
-					It("should update the ClusterOperator status to be available, upgradeable, non-progressing, non-degraded", func() {
-						co := komega.Object(configv1resourcebuilder.ClusterOperator().WithName(clusterOperatorName).Build())
-						Eventually(co).Should(
-							HaveField("Status.Conditions", SatisfyAll(
-								ContainElement(And(HaveField("Type", Equal(configv1.OperatorAvailable)), HaveField("Status", Equal(configv1.ConditionTrue)))),
-								ContainElement(And(HaveField("Type", Equal(configv1.OperatorProgressing)), HaveField("Status", Equal(configv1.ConditionFalse)))),
-								ContainElement(And(HaveField("Type", Equal(configv1.OperatorDegraded)), HaveField("Status", Equal(configv1.ConditionFalse)))),
-								ContainElement(And(HaveField("Type", Equal(configv1.OperatorUpgradeable)), HaveField("Status", Equal(configv1.ConditionTrue)))),
+				It("should update the ClusterOperator status conditions with controller specific ones to reflect a normal state", func() {
+					Eventually(komega.Object(configv1resourcebuilder.ClusterOperator().WithName(controllers.ClusterOperatorName).Build())).Should(
+						HaveField("Status.Conditions", SatisfyAll(
+							ContainElement(And(
+								HaveField("Type", BeEquivalentTo(CoreClusterControllerAvailableCondition)),
+								HaveField("Status", BeEquivalentTo(configv1.ConditionTrue)),
 							)),
-						)
-					})
-
-					It("should update the ClusterOperator status version to the desired one", func() {
-						co := komega.Object(configv1resourcebuilder.ClusterOperator().WithName(clusterOperatorName).Build())
-						Eventually(co).Should(
-							HaveField("Status.Versions", ContainElement(SatisfyAll(
-								HaveField("Name", Equal("operator")),
-								HaveField("Version", Equal(desiredOperatorReleaseVersion)),
-							))),
-						)
-					})
+							ContainElement(And(
+								HaveField("Type", BeEquivalentTo(CoreClusterControllerDegradedCondition)),
+								HaveField("Status", BeEquivalentTo(configv1.ConditionFalse)),
+							)),
+						)),
+					)
 				})
 			})
 		})
@@ -233,10 +235,28 @@ var _ = Describe("Reconcile Core cluster", func() {
 						)),
 					)
 				})
+
+				It("should update the ClusterOperator status conditions with controller specific ones to reflect a normal state", func() {
+					Eventually(komega.Object(configv1resourcebuilder.ClusterOperator().WithName(controllers.ClusterOperatorName).Build())).Should(
+						HaveField("Status.Conditions", SatisfyAll(
+							ContainElement(And(
+								HaveField("Type", BeEquivalentTo(CoreClusterControllerAvailableCondition)),
+								HaveField("Status", BeEquivalentTo(configv1.ConditionTrue)),
+							)),
+							ContainElement(And(
+								HaveField("Type", BeEquivalentTo(CoreClusterControllerDegradedCondition)),
+								HaveField("Status", BeEquivalentTo(configv1.ConditionFalse)),
+							)),
+						)),
+					)
+				})
 			})
+
 		})
 	})
 
+	// This case should not happen as this controller should not run on an unsupported platform.
+	// Still we want to test this as we have logic in place to handle cases where the controller runs out of band.
 	Context("With an unsupported platform", func() {
 		BeforeEach(func() {
 			By("Creating the testing infrastructure for NonePlatform")
@@ -253,7 +273,7 @@ var _ = Describe("Reconcile Core cluster", func() {
 					Type: configv1.NonePlatformType,
 				},
 			}
-			Expect(cl.Status().Patch(ctx, noneInfra, client.MergeFrom(infra))).To(Succeed())
+			Expect(cl.Status().Patch(ctx, infra, client.MergeFrom(noneInfra))).To(Succeed())
 		})
 
 		JustBeforeEach(func() {

--- a/pkg/controllers/infracluster/infracluster_controller.go
+++ b/pkg/controllers/infracluster/infracluster_controller.go
@@ -254,7 +254,7 @@ func (r *InfraClusterController) setAvailableCondition(ctx context.Context, log 
 
 	log.V(2).Info("InfraCluster Controller is Available")
 
-	if err := r.SyncStatus(ctx, co, conds); err != nil {
+	if err := r.SyncStatus(ctx, controllerName, co, conds); err != nil {
 		return fmt.Errorf("failed to sync status: %w", err)
 	}
 

--- a/pkg/controllers/secretsync/secret_sync_controller.go
+++ b/pkg/controllers/secretsync/secret_sync_controller.go
@@ -203,7 +203,7 @@ func (r *UserDataSecretController) setAvailableCondition(ctx context.Context, lo
 
 	log.Info("user Data Secret Controller is available")
 
-	if err := r.SyncStatus(ctx, co, conds); err != nil {
+	if err := r.SyncStatus(ctx, controllerName, co, conds); err != nil {
 		return fmt.Errorf("failed to sync status: %w", err)
 	}
 
@@ -227,7 +227,7 @@ func (r *UserDataSecretController) setDegradedCondition(ctx context.Context, log
 
 	log.Info("user Data Secret Controller is degraded")
 
-	if err := r.SyncStatus(ctx, co, conds); err != nil {
+	if err := r.SyncStatus(ctx, controllerName, co, conds); err != nil {
 		return fmt.Errorf("failed to sync status: %w", err)
 	}
 

--- a/pkg/operatorstatus/operator_status.go
+++ b/pkg/operatorstatus/operator_status.go
@@ -26,12 +26,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/clock"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	configv1 "github.com/openshift/api/config/v1"
+	configv1applyconfigs "github.com/openshift/client-go/config/applyconfigurations/config/v1"
 	"github.com/openshift/cluster-capi-operator/pkg/controllers"
+	"github.com/openshift/cluster-capi-operator/pkg/util"
 	"github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
 )
 
@@ -82,7 +83,7 @@ func (r *ClusterOperatorStatusClient) SetStatusAvailable(ctx context.Context, av
 
 	if co, shouldUpdate := clusterObjectNeedsUpdating(co, conds, r.operandVersions(), r.relatedObjects()); shouldUpdate {
 		log.V(2).Info("syncing status: available")
-		return r.SyncStatus(ctx, co, conds)
+		return r.SyncStatus(ctx, "cluster-operator-status-client", co, conds)
 	}
 
 	return nil
@@ -111,8 +112,7 @@ func (r *ClusterOperatorStatusClient) SetStatusDegraded(ctx context.Context, rec
 	}
 
 	conds := []configv1.ClusterOperatorStatusCondition{
-		NewClusterOperatorStatusCondition(configv1.OperatorDegraded, configv1.ConditionTrue,
-			ReasonSyncFailed, message),
+		NewClusterOperatorStatusCondition(configv1.OperatorDegraded, configv1.ConditionTrue, ReasonSyncFailed, message),
 		NewClusterOperatorStatusCondition(configv1.OperatorUpgradeable, configv1.ConditionFalse, ReasonAsExpected, ""),
 	}
 
@@ -122,7 +122,7 @@ func (r *ClusterOperatorStatusClient) SetStatusDegraded(ctx context.Context, rec
 			r.Recorder.Eventf(co, corev1.EventTypeWarning, "Status degraded", reconcileErr.Error())
 			log.V(2).Info("syncing status: degraded", "message", message)
 
-			return r.SyncStatus(ctx, co, conds)
+			return r.SyncStatus(ctx, "cluster-operator-status-client", co, conds)
 		}
 	}
 
@@ -159,14 +159,88 @@ func (r *ClusterOperatorStatusClient) GetOrCreateClusterOperator(ctx context.Con
 	return co, nil
 }
 
-// SyncStatus applies the new condition to the ClusterOperator object.
-func (r *ClusterOperatorStatusClient) SyncStatus(ctx context.Context, co *configv1.ClusterOperator, conds []configv1.ClusterOperatorStatusCondition) error {
-	for _, c := range conds {
-		v1helpers.SetStatusCondition(&co.Status.Conditions, c, clock.RealClock{})
+// SyncControllerConditions syncs the controller conditions to the ClusterOperator object status.
+func (r *ClusterOperatorStatusClient) SyncControllerConditions(ctx context.Context, co *configv1.ClusterOperator, controllerName string, conditions *[]configv1.ClusterOperatorStatusCondition, expectedConditionTypes []string) error {
+	// Mark the conditions not present as Unknown.
+	for _, v := range getMissingConditionTypes(conditions, expectedConditionTypes) {
+		co.Status.Conditions = append(co.Status.Conditions, NewClusterOperatorStatusCondition(configv1.ClusterStatusConditionType(v), configv1.ConditionUnknown, "Unknown", ""))
 	}
 
-	if err := r.Client.Status().Update(ctx, co); err != nil {
-		return fmt.Errorf("failed to update cluster operator status: %w", err)
+	if err := r.SyncStatus(ctx, controllerName, co, *conditions); err != nil {
+		return fmt.Errorf("failed to sync cluster operator status: %w", err)
+	}
+
+	return nil
+}
+
+func getMissingConditionTypes(conditions *[]configv1.ClusterOperatorStatusCondition, expectedConditionTypes []string) []string {
+	missing := []string{}
+
+	for _, e := range expectedConditionTypes {
+		found := false
+
+		for _, c := range *conditions {
+			if c.Type == configv1.ClusterStatusConditionType(e) {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			missing = append(missing, e)
+		}
+	}
+
+	return missing
+}
+
+// SyncStatus syncs the updated status to the ClusterOperator object.
+func (r *ClusterOperatorStatusClient) SyncStatus(ctx context.Context, fieldOwner string, co *configv1.ClusterOperator, conds []configv1.ClusterOperatorStatusCondition) error {
+	// Convert conditions to applyConfig ones.
+	conditionsAc := make([]*configv1applyconfigs.ClusterOperatorStatusConditionApplyConfiguration, len(conds))
+	for i, c := range conds {
+		conditionsAc[i] = configv1applyconfigs.
+			ClusterOperatorStatusCondition().
+			WithType(c.Type).
+			WithStatus(c.Status).
+			WithReason(c.Reason).
+			WithMessage(c.Message).
+			WithLastTransitionTime(c.LastTransitionTime)
+	}
+
+	// Convert OperatorVersion to applyConfig.
+	versionsAc := make([]*configv1applyconfigs.OperandVersionApplyConfiguration, len(co.Status.Versions))
+	for i, v := range co.Status.Versions {
+		versionsAc[i] = &configv1applyconfigs.OperandVersionApplyConfiguration{
+			Name:    &v.Name,
+			Version: &v.Version,
+		}
+	}
+
+	// Convert RelatedObjects to applyConfig.
+	relatedObjectsAc := make([]*configv1applyconfigs.ObjectReferenceApplyConfiguration, len(co.Status.RelatedObjects))
+	for i, o := range co.Status.RelatedObjects {
+		relatedObjectsAc[i] = &configv1applyconfigs.ObjectReferenceApplyConfiguration{
+			Group:     &o.Group,
+			Name:      &o.Name,
+			Namespace: &o.Namespace,
+			Resource:  &o.Resource,
+		}
+	}
+
+	// Define the applyConfig to use as a patch.
+	coAc := configv1applyconfigs.
+		ClusterOperator(co.Name).
+		WithStatus(
+			configv1applyconfigs.ClusterOperatorStatus().
+				WithConditions(conditionsAc...).
+				WithRelatedObjects(relatedObjectsAc...).
+				WithVersions(versionsAc...),
+		)
+
+	// Apply the patch using ServerSideApply.
+	if err := r.Status().Patch(ctx, co, util.ApplyConfigPatch(coAc), client.ForceOwnership, client.FieldOwner(fieldOwner)); err != nil {
+		return fmt.Errorf("failed to patch cluster operator status with conditions: %w", err)
 	}
 
 	return nil
@@ -234,6 +308,35 @@ func NewClusterOperatorStatusCondition(conditionType configv1.ClusterStatusCondi
 	}
 }
 
+// SetCondition updates or appends a condition to the conditions slice.
+// If the condition doesn't exist, it will be appended as a new entry,
+// otherwise if a condition of the same type already exists, it will be updated.
+// It also handles the condition LastTransitionTime.
+func SetCondition(conditions *[]configv1.ClusterOperatorStatusCondition, conditionType configv1.ClusterStatusConditionType,
+	conditionStatus configv1.ConditionStatus, reason string, message string) {
+	newCond := NewClusterOperatorStatusCondition(conditionType, conditionStatus, reason, message)
+
+	// Try to find and update existing condition.
+	for i := range *conditions {
+		if (*conditions)[i].Type == newCond.Type {
+			// The condition already exists.
+			if (*conditions)[i].Status == newCond.Status {
+				// The condition status hasn't changed, retain the previous lastTransitionTime.
+				newCond.LastTransitionTime = (*conditions)[i].LastTransitionTime
+			}
+
+			// Override the existing condition with the new one.
+			(*conditions)[i] = newCond
+
+			// Return early as we found and updated the condition in the slice.
+			return
+		}
+	}
+
+	// If we get here, condition wasn't found, so append it.
+	*conditions = append(*conditions, newCond)
+}
+
 func printOperandVersions(versions []configv1.OperandVersion) string {
 	versionsOutput := []string{}
 	for _, operand := range versions {
@@ -263,4 +366,19 @@ func clusterObjectNeedsUpdating(co *configv1.ClusterOperator, conds []configv1.C
 	}
 
 	return co, shouldUpdate
+}
+
+// FilterOwnedConditions returns filters the list of provided conditions based on whether they have an expected condition type.
+func FilterOwnedConditions(conditions []configv1.ClusterOperatorStatusCondition, expectedConditionTypes []string) *[]configv1.ClusterOperatorStatusCondition {
+	filtered := []configv1.ClusterOperatorStatusCondition{}
+
+	for _, e := range expectedConditionTypes {
+		for _, c := range conditions {
+			if c.Type == configv1.ClusterStatusConditionType(e) {
+				filtered = append(filtered, c)
+			}
+		}
+	}
+
+	return &filtered
 }


### PR DESCRIPTION
Reverts openshift/cluster-capi-operator#273 which is the revert of https://github.com/openshift/cluster-capi-operator/pull/256

Context: https://redhat-internal.slack.com/archives/C01CQA76KMX/p1748604228528099?thread_ts=1741634385.702679&cid=C01CQA76KMX