### PR TITLE
NO-JIRA: Get openshift/api directory from packages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/openshift/library-go v0.0.0-20250527100820-96e64a9a7065
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.6
+	golang.org/x/tools v0.28.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.32.3
 	k8s.io/apiextensions-apiserver v0.32.3
@@ -279,7 +280,6 @@ require (
 	golang.org/x/term v0.29.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 	golang.org/x/time v0.7.0 // indirect
-	golang.org/x/tools v0.28.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20241209162323-e6fa225c2576 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241209162323-e6fa225c2576 // indirect


### PR DESCRIPTION
This causes the envtests to automatically use a locally overridden openshift/api package. It continues to use the vendor directory by default while we use vendoring, but will also continue working seamlessly if we ever stop using vendoring.
