### PR TITLE
OCPBUGS-57040: Fix failure to retry unpause

### DIFF
--- a/pkg/controllers/machinemigration/machine_migration_controller.go
+++ b/pkg/controllers/machinemigration/machine_migration_controller.go
@@ -190,14 +190,14 @@ func (r *MachineMigrationReconciler) Reconcile(ctx context.Context, req reconcil
 		return ctrl.Result{}, nil
 	}
 
-	// Set the actual AuthoritativeAPI to the desired one, reset the synchronized generation and condition.
-	if err := r.setNewAuthoritativeAPIAndResetSynchronized(ctx, mapiMachine, mapiMachine.Spec.AuthoritativeAPI); err != nil {
-		return ctrl.Result{}, fmt.Errorf("unable to apply authoritativeAPI to status with patch: %w", err)
-	}
-
 	// Make sure the new authoritative resource has been requested to unpause.
 	if err := r.ensureUnpauseRequestedOnNewAuthoritativeResource(ctx, mapiMachine); err != nil {
 		return ctrl.Result{}, fmt.Errorf("unable to ensure the new AuthoritativeAPI has been un-paused: %w", err)
+	}
+
+	// Set the actual AuthoritativeAPI to the desired one, reset the synchronized generation and condition.
+	if err := r.setNewAuthoritativeAPIAndResetSynchronized(ctx, mapiMachine, mapiMachine.Spec.AuthoritativeAPI); err != nil {
+		return ctrl.Result{}, fmt.Errorf("unable to apply authoritativeAPI to status with patch: %w", err)
 	}
 
 	logger.Info("Machine authority switch has now been completed and the resource unpaused")

--- a/pkg/controllers/machinesetmigration/machineset_migration_controller.go
+++ b/pkg/controllers/machinesetmigration/machineset_migration_controller.go
@@ -187,14 +187,14 @@ func (r *MachineSetMigrationReconciler) Reconcile(ctx context.Context, req recon
 		return ctrl.Result{}, nil
 	}
 
-	// Set the actual AuthoritativeAPI to the desired one, reset the synchronized generation and condition.
-	if err := r.setNewAuthoritativeAPIAndResetSynchronized(ctx, mapiMachineSet, mapiMachineSet.Spec.AuthoritativeAPI); err != nil {
-		return ctrl.Result{}, fmt.Errorf("unable to apply authoritativeAPI to status with patch: %w", err)
-	}
-
 	// Make sure the new authoritative resource has been requested to unpause.
 	if err := r.ensureUnpauseRequestedOnNewAuthoritativeResource(ctx, mapiMachineSet); err != nil {
 		return ctrl.Result{}, fmt.Errorf("unable to ensure the new AuthoritativeAPI has been un-paused: %w", err)
+	}
+
+	// Set the actual AuthoritativeAPI to the desired one, reset the synchronized generation and condition.
+	if err := r.setNewAuthoritativeAPIAndResetSynchronized(ctx, mapiMachineSet, mapiMachineSet.Spec.AuthoritativeAPI); err != nil {
+		return ctrl.Result{}, fmt.Errorf("unable to apply authoritativeAPI to status with patch: %w", err)
 	}
 
 	logger.Info("Machine set authority switch has now been completed and the resource unpaused")


### PR DESCRIPTION
The migration controllers shortcut reconciliation if their status indicate prior success. Therefore setting this status must be the last thing the controller does after all work is complete.

We were unpausing after setting completion status. Therefore if we failed to set unpause due to, e.g. an epheral api-server issue, we would never retry.