### PR TITLE
fix: synchronized condition should reset on migration

### DIFF
--- a/pkg/controllers/common_consts.go
+++ b/pkg/controllers/common_consts.go
@@ -43,4 +43,8 @@ const (
 	// ReasonResourceSynchronized denotes that the resource is synchronized
 	// successfully.
 	ReasonResourceSynchronized = "ResourceSynchronized"
+
+	// ReasonResourceAuthoritySwitched denotes that the resource is synchronization
+	// state is unknown due to the recent resource authority switch.
+	ReasonResourceAuthoritySwitched = "ResourceAuthoritySwitched"
 )


### PR DESCRIPTION
Superseded by https://github.com/openshift/cluster-capi-operator/pull/313

---
Synchronized condition should reset on successful migration.
To then let the sync controllers take ownership of the condition and switch it back to True when a new sync has happened.
It is sufficient for us to unset the True and move to Unknown for this.
