### PR TITLE
NO-JIRA: Improve ergonomics of running tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 # vendor/
 
 bin/
+/.localtestenv

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "editor.stickyScroll.defaultModel": "foldingProviderModel"
+    "editor.stickyScroll.defaultModel": "foldingProviderModel",
+    "go.testEnvFile": "${workspaceFolder}/.localtestenv"
 }

--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,16 @@ migration:
 	# building migration
 	go build -o bin/machine-api-migration cmd/machine-api-migration/main.go
 
+.PHONY: localtestenv
+localtestenv: .localtestenv
+
+KUBEBUILDER_ASSETS ?= $(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path --bin-dir $(PROJECT_DIR)/bin --index https://raw.githubusercontent.com/openshift/api/master/envtest-releases.yaml)
+.localtestenv: Makefile
+	echo "KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS)" > $@
+
 TEST_DIRS ?= ./pkg/... ./manifests-gen/...
-unit:
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path --bin-dir $(PROJECT_DIR)/bin --index https://raw.githubusercontent.com/openshift/api/master/envtest-releases.yaml)" ./hack/test.sh "$(TEST_DIRS)" 10m
+unit: .localtestenv
+	./hack/test.sh "$(TEST_DIRS)" 10m
 
 .PHONY: e2e
 e2e:

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -5,6 +5,11 @@ set -o pipefail
 
 REPO_ROOT=$(dirname "${BASH_SOURCE}")/..
 
+localtestenv=${REPO_ROOT}/.localtestenv
+if [ -e "$localtestenv" ]; then
+    export $(xargs < "$localtestenv")
+fi
+
 # Use existing value of TEST_DIRS, or $1 if not set. Makes it easier to target suites.
 TEST_DIRS=${TEST_DIRS:-$1}
 # Use 2nd arg, or 5m.


### PR DESCRIPTION
This PR is a roundup of several minor enhancements:

* VSCode: Default stickyScroll to foldingProviderModel

This has the advantage of working for Ginkgo tests, where it is incredibly useful. The default 'outline' model does not work there. It can still be overridden in user configuration.

* Allow test package override in make unit

This allows you to run `make unit TEST_DIRS=./pkg/controllers/capiinstaller/...` and it will run only those tests.

* Set KUBEBUILDER_ASSETS when running tests from VS Code

The KUBEBUILDER_ASSETS environment variable is required to run envtests. This change causes VS Code to read a local environment file called `.localtestenv` when running tests, and adds a make target to generate it.

Note that this currently requires manually running `make localtestenv` before attempting to invoke tests from VS Code. There's probably a way to modify the default launch configuration to do this automatically.