### PR TITLE
NO-JIRA: lint: Replace tenv with usetesting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,7 +56,7 @@ linters:
     - revive
     - stylecheck
     - tagliatelle
-    - tenv
+    - usetesting
     - unconvert
     - unparam
     - wastedassign


### PR DESCRIPTION
Resolve the following warning currently being emitted when linting:

    WARN The linter 'tenv' is deprecated (since v1.64.0) due to: Duplicate feature in another linter. Replaced by usetesting.
