### PR TITLE
NO-JIRA: Remove manifest for validating-webhook-configuration

### DIFF
--- a/manifests/0000_30_cluster-api_10_webhooks.yaml
+++ b/manifests/0000_30_cluster-api_10_webhooks.yaml
@@ -100,14 +100,3 @@ webhooks:
         resources:
           - providers
     sideEffects: None
----
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
-metadata:
-  annotations:
-    exclude.release.openshift.io/internal-openshift-hosted: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-set: "CustomNoUpgrade,TechPreviewNoUpgrade"
-    release.openshift.io/delete: "true"
-  name: validating-webhook-configuration


### PR DESCRIPTION
kind of post-cleanup of https://github.com/openshift/cluster-capi-operator/pull/145

reduce the unused number of yamls, cvo will not reconcile this yaml

it only works when upgrade from 4.15, can be removed in the newest version(4.20)