### PR TITLE
OCPCLOUD-2871: Machine conversion for the delete-machine annotation and unit tests

### DIFF
--- a/pkg/conversion/capi2mapi/common.go
+++ b/pkg/conversion/capi2mapi/common.go
@@ -26,6 +26,8 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
+var mapiDeleteMachineAnnotation = "machine.openshift.io/delete-machine"
+
 // RawExtensionFromProviderSpec marshals the machine provider spec.
 func RawExtensionFromProviderSpec(spec interface{}) (*runtime.RawExtension, error) {
 	if spec == nil {
@@ -138,6 +140,11 @@ func convertCAPIAnnotationsToMAPIAnnotations(capiAnnotations map[string]string) 
 	for k, v := range capiAnnotations {
 		if toNotConvertAnnotations.Has(k) {
 			// Skip this annotation.
+			continue
+		}
+
+		if k == clusterv1.DeleteMachineAnnotation {
+			capiAnnotations[mapiDeleteMachineAnnotation] = v
 			continue
 		}
 

--- a/pkg/conversion/capi2mapi/common.go
+++ b/pkg/conversion/capi2mapi/common.go
@@ -143,7 +143,7 @@ func convertCAPIAnnotationsToMAPIAnnotations(capiAnnotations map[string]string) 
 		}
 
 		if k == clusterv1.DeleteMachineAnnotation {
-			capiAnnotations[util.MapiDeleteMachineAnnotation] = v
+			mapiAnnotations[util.MapiDeleteMachineAnnotation] = v
 			continue
 		}
 

--- a/pkg/conversion/capi2mapi/common.go
+++ b/pkg/conversion/capi2mapi/common.go
@@ -20,13 +20,12 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/openshift/cluster-capi-operator/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
-
-var mapiDeleteMachineAnnotation = "machine.openshift.io/delete-machine"
 
 // RawExtensionFromProviderSpec marshals the machine provider spec.
 func RawExtensionFromProviderSpec(spec interface{}) (*runtime.RawExtension, error) {
@@ -144,7 +143,7 @@ func convertCAPIAnnotationsToMAPIAnnotations(capiAnnotations map[string]string) 
 		}
 
 		if k == clusterv1.DeleteMachineAnnotation {
-			capiAnnotations[mapiDeleteMachineAnnotation] = v
+			capiAnnotations[util.MapiDeleteMachineAnnotation] = v
 			continue
 		}
 

--- a/pkg/conversion/capi2mapi/machine_test.go
+++ b/pkg/conversion/capi2mapi/machine_test.go
@@ -20,9 +20,11 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/api/machine/v1beta1"
 	capibuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/cluster-api/core/v1beta1"
 	capabuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2"
 	"github.com/openshift/cluster-capi-operator/pkg/conversion/test/matchers"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -37,19 +39,24 @@ var _ = Describe("capi2mapi Machine conversion", func() {
 		machineBuilder   capibuilder.MachineBuilder
 		expectedErrors   []string
 		expectedWarnings []string
+		assertion        func(machine *v1beta1.Machine)
 	}
 
 	var _ = DescribeTable("capi2mapi convert CAPI Machine/InfraMachine/InfraCluster to a MAPI Machine",
 		func(in capi2MAPIMachineConversionInput) {
-			_, warns, err := FromMachineAndAWSMachineAndAWSCluster(
+			m := FromMachineAndAWSMachineAndAWSCluster(
 				in.machineBuilder.Build(),
 				capabuilder.AWSMachine().Build(),
 				capabuilder.AWSCluster().Build(),
-			).ToMachine()
+			)
+			machine, warns, err := m.ToMachine()
 			Expect(err).To(matchers.ConsistOfMatchErrorSubstrings(in.expectedErrors),
 				"should match expected errors while converting CAPI resources to MAPI Machine")
 			Expect(warns).To(matchers.ConsistOfSubstrings(in.expectedWarnings),
 				"should match expected warnings while converting CAPI resources to MAPI Machine")
+			if in.assertion != nil {
+				in.assertion(machine)
+			}
 		},
 
 		// Base Case.
@@ -77,6 +84,15 @@ var _ = Describe("capi2mapi Machine conversion", func() {
 			machineBuilder:   capiMachineBase.WithNodeDeletionTimeout(ptr.To(metav1.Duration{Duration: 1 * time.Second})),
 			expectedErrors:   []string{"spec.nodeDeletionTimeout: Invalid value: v1.Duration{Duration:1000000000}: nodeDeletionTimeout is not supported"},
 			expectedWarnings: []string{},
+		}),
+		Entry("With delete-machine annotation", capi2MAPIMachineConversionInput{
+			machineBuilder:   capiMachineBase.WithAnnotations(map[string]string{clusterv1.DeleteMachineAnnotation: "true"}),
+			expectedErrors:   []string{},
+			expectedWarnings: []string{},
+			assertion: func(machine *v1beta1.Machine) {
+				Expect(machine.Annotations).To(HaveKeyWithValue(mapiDeleteMachineAnnotation, "true"))
+				Expect(machine.Annotations).ToNot(HaveKey(clusterv1.DeleteMachineAnnotation))
+			},
 		}),
 	)
 })

--- a/pkg/conversion/capi2mapi/machine_test.go
+++ b/pkg/conversion/capi2mapi/machine_test.go
@@ -24,6 +24,7 @@ import (
 	capibuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/cluster-api/core/v1beta1"
 	capabuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2"
 	"github.com/openshift/cluster-capi-operator/pkg/conversion/test/matchers"
+	"github.com/openshift/cluster-capi-operator/pkg/util"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -90,7 +91,7 @@ var _ = Describe("capi2mapi Machine conversion", func() {
 			expectedErrors:   []string{},
 			expectedWarnings: []string{},
 			assertion: func(machine *v1beta1.Machine) {
-				Expect(machine.Annotations).To(HaveKeyWithValue(mapiDeleteMachineAnnotation, "true"))
+				Expect(machine.Annotations).To(HaveKeyWithValue(util.MapiDeleteMachineAnnotation, "true"))
 				Expect(machine.Annotations).ToNot(HaveKey(clusterv1.DeleteMachineAnnotation))
 			},
 		}),

--- a/pkg/conversion/mapi2capi/machine_test.go
+++ b/pkg/conversion/mapi2capi/machine_test.go
@@ -23,6 +23,7 @@ import (
 	configbuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/config/v1"
 	machinebuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1beta1"
 	"github.com/openshift/cluster-capi-operator/pkg/conversion/test/matchers"
+	"github.com/openshift/cluster-capi-operator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -128,12 +129,12 @@ var _ = Describe("mapi2capi Machine conversion", func() {
 
 		Entry("With delete-machine annotation", mapi2CAPIMachineConversionInput{
 			infraBuilder:     infraBase,
-			machineBuilder:   mapiMachineBase.WithAnnotations(map[string]string{mapiDeleteMachineAnnotation: "true"}),
+			machineBuilder:   mapiMachineBase.WithAnnotations(map[string]string{util.MapiDeleteMachineAnnotation: "true"}),
 			expectedErrors:   []string{},
 			expectedWarnings: []string{},
 			assertion: func(machine *mapiv1.Machine) {
 				Expect(machine.Annotations).To(HaveKeyWithValue(clusterv1.DeleteMachineAnnotation, "true"))
-				Expect(machine.Annotations).ToNot(HaveKey(mapiDeleteMachineAnnotation))
+				Expect(machine.Annotations).ToNot(HaveKey(util.MapiDeleteMachineAnnotation))
 			},
 		}),
 	)

--- a/pkg/conversion/mapi2capi/machine_test.go
+++ b/pkg/conversion/mapi2capi/machine_test.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 var _ = Describe("mapi2capi Machine conversion", func() {
@@ -40,6 +41,7 @@ var _ = Describe("mapi2capi Machine conversion", func() {
 		infraBuilder     configbuilder.InfrastructureBuilder
 		expectedErrors   []string
 		expectedWarnings []string
+		assertion        func(machine *mapiv1.Machine)
 	}
 	var _ = DescribeTable("mapi2capi convert MAPI Machine to a CAPI Machine",
 		func(in mapi2CAPIMachineConversionInput) {
@@ -122,6 +124,17 @@ var _ = Describe("mapi2capi Machine conversion", func() {
 			}}),
 			expectedErrors:   []string{"spec.taints: Invalid value: []v1.Taint{v1.Taint{Key:\"key1\", Value:\"value1\", Effect:\"NoSchedule\", TimeAdded:<nil>}}: taints are not currently supported"},
 			expectedWarnings: []string{},
+		}),
+
+		Entry("With delete-machine annotation", mapi2CAPIMachineConversionInput{
+			infraBuilder:     infraBase,
+			machineBuilder:   mapiMachineBase.WithAnnotations(map[string]string{mapiDeleteMachineAnnotation: "true"}),
+			expectedErrors:   []string{},
+			expectedWarnings: []string{},
+			assertion: func(machine *mapiv1.Machine) {
+				Expect(machine.Annotations).To(HaveKeyWithValue(clusterv1.DeleteMachineAnnotation, "true"))
+				Expect(machine.Annotations).ToNot(HaveKey(mapiDeleteMachineAnnotation))
+			},
 		}),
 	)
 })

--- a/pkg/conversion/mapi2capi/util.go
+++ b/pkg/conversion/mapi2capi/util.go
@@ -20,12 +20,11 @@ import (
 	"fmt"
 
 	mapiv1 "github.com/openshift/api/machine/v1beta1"
+	"github.com/openshift/cluster-capi-operator/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
-
-var mapiDeleteMachineAnnotation = "machine.openshift.io/delete-machine"
 
 func convertMAPIMachineSetSelectorToCAPI(mapiSelector metav1.LabelSelector) metav1.LabelSelector {
 	capiSelector := mapiSelector.DeepCopy()
@@ -74,10 +73,11 @@ func convertMAPIAnnotationsToCAPI(mapiAnnotations map[string]string) map[string]
 	capiAnnotations := make(map[string]string)
 
 	for k, v := range mapiAnnotations {
-		if k == mapiDeleteMachineAnnotation {
+		if k == util.MapiDeleteMachineAnnotation {
 			capiAnnotations[clusterv1.DeleteMachineAnnotation] = v
 			continue
 		}
+
 		capiAnnotations[k] = v
 	}
 

--- a/pkg/conversion/mapi2capi/util.go
+++ b/pkg/conversion/mapi2capi/util.go
@@ -25,6 +25,8 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
+var mapiDeleteMachineAnnotation = "machine.openshift.io/delete-machine"
+
 func convertMAPIMachineSetSelectorToCAPI(mapiSelector metav1.LabelSelector) metav1.LabelSelector {
 	capiSelector := mapiSelector.DeepCopy()
 	capiSelector.MatchLabels = convertMAPILabelsToCAPI(mapiSelector.MatchLabels)
@@ -72,6 +74,10 @@ func convertMAPIAnnotationsToCAPI(mapiAnnotations map[string]string) map[string]
 	capiAnnotations := make(map[string]string)
 
 	for k, v := range mapiAnnotations {
+		if k == mapiDeleteMachineAnnotation {
+			capiAnnotations[clusterv1.DeleteMachineAnnotation] = v
+			continue
+		}
 		capiAnnotations[k] = v
 	}
 

--- a/pkg/util/annotations.go
+++ b/pkg/util/annotations.go
@@ -21,9 +21,7 @@ import (
 
 // MapiDeleteMachineAnnotation is the delete-machine annotation used in Machine API.
 // It has an equivalent annotation in Cluster API to convert to.
-//
-//nolint:gochecknoglobals
-var MapiDeleteMachineAnnotation = "machine.openshift.io/delete-machine"
+const MapiDeleteMachineAnnotation = "machine.openshift.io/delete-machine"
 
 // RemoveAnnotation deletes a specific annotation from a client.Object.
 func RemoveAnnotation(obj client.Object, key string) {

--- a/pkg/util/annotations.go
+++ b/pkg/util/annotations.go
@@ -19,6 +19,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// MapiDeleteMachineAnnotation is the delete-machine annotation used in Machine API.
+// It has an equivalent annotation in Cluster API to convert to.
+//
+//nolint:gochecknoglobals
+var MapiDeleteMachineAnnotation = "machine.openshift.io/delete-machine"
+
 // RemoveAnnotation deletes a specific annotation from a client.Object.
 func RemoveAnnotation(obj client.Object, key string) {
 	annotations := obj.GetAnnotations()


### PR DESCRIPTION
Implements bi-directional conversion for mapi`s <-> capi's delete-machine annotations:

* mapi:  `machine.openshift.io/delete-machine`
* capi: `cluster.x-k8s.io/delete-machine`

