### PR TITLE
NO-JIRA: migration controllers: add comment for authority propagation logic

### DIFF
--- a/pkg/controllers/machinemigration/machine_migration_controller.go
+++ b/pkg/controllers/machinemigration/machine_migration_controller.go
@@ -125,6 +125,11 @@ func (r *MachineMigrationReconciler) Reconcile(ctx context.Context, req reconcil
 
 	// If authoritativeAPI status is empty, it means it is the first time we see this resource.
 	// Set the status.authoritativeAPI to match the spec.authoritativeAPI.
+	//
+	// N.B. Very similar logic is also present in the Machine API machine/machineset controllers
+	// to cover for the cases when the migration controller is not running (e.g. on not yet supported platforms),
+	// as such if any change is done to this logic, please consider changing it also there. See:
+	// https://github.com/openshift/machine-api-operator/pull/1386/files#diff-8a4a734efbb8fef769f9f6ba5d30d94f19433a0b1eaeb1be4f2a55aa226c3b3dR180-R197
 	if mapiMachine.Status.AuthoritativeAPI == "" {
 		if err := r.applyStatusAuthoritativeAPIWithPatch(ctx, mapiMachine, mapiMachine.Spec.AuthoritativeAPI); err != nil {
 			return ctrl.Result{}, fmt.Errorf("unable to apply authoritativeAPI to status with patch: %w", err)

--- a/pkg/controllers/machinesetmigration/machineset_migration_controller.go
+++ b/pkg/controllers/machinesetmigration/machineset_migration_controller.go
@@ -125,6 +125,11 @@ func (r *MachineSetMigrationReconciler) Reconcile(ctx context.Context, req recon
 
 	// If authoritativeAPI status is empty, it means it is the first time we see this resource.
 	// Set the status.authoritativeAPI to match the spec.authoritativeAPI.
+	//
+	// N.B. Very similar logic is also present in the Machine API machine/machineset controllers
+	// to cover for the cases when the migration controller is not running (e.g. on not yet supported platforms),
+	// as such if any change is done to this logic, please consider changing it also there. See:
+	// https://github.com/openshift/machine-api-operator/pull/1386/files#diff-3a93acbdaa255c0afa7f52535fc7df9c3890d6403035dd4c3bd47b0092eb3a37R177-R194
 	if mapiMachineSet.Status.AuthoritativeAPI == "" {
 		if err := r.applyStatusAuthoritativeAPIWithPatch(ctx, mapiMachineSet, mapiMachineSet.Spec.AuthoritativeAPI); err != nil {
 			return ctrl.Result{}, fmt.Errorf("unable to apply authoritativeAPI to status with patch: %w", err)


### PR DESCRIPTION
As discussed in https://github.com/openshift/machine-api-operator/pull/1386/files#r2182473725 and https://redhat-internal.slack.com/archives/GE2HQ9QP4/p1751536658080839 we want to add a comment to tell that this logic is duplicated in other places and should be considered to be changed in tandem.