### PR TITLE
OCPCLOUD-2709: Implement MAPI2CAPI conversion of loadbalancers

### DIFF
--- a/cmd/cluster-capi-operator/main.go
+++ b/cmd/cluster-capi-operator/main.go
@@ -419,6 +419,11 @@ func getDefaultCacheOptions(capiNamespace string, sync time.Duration) cache.Opti
 					defaultMachineAPINamespace: {},
 				},
 			},
+			&mapiv1beta1.Machine{}: {
+				Namespaces: map[string]cache.Config{
+					defaultMachineAPINamespace: {},
+				},
+			},
 		},
 	}
 }

--- a/pkg/controllers/infracluster/aws.go
+++ b/pkg/controllers/infracluster/aws.go
@@ -17,34 +17,50 @@ package infracluster
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/go-logr/logr"
 	cerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 	awsv1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	mapiv1beta1 "github.com/openshift/api/machine/v1beta1"
+)
+
+var (
+	// ErrNoControlPlaneLoadBalancerConfigured indicates there is no control plane load balancer configuration present.
+	ErrNoControlPlaneLoadBalancerConfigured = errors.New("no control plane load balancer configured")
+	// ErrNilProviderSpec indicates a nil provider spec raw extension.
+	ErrNilProviderSpec = errors.New("provider spec is nil")
+	// ErrInvalidNumberOfControlPlaneLoadBalancers indicates an invalid number of control plane load balancers has been configured.
+	ErrInvalidNumberOfControlPlaneLoadBalancers = errors.New("invalid number of control plane load balancers")
+	// ErrUnsupportedLoadBalancerType indicates an unsupported load balancer type.
+	ErrUnsupportedLoadBalancerType = errors.New("unsupported load balancer type")
 )
 
 // ensureAWSCluster ensures the AWSCluster cluster object exists.
 func (r *InfraClusterController) ensureAWSCluster(ctx context.Context, log logr.Logger) (client.Object, error) {
-	target := &awsv1.AWSCluster{ObjectMeta: metav1.ObjectMeta{
+	awsCluster := &awsv1.AWSCluster{ObjectMeta: metav1.ObjectMeta{
 		Name:      r.Infra.Status.InfrastructureName,
-		Namespace: defaultCAPINamespace,
+		Namespace: r.CAPINamespace,
 	}}
 
 	// Checking whether InfraCluster object exists. If it doesn't, create it.
-
-	if err := r.Get(ctx, client.ObjectKeyFromObject(target), target); err != nil && !cerrors.IsNotFound(err) {
+	if err := r.Get(ctx, client.ObjectKeyFromObject(awsCluster), awsCluster); err != nil && !cerrors.IsNotFound(err) {
 		return nil, fmt.Errorf("failed to get InfraCluster: %w", err)
 	} else if err == nil {
-		return target, nil
+		return awsCluster, nil
 	}
 
-	log.Info(fmt.Sprintf("AWSCluster %s/%s does not exist, creating it", target.Namespace, target.Name))
+	log = log.WithValues("AWSCluster", klog.KObj(awsCluster))
+	log.Info("AWSCluster does not exist, creating it")
 
 	apiURL, err := url.Parse(r.Infra.Status.APIServerInternalURL)
 	if err != nil {
@@ -60,10 +76,35 @@ func (r *InfraClusterController) ensureAWSCluster(ctx context.Context, log logr.
 		return nil, fmt.Errorf("infrastructure PlatformStatus should not be nil: %w", err)
 	}
 
-	target = &awsv1.AWSCluster{
+	providerSpec, err := r.getAWSMAPIProviderSpec(ctx, r.Client)
+	if err != nil {
+		return nil, fmt.Errorf("unable to obtain MAPI ProviderSpec: %w", err)
+	}
+
+	awsCluster, err = r.newAWSCluster(providerSpec, apiURL, int32(port))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get AWSCluster: %w", err)
+	}
+
+	if err := r.Create(ctx, awsCluster); err != nil {
+		return nil, fmt.Errorf("failed to create AWSCluster: %w", err)
+	}
+
+	log.Info("AWSCluster successfully created")
+
+	return awsCluster, nil
+}
+
+func (r *InfraClusterController) newAWSCluster(providerSpec *mapiv1beta1.AWSMachineProviderConfig, apiURL *url.URL, port int32) (*awsv1.AWSCluster, error) {
+	controlPlaneLoadBalancer, secondaryControlPlaneLoadBalancer, err := extractLoadBalancerConfigFromMAPIAWSProviderSpec(providerSpec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract control plane load balancer configuration: %w", err)
+	}
+
+	target := &awsv1.AWSCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      r.Infra.Status.InfrastructureName,
-			Namespace: defaultCAPINamespace,
+			Namespace: r.CAPINamespace,
 			// The ManagedBy Annotation is set so CAPI infra providers ignore the InfraCluster object,
 			// as that's managed externally, in this case by this controller.
 			Annotations: map[string]string{
@@ -74,7 +115,7 @@ func (r *InfraClusterController) ensureAWSCluster(ctx context.Context, log logr.
 			Region: r.Infra.Status.PlatformStatus.AWS.Region,
 			ControlPlaneEndpoint: clusterv1.APIEndpoint{
 				Host: apiURL.Hostname(),
-				Port: int32(port),
+				Port: port,
 			},
 			// This default IdentityRef will be created by the controlleridentitycreator controller.
 			// Leaving it as nil works the same as this value, but fills the log with log messages
@@ -84,14 +125,80 @@ func (r *InfraClusterController) ensureAWSCluster(ctx context.Context, log logr.
 				Kind: awsv1.ControllerIdentityKind,
 				Name: "default",
 			},
+			// Set control plane load balancer configuration extracted from MAPI machines
+			ControlPlaneLoadBalancer:          controlPlaneLoadBalancer,
+			SecondaryControlPlaneLoadBalancer: secondaryControlPlaneLoadBalancer,
 		},
 	}
 
-	if err := r.Create(ctx, target); err != nil {
-		return nil, fmt.Errorf("failed to create InfraCluster: %w", err)
+	return target, nil
+}
+
+func (r *InfraClusterController) getAWSMAPIProviderSpec(ctx context.Context, cl client.Client) (*mapiv1beta1.AWSMachineProviderConfig, error) {
+	return getMAPIProviderSpec[mapiv1beta1.AWSMachineProviderConfig](ctx, cl, r.getRawMAPIProviderSpec)
+}
+
+// extractLoadBalancerConfigFromMAPIAWSProviderSpec extracts one or two control plane load balancers from a MAPI machine's provider spec.
+// When two load balancers are present, the one whose name ends with "-int" is preferred as the return value.
+// Returns an error if zero or more than two load balancers are defined.
+func extractLoadBalancerConfigFromMAPIAWSProviderSpec(providerSpec *mapiv1beta1.AWSMachineProviderConfig) (*awsv1.AWSLoadBalancerSpec, *awsv1.AWSLoadBalancerSpec, error) {
+	if providerSpec == nil {
+		return nil, nil, ErrNilProviderSpec
 	}
 
-	log.Info(fmt.Sprintf("InfraCluster '%s/%s' successfully created", defaultCAPINamespace, r.Infra.Status.InfrastructureName))
+	switch len(providerSpec.LoadBalancers) {
+	case 0:
+		return nil, nil, ErrNoControlPlaneLoadBalancerConfigured
+	case 1:
+		lbPrimary := providerSpec.LoadBalancers[0]
 
-	return target, nil
+		lbType, err := convertMAPILoadBalancerTypeToCAPI(lbPrimary.Type)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to convert load balancer type: %w", err)
+		}
+
+		return &awsv1.AWSLoadBalancerSpec{
+			Name:             &lbPrimary.Name,
+			LoadBalancerType: lbType,
+		}, nil, nil
+	case 2:
+		lbFirst := providerSpec.LoadBalancers[0]
+		lbSecond := providerSpec.LoadBalancers[1]
+		// Prefer the load balancer with "-int" suffix as primary when two are present.
+		if strings.HasSuffix(lbSecond.Name, "-int") && !strings.HasSuffix(lbFirst.Name, "-int") {
+			lbFirst, lbSecond = lbSecond, lbFirst
+		}
+
+		lbTypeFirst, err := convertMAPILoadBalancerTypeToCAPI(lbFirst.Type)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to convert load balancer type: %w", err)
+		}
+
+		lbTypeSecond, err := convertMAPILoadBalancerTypeToCAPI(lbSecond.Type)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to convert load balancer type: %w", err)
+		}
+
+		return &awsv1.AWSLoadBalancerSpec{
+				Name:             &lbFirst.Name,
+				LoadBalancerType: lbTypeFirst,
+			}, &awsv1.AWSLoadBalancerSpec{
+				Name:             &lbSecond.Name,
+				LoadBalancerType: lbTypeSecond,
+			}, nil
+	default:
+		return nil, nil, fmt.Errorf("%w: expected 1 or 2, got %d", ErrInvalidNumberOfControlPlaneLoadBalancers, len(providerSpec.LoadBalancers))
+	}
+}
+
+// convertMAPILoadBalancerTypeToCAPI converts MAPI AWSLoadBalancerType to CAPI LoadBalancerType.
+func convertMAPILoadBalancerTypeToCAPI(mapiType mapiv1beta1.AWSLoadBalancerType) (awsv1.LoadBalancerType, error) {
+	switch mapiType {
+	case mapiv1beta1.ClassicLoadBalancerType:
+		return awsv1.LoadBalancerTypeClassic, nil
+	case mapiv1beta1.NetworkLoadBalancerType:
+		return awsv1.LoadBalancerTypeNLB, nil
+	default:
+		return "", fmt.Errorf("%w: unknown load balancer type: %s", ErrUnsupportedLoadBalancerType, mapiType)
+	}
 }

--- a/pkg/controllers/infracluster/metal3.go
+++ b/pkg/controllers/infracluster/metal3.go
@@ -33,7 +33,7 @@ import (
 func (r *InfraClusterController) ensureMetal3Cluster(ctx context.Context, log logr.Logger) (client.Object, error) {
 	target := &metal3v1.Metal3Cluster{ObjectMeta: metav1.ObjectMeta{
 		Name:      r.Infra.Status.InfrastructureName,
-		Namespace: defaultCAPINamespace,
+		Namespace: r.CAPINamespace,
 	}}
 
 	// Checking whether InfraCluster object exists. If it doesn't, create it.
@@ -58,7 +58,7 @@ func (r *InfraClusterController) ensureMetal3Cluster(ctx context.Context, log lo
 	target = &metal3v1.Metal3Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      r.Infra.Status.InfrastructureName,
-			Namespace: defaultCAPINamespace,
+			Namespace: r.CAPINamespace,
 			// The ManagedBy Annotation is set so CAPI infra providers ignore the InfraCluster object,
 			// as that's managed externally, in this case by the cluster-capi-operator's infracluster controller.
 			Annotations: map[string]string{
@@ -78,7 +78,7 @@ func (r *InfraClusterController) ensureMetal3Cluster(ctx context.Context, log lo
 		return nil, fmt.Errorf("failed to creat InfraCluster: %w", err)
 	}
 
-	log.Info(fmt.Sprintf("InfraCluster '%s/%s' successfully created", defaultCAPINamespace, r.Infra.Status.InfrastructureName))
+	log.Info(fmt.Sprintf("InfraCluster '%s/%s' successfully created", r.CAPINamespace, r.Infra.Status.InfrastructureName))
 
 	return target, nil
 }

--- a/pkg/controllers/machinesync/aws.go
+++ b/pkg/controllers/machinesync/aws.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machinesync
+
+import (
+	"context"
+	"fmt"
+
+	mapiv1beta1 "github.com/openshift/api/machine/v1beta1"
+	"github.com/openshift/cluster-capi-operator/pkg/conversion/capi2mapi"
+	"github.com/openshift/cluster-capi-operator/pkg/conversion/mapi2capi"
+	"github.com/openshift/cluster-capi-operator/pkg/util"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
+	awsv1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// validateMachineAWSLoadBalancers validates that when converting from MAPI->CAPI:
+//   - Control plane machines must define an internal load balancer with "-int" suffix.
+//   - Control plane machines can define an secondary external load balancer with "-ext" suffix.
+//   - MAPI machine's load balancers must match the AWSCluster load balancers.
+//   - Worker machines must not define load balancers.
+func (r *MachineSyncReconciler) validateMachineAWSLoadBalancers(ctx context.Context, mapiMachine *mapiv1beta1.Machine) error {
+	providerSpec, err := mapi2capi.AWSProviderSpecFromRawExtension(mapiMachine.Spec.ProviderSpec.Value)
+	if err != nil {
+		return fmt.Errorf("unable to parse Machine API providerSpec: %w", err)
+	}
+
+	lbFieldPath := field.NewPath("spec", "providerSpec", "value", "loadBalancers")
+
+	if !util.IsControlPlaneMAPIMachine(mapiMachine) {
+		if len(providerSpec.LoadBalancers) == 0 {
+			return nil
+		}
+
+		return field.Invalid(lbFieldPath, providerSpec.LoadBalancers, "loadBalancers are not supported for non-control plane machines")
+	}
+
+	awsCluster := &awsv1.AWSCluster{}
+	if err := r.Get(ctx, client.ObjectKey{Namespace: r.CAPINamespace, Name: r.Infra.Status.InfrastructureName}, awsCluster); err != nil {
+		return fmt.Errorf("failed to get AWSCluster: %w", err)
+	}
+
+	if awsCluster.Spec.ControlPlaneLoadBalancer == nil || ptr.Deref(awsCluster.Spec.ControlPlaneLoadBalancer.Name, "") == "" {
+		return field.Invalid(lbFieldPath, providerSpec.LoadBalancers, "no control plane load balancer configured on AWSCluster")
+	}
+
+	controlPlaneLB, err := capi2mapi.ConvertAWSLoadBalancerToMAPI(awsCluster.Spec.ControlPlaneLoadBalancer)
+	if err != nil {
+		return field.Invalid(lbFieldPath, providerSpec.LoadBalancers, fmt.Sprintf("failed to convert control plane load balancer: %v", err))
+	}
+
+	expectedLoadBalancers := map[string]mapiv1beta1.AWSLoadBalancerType{
+		ptr.Deref(awsCluster.Spec.ControlPlaneLoadBalancer.Name, ""): controlPlaneLB.Type,
+	}
+
+	if awsCluster.Spec.SecondaryControlPlaneLoadBalancer != nil {
+		if ptr.Deref(awsCluster.Spec.SecondaryControlPlaneLoadBalancer.Name, "") == "" {
+			return field.Invalid(lbFieldPath, providerSpec.LoadBalancers, "secondary control plane load balancer name is not configured on AWSCluster")
+		}
+
+		secondaryControlPlaneLB, err := capi2mapi.ConvertAWSLoadBalancerToMAPI(awsCluster.Spec.SecondaryControlPlaneLoadBalancer)
+		if err != nil {
+			return field.Invalid(lbFieldPath, providerSpec.LoadBalancers, fmt.Sprintf("failed to convert secondary control plane load balancer: %v", err))
+		}
+
+		expectedLoadBalancers[ptr.Deref(awsCluster.Spec.SecondaryControlPlaneLoadBalancer.Name, "")] = secondaryControlPlaneLB.Type
+	}
+
+	return validateLoadBalancerReferencesAgainstExpected(providerSpec.LoadBalancers, expectedLoadBalancers, lbFieldPath)
+}
+
+// validateLoadBalancerReferencesAgainstExpected validates that the actual load balancers match the expected load balancers.
+func validateLoadBalancerReferencesAgainstExpected(
+	actualLoadBalancers []mapiv1beta1.LoadBalancerReference,
+	expectedLoadBalancers map[string]mapiv1beta1.AWSLoadBalancerType,
+	lbFieldPath *field.Path,
+) error {
+	errs := field.ErrorList{}
+	foundLoadBalancers := map[string]bool{}
+
+	for i, lb := range actualLoadBalancers {
+		indexPath := lbFieldPath.Index(i)
+
+		expectedType, isExpected := expectedLoadBalancers[lb.Name]
+		if !isExpected {
+			errs = append(errs, field.Invalid(indexPath.Child("name"), lb.Name, fmt.Sprintf("unexpected load balancer %q defined on machine", lb.Name)))
+			continue
+		}
+
+		if lb.Type != expectedType {
+			errs = append(errs, field.Invalid(indexPath.Child("type"), lb.Type, fmt.Sprintf("load balancer %q must be of type %q to match AWSCluster", lb.Name, expectedType)))
+		}
+
+		foundLoadBalancers[lb.Name] = true
+	}
+
+	for expectedName := range expectedLoadBalancers {
+		if !foundLoadBalancers[expectedName] {
+			errs = append(errs, field.Invalid(lbFieldPath, actualLoadBalancers, fmt.Sprintf("must include load balancer named %q", expectedName)))
+		}
+	}
+
+	return errs.ToAggregate()
+}

--- a/pkg/controllers/machinesync/aws_test.go
+++ b/pkg/controllers/machinesync/aws_test.go
@@ -1,0 +1,407 @@
+/*
+Copyright 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machinesync
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	configv1 "github.com/openshift/api/config/v1"
+	mapiv1beta1 "github.com/openshift/api/machine/v1beta1"
+	clusterv1resourcebuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/cluster-api/core/v1beta1"
+	awsv1resourcebuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2"
+	configv1resourcebuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/config/v1"
+	corev1resourcebuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/core/v1"
+	machinev1resourcebuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1beta1"
+	consts "github.com/openshift/cluster-capi-operator/pkg/controllers"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/client-go/rest"
+
+	"k8s.io/utils/ptr"
+	awsv1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+var _ = Describe("AWS load balancer validation during MAPI->CAPI conversion", func() {
+	var (
+		mgrCancel  context.CancelFunc
+		mgrDone    chan struct{}
+		mgr        manager.Manager
+		reconciler *MachineSyncReconciler
+
+		awsClusterBuilder awsv1resourcebuilder.AWSClusterBuilder
+
+		capiNamespace *corev1.Namespace
+		mapiNamespace *corev1.Namespace
+
+		k komega.Komega
+
+		infrastructureName string
+	)
+
+	startManager := func(mgr *manager.Manager) (context.CancelFunc, chan struct{}) {
+		mgrCtx, mgrCancel := context.WithCancel(context.Background())
+		mgrDone := make(chan struct{})
+
+		go func() {
+			defer GinkgoRecover()
+			defer close(mgrDone)
+
+			Expect((*mgr).Start(mgrCtx)).To(Succeed())
+		}()
+
+		return mgrCancel, mgrDone
+	}
+
+	stopManager := func() {
+		mgrCancel()
+		<-mgrDone
+	}
+
+	BeforeEach(func() {
+		k = komega.New(k8sClient)
+
+		mapiNamespace = corev1resourcebuilder.Namespace().WithGenerateName("openshift-machine-api-").Build()
+		capiNamespace = corev1resourcebuilder.Namespace().WithGenerateName("openshift-cluster-api-").Build()
+		Expect(k8sClient.Create(ctx, mapiNamespace)).To(Succeed())
+		Expect(k8sClient.Create(ctx, capiNamespace)).To(Succeed())
+
+		infrastructureName = "cluster-aws-lb"
+		awsClusterBuilder = awsv1resourcebuilder.AWSCluster().WithNamespace(capiNamespace.GetName()).WithName(infrastructureName)
+
+		// Create CAPI Cluster that all tests will use
+		capiCluster := clusterv1resourcebuilder.Cluster().WithNamespace(capiNamespace.GetName()).WithName(infrastructureName).WithInfrastructureRef(&corev1.ObjectReference{
+			APIVersion: "infrastructure.cluster.x-k8s.io/v1beta2",
+			Kind:       "AWSCluster",
+			Name:       infrastructureName,
+			Namespace:  capiNamespace.GetName(),
+		}).Build()
+		Expect(k8sClient.Create(ctx, capiCluster)).To(Succeed())
+
+		var err error
+		var controllerCfg *rest.Config
+		controllerCfg, err = testEnv.ControlPlane.APIServer.SecureServing.AddUser(
+			envtest.User{
+				Name:   "system:serviceaccount:openshift-cluster-api:cluster-capi-operator",
+				Groups: []string{"system:masters", "system:authenticated"},
+			}, cfg)
+		Expect(err).ToNot(HaveOccurred())
+
+		mgr, err = ctrl.NewManager(controllerCfg, ctrl.Options{
+			Scheme: testScheme,
+			Controller: config.Controller{
+				SkipNameValidation: ptr.To(true),
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		reconciler = &MachineSyncReconciler{
+			Client:        mgr.GetClient(),
+			Infra:         configv1resourcebuilder.Infrastructure().AsAWS("cluster", "us-east-1").WithInfrastructureName(infrastructureName).Build(),
+			Platform:      configv1.AWSPlatformType,
+			CAPINamespace: capiNamespace.GetName(),
+			MAPINamespace: mapiNamespace.GetName(),
+		}
+		Expect(reconciler.SetupWithManager(mgr)).To(Succeed())
+
+		mgrCancel, mgrDone = startManager(&mgr)
+	})
+
+	AfterEach(func() {
+		stopManager()
+
+		// Cleanup created resources in test namespaces
+		Expect(k8sClient.DeleteAllOf(ctx, &clusterv1.Machine{}, client.InNamespace(capiNamespace.GetName()))).To(Succeed())
+		Expect(k8sClient.DeleteAllOf(ctx, &awsv1.AWSMachine{}, client.InNamespace(capiNamespace.GetName()))).To(Succeed())
+		Expect(k8sClient.DeleteAllOf(ctx, &awsv1.AWSCluster{}, client.InNamespace(capiNamespace.GetName()))).To(Succeed())
+		Expect(k8sClient.DeleteAllOf(ctx, &clusterv1.Cluster{}, client.InNamespace(capiNamespace.GetName()))).To(Succeed())
+		Expect(k8sClient.Delete(ctx, mapiNamespace)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, capiNamespace)).To(Succeed())
+	})
+
+	It("rejects worker machines that define load balancers", func() {
+		loadBalancerSpec := &awsv1.AWSLoadBalancerSpec{
+			Name:             ptr.To("cluster-int"),
+			LoadBalancerType: awsv1.LoadBalancerTypeNLB,
+		}
+
+		awsCluster := awsClusterBuilder.WithControlPlaneLoadBalancer(loadBalancerSpec).Build()
+		Expect(k8sClient.Create(ctx, awsCluster)).To(Succeed())
+
+		lbRefs := []mapiv1beta1.LoadBalancerReference{
+			{Name: "cluster-int", Type: mapiv1beta1.NetworkLoadBalancerType},
+		}
+
+		mapiMachine := machinev1resourcebuilder.Machine().
+			WithNamespace(mapiNamespace.GetName()).
+			WithGenerateName("worker-").
+			AsWorker().
+			WithProviderSpecBuilder(machinev1resourcebuilder.AWSProviderSpec().WithLoadBalancers(lbRefs)).
+			Build()
+
+		Expect(k8sClient.Create(ctx, mapiMachine)).To(Succeed())
+		Eventually(k.UpdateStatus(mapiMachine, func() { mapiMachine.Status.AuthoritativeAPI = mapiv1beta1.MachineAuthorityMachineAPI })).Should(Succeed())
+
+		Eventually(k.Object(mapiMachine), timeout).Should(
+			HaveField("Status.Conditions", ContainElement(
+				SatisfyAll(
+					HaveField("Type", Equal(consts.SynchronizedCondition)),
+					HaveField("Status", Equal(corev1.ConditionFalse)),
+					HaveField("Reason", Equal("FailedToConvertMAPIMachineToCAPI")),
+					HaveField("Message", ContainSubstring("loadBalancers are not supported for non-control plane machines")),
+				))),
+		)
+	})
+
+	It("rejects control-plane machines missing required control-plane LB", func() {
+		loadBalancerSpec := &awsv1.AWSLoadBalancerSpec{
+			Name:             ptr.To("cluster-int"),
+			LoadBalancerType: awsv1.LoadBalancerTypeNLB,
+		}
+		awsCluster := awsClusterBuilder.WithControlPlaneLoadBalancer(loadBalancerSpec).Build()
+		Expect(k8sClient.Create(ctx, awsCluster)).To(Succeed())
+
+		mapiMachine := machinev1resourcebuilder.Machine().
+			WithNamespace(mapiNamespace.GetName()).
+			WithGenerateName("master-").
+			AsMaster().
+			WithProviderSpecBuilder(machinev1resourcebuilder.AWSProviderSpec().WithLoadBalancers(nil)).
+			Build()
+
+		Expect(k8sClient.Create(ctx, mapiMachine)).To(Succeed())
+		Eventually(k.UpdateStatus(mapiMachine, func() { mapiMachine.Status.AuthoritativeAPI = mapiv1beta1.MachineAuthorityMachineAPI })).Should(Succeed())
+
+		Eventually(k.Object(mapiMachine), timeout).Should(
+			HaveField("Status.Conditions", ContainElement(
+				SatisfyAll(
+					HaveField("Type", Equal(consts.SynchronizedCondition)),
+					HaveField("Status", Equal(corev1.ConditionFalse)),
+					HaveField("Reason", Equal("FailedToConvertMAPIMachineToCAPI")),
+					HaveField("Message", ContainSubstring("must include load balancer named \"cluster-int\"")),
+				))),
+		)
+	})
+
+	It("rejects control-plane machines with wrong LB type", func() {
+		loadBalancerSpec := &awsv1.AWSLoadBalancerSpec{
+			Name:             ptr.To("cluster-int"),
+			LoadBalancerType: awsv1.LoadBalancerTypeNLB,
+		}
+		extraLoadBalancerSpec := &awsv1.AWSLoadBalancerSpec{
+			Name:             ptr.To("cluster-ext"),
+			LoadBalancerType: awsv1.LoadBalancerTypeNLB,
+		}
+		awsCluster := awsClusterBuilder.WithControlPlaneLoadBalancer(loadBalancerSpec).WithSecondaryControlPlaneLoadBalancer(extraLoadBalancerSpec).Build()
+		Expect(k8sClient.Create(ctx, awsCluster)).To(Succeed())
+
+		// Provide wrong type for cluster-int and an extra unexpected lb
+		lbRefs := []mapiv1beta1.LoadBalancerReference{
+			{Name: "cluster-int", Type: mapiv1beta1.ClassicLoadBalancerType},
+			{Name: "unexpected", Type: mapiv1beta1.NetworkLoadBalancerType},
+			// Purposely omit cluster-ext to also trigger missing secondary error
+		}
+
+		mapiMachine := machinev1resourcebuilder.Machine().AsMaster().
+			WithNamespace(mapiNamespace.GetName()).
+			WithGenerateName("master-").
+			WithProviderSpecBuilder(machinev1resourcebuilder.AWSProviderSpec().WithLoadBalancers(lbRefs)).
+			Build()
+
+		Expect(k8sClient.Create(ctx, mapiMachine)).To(Succeed())
+		Eventually(k.UpdateStatus(mapiMachine, func() { mapiMachine.Status.AuthoritativeAPI = mapiv1beta1.MachineAuthorityMachineAPI })).Should(Succeed())
+
+		Eventually(k.Object(mapiMachine), timeout).Should(
+			HaveField("Status.Conditions", ContainElement(
+				SatisfyAll(
+					HaveField("Type", Equal(consts.SynchronizedCondition)),
+					HaveField("Status", Equal(corev1.ConditionFalse)),
+					HaveField("Reason", Equal("FailedToConvertMAPIMachineToCAPI")),
+					HaveField("Message", SatisfyAll(
+						ContainSubstring("load balancer \"cluster-int\" must be of type \"network\""),
+						ContainSubstring("must include load balancer named \"cluster-ext\""),
+						ContainSubstring("unexpected load balancer \"unexpected\" defined on machine"),
+					)),
+				))),
+		)
+	})
+
+	It("accepts control-plane machines with matching LB names and types", func() {
+		loadBalancerSpec := &awsv1.AWSLoadBalancerSpec{
+			Name:             ptr.To("cluster-int"),
+			LoadBalancerType: awsv1.LoadBalancerTypeNLB,
+		}
+		secondaryLoadBalancerSpec := &awsv1.AWSLoadBalancerSpec{
+			Name:             ptr.To("cluster-ext"),
+			LoadBalancerType: awsv1.LoadBalancerTypeNLB,
+		}
+		awsCluster := awsClusterBuilder.WithControlPlaneLoadBalancer(loadBalancerSpec).WithSecondaryControlPlaneLoadBalancer(secondaryLoadBalancerSpec).Build()
+		Expect(k8sClient.Create(ctx, awsCluster)).To(Succeed())
+
+		lbRefs := []mapiv1beta1.LoadBalancerReference{
+			{Name: "cluster-int", Type: mapiv1beta1.NetworkLoadBalancerType},
+			{Name: "cluster-ext", Type: mapiv1beta1.NetworkLoadBalancerType},
+		}
+
+		mapiMachine := machinev1resourcebuilder.Machine().
+			WithNamespace(mapiNamespace.GetName()).
+			WithGenerateName("master-").
+			AsMaster().
+			WithProviderSpecBuilder(machinev1resourcebuilder.AWSProviderSpec().WithLoadBalancers(lbRefs)).
+			Build()
+
+		Expect(k8sClient.Create(ctx, mapiMachine)).To(Succeed())
+		Eventually(k.UpdateStatus(mapiMachine, func() { mapiMachine.Status.AuthoritativeAPI = mapiv1beta1.MachineAuthorityMachineAPI })).Should(Succeed())
+
+		// Expect success condition
+		Eventually(k.Object(mapiMachine), timeout).Should(
+			HaveField("Status.Conditions", ContainElement(
+				SatisfyAll(
+					HaveField("Type", Equal(consts.SynchronizedCondition)),
+					HaveField("Status", Equal(corev1.ConditionTrue)),
+					HaveField("Reason", Equal("ResourceSynchronized")),
+					HaveField("Message", Equal("Successfully synchronized MAPI Machine to CAPI")),
+				))),
+		)
+
+		// And that a CAPI machine has been created
+		capiMachine := clusterv1resourcebuilder.Machine().WithNamespace(capiNamespace.GetName()).WithName(mapiMachine.GetName()).Build()
+		Eventually(k8sClient.Get(ctx, client.ObjectKeyFromObject(capiMachine), capiMachine), timeout).Should(Succeed())
+	})
+})
+
+var _ = Describe("validateLoadBalancerReferencesAgainstExpected", func() {
+	var (
+		lbfieldPath *field.Path
+	)
+
+	BeforeEach(func() {
+		lbfieldPath = field.NewPath("spec", "providerSpec", "value", "loadBalancers")
+	})
+
+	type validateLoadBalancerMatchTableInput struct {
+		actualLoadBalancers   []mapiv1beta1.LoadBalancerReference
+		expectedLoadBalancers map[string]mapiv1beta1.AWSLoadBalancerType
+		expectedErrorMessages []string
+	}
+
+	DescribeTable("validate load balancer matching",
+		func(in validateLoadBalancerMatchTableInput) {
+			err := validateLoadBalancerReferencesAgainstExpected(in.actualLoadBalancers, in.expectedLoadBalancers, lbfieldPath)
+
+			if len(in.expectedErrorMessages) > 0 {
+				Expect(err).ToNot(BeNil())
+				for _, expectedMsg := range in.expectedErrorMessages {
+					Expect(err.Error()).To(ContainSubstring(expectedMsg))
+				}
+			} else {
+				Expect(err).To(BeNil())
+			}
+		},
+		Entry("should succeed when actual and expected load balancers match perfectly", validateLoadBalancerMatchTableInput{
+			actualLoadBalancers: []mapiv1beta1.LoadBalancerReference{
+				{Name: "cluster-int", Type: mapiv1beta1.NetworkLoadBalancerType},
+				{Name: "cluster-ext", Type: mapiv1beta1.ClassicLoadBalancerType},
+			},
+			expectedLoadBalancers: map[string]mapiv1beta1.AWSLoadBalancerType{
+				"cluster-int": mapiv1beta1.NetworkLoadBalancerType,
+				"cluster-ext": mapiv1beta1.ClassicLoadBalancerType,
+			},
+		}),
+		Entry("should succeed when load balancers are in different order", validateLoadBalancerMatchTableInput{
+			actualLoadBalancers: []mapiv1beta1.LoadBalancerReference{
+				{Name: "cluster-ext", Type: mapiv1beta1.ClassicLoadBalancerType},
+				{Name: "cluster-int", Type: mapiv1beta1.NetworkLoadBalancerType},
+			},
+			expectedLoadBalancers: map[string]mapiv1beta1.AWSLoadBalancerType{
+				"cluster-int": mapiv1beta1.NetworkLoadBalancerType,
+				"cluster-ext": mapiv1beta1.ClassicLoadBalancerType,
+			},
+		}),
+		Entry("should fail when an unexpected load balancer is present", validateLoadBalancerMatchTableInput{
+			actualLoadBalancers: []mapiv1beta1.LoadBalancerReference{
+				{Name: "cluster-int", Type: mapiv1beta1.NetworkLoadBalancerType},
+				{Name: "unexpected-lb", Type: mapiv1beta1.NetworkLoadBalancerType},
+			},
+			expectedLoadBalancers: map[string]mapiv1beta1.AWSLoadBalancerType{
+				"cluster-int": mapiv1beta1.NetworkLoadBalancerType,
+			},
+			expectedErrorMessages: []string{"unexpected load balancer \"unexpected-lb\" defined on machine"},
+		}),
+		Entry("should fail when a required load balancer is missing", validateLoadBalancerMatchTableInput{
+			actualLoadBalancers: []mapiv1beta1.LoadBalancerReference{
+				{Name: "cluster-int", Type: mapiv1beta1.NetworkLoadBalancerType},
+			},
+			expectedLoadBalancers: map[string]mapiv1beta1.AWSLoadBalancerType{
+				"cluster-int": mapiv1beta1.NetworkLoadBalancerType,
+				"cluster-ext": mapiv1beta1.ClassicLoadBalancerType,
+			},
+			expectedErrorMessages: []string{"must include load balancer named \"cluster-ext\""},
+		}),
+		Entry("should fail when load balancer type is incorrect", validateLoadBalancerMatchTableInput{
+			actualLoadBalancers: []mapiv1beta1.LoadBalancerReference{
+				{Name: "cluster-int", Type: mapiv1beta1.ClassicLoadBalancerType},
+			},
+			expectedLoadBalancers: map[string]mapiv1beta1.AWSLoadBalancerType{
+				"cluster-int": mapiv1beta1.NetworkLoadBalancerType,
+			},
+			expectedErrorMessages: []string{"load balancer \"cluster-int\" must be of type \"network\" to match AWSCluster"},
+		}),
+		Entry("should report multiple errors when multiple issues are present", validateLoadBalancerMatchTableInput{
+			actualLoadBalancers: []mapiv1beta1.LoadBalancerReference{
+				{Name: "cluster-int", Type: mapiv1beta1.ClassicLoadBalancerType},
+				{Name: "unexpected-lb", Type: mapiv1beta1.NetworkLoadBalancerType},
+			},
+			expectedLoadBalancers: map[string]mapiv1beta1.AWSLoadBalancerType{
+				"cluster-int": mapiv1beta1.NetworkLoadBalancerType,
+				"cluster-ext": mapiv1beta1.ClassicLoadBalancerType,
+			},
+			expectedErrorMessages: []string{
+				"load balancer \"cluster-int\" must be of type \"network\" to match AWSCluster",
+				"unexpected load balancer \"unexpected-lb\" defined on machine",
+				"must include load balancer named \"cluster-ext\"",
+			},
+		}),
+		Entry("should succeed when both actual and expected are empty", validateLoadBalancerMatchTableInput{
+			actualLoadBalancers:   []mapiv1beta1.LoadBalancerReference{},
+			expectedLoadBalancers: map[string]mapiv1beta1.AWSLoadBalancerType{},
+		}),
+		Entry("should fail when actual is empty but expected has values", validateLoadBalancerMatchTableInput{
+			actualLoadBalancers: []mapiv1beta1.LoadBalancerReference{},
+			expectedLoadBalancers: map[string]mapiv1beta1.AWSLoadBalancerType{
+				"cluster-int": mapiv1beta1.NetworkLoadBalancerType,
+			},
+			expectedErrorMessages: []string{"must include load balancer named \"cluster-int\""},
+		}),
+		Entry("should fail when expected is empty but actual has values", validateLoadBalancerMatchTableInput{
+			actualLoadBalancers: []mapiv1beta1.LoadBalancerReference{
+				{Name: "unexpected-lb", Type: mapiv1beta1.NetworkLoadBalancerType},
+			},
+			expectedLoadBalancers: map[string]mapiv1beta1.AWSLoadBalancerType{},
+			expectedErrorMessages: []string{"unexpected load balancer \"unexpected-lb\" defined on machine"},
+		}),
+	)
+})

--- a/pkg/conversion/mapi2capi/aws.go
+++ b/pkg/conversion/mapi2capi/aws.go
@@ -326,8 +326,10 @@ func (m *awsMachineAndInfra) toAWSMachine(providerSpec mapiv1beta1.AWSMachinePro
 	}
 
 	if len(providerSpec.LoadBalancers) > 0 {
-		// TODO(OCPCLOUD-2709): CAPA only applies load balancers to the control plane nodes. We should always reject LBs on non-control plane and work out how to connect the control plane LBs correctly otherwise.
-		errs = append(errs, field.Invalid(fldPath.Child("loadBalancers"), providerSpec.LoadBalancers, "loadBalancers are not supported"))
+		// Load balancers are only supported for control plane machines
+		if !util.IsControlPlaneMAPIMachine(m.machine) {
+			errs = append(errs, field.Invalid(fldPath.Child("loadBalancers"), providerSpec.LoadBalancers, "loadBalancers are not supported for non-control plane machines"))
+		}
 	}
 
 	return &awsv1.AWSMachine{

--- a/pkg/test/crdbuilder.go
+++ b/pkg/test/crdbuilder.go
@@ -76,6 +76,15 @@ var (
 	// fakeOpenStackMachineTemplateCRD is a fake OpenStackMachineTemplate CRD.
 	fakeOpenStackMachineTemplateCRD = generateCRD(v1beta1InfrastructureGroupVersion.WithKind(fakeOpenStackMachineTemplateKind))
 
+	// mapiv1GroupVersion is group version used for MAPI v1 objects.
+	mapiv1GroupVersion = schema.GroupVersion{Group: "machine.openshift.io", Version: "v1"}
+
+	// fakeControlPlaneMachineSetKind is the Kind for the ControlPlaneMachineSet.
+	fakeControlPlaneMachineSetKind = "ControlPlaneMachineSet"
+
+	// fakeControlPlaneMachineSetCRD is a fake ControlPlaneMachineSet CRD.
+	fakeControlPlaneMachineSetCRD = generateCRD(mapiv1GroupVersion.WithKind(fakeControlPlaneMachineSetKind))
+
 	// v1beta2InfrastructureGroupVersion is a v1beta2 group version used for infrastructure objects.
 	v1beta2InfrastructureGroupVersion = schema.GroupVersion{Group: "infrastructure.cluster.x-k8s.io", Version: "v1beta2"}
 

--- a/pkg/test/envtest.go
+++ b/pkg/test/envtest.go
@@ -67,6 +67,7 @@ func StartEnvTest(testEnv *envtest.Environment) (*rest.Config, client.Client, er
 		fakeClusterCRD,
 		fakeMachineCRD,
 		fakeMachineSetCRD,
+		fakeControlPlaneMachineSetCRD,
 		fakeAWSClusterCRD,
 		fakeAWSMachineTemplateCRD,
 		fakeAWSMachineCRD,

--- a/pkg/util/controlplane.go
+++ b/pkg/util/controlplane.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	mapiv1beta1 "github.com/openshift/api/machine/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// controlPlaneMachineSetKind is the kind used by the ControlPlaneMachineSet resource.
+	controlPlaneMachineSetKind = "ControlPlaneMachineSet"
+
+	// machineRoleLabelName is the label for specifying the role of a machine.
+	machineRoleLabelName = "machine.openshift.io/cluster-api-machine-role"
+)
+
+// IsControlPlaneMAPIMachine returns true if the given MAPI Machine is a control plane machine.
+func IsControlPlaneMAPIMachine(machine *mapiv1beta1.Machine) bool {
+	if machine == nil {
+		return false
+	}
+
+	if hasOwnerKind(machine.OwnerReferences, controlPlaneMachineSetKind) {
+		return true
+	}
+
+	if role, exists := machine.Labels[machineRoleLabelName]; exists && role == "master" {
+		return true
+	}
+
+	return false
+}
+
+func hasOwnerKind(refs []metav1.OwnerReference, kind string) bool {
+	for _, ownerRef := range refs {
+		if ownerRef.Kind == kind {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime-configurable CAPI/MAPI namespaces; AWS infra now derives and populates primary + optional secondary control‑plane load balancers from provider specs and exposes conversions for LB types.

* **Bug Fixes**
  * Worker machines rejected for declaring LBs; control‑plane machines may use LBs. Improved control‑plane endpoint port handling and degraded-condition reporting when control plane is missing.

* **Refactor**
  * Provider-spec retrieval and namespace usage unified under controller context across platforms; namespaces propagated into created resources and logs.

* **Tests**
  * Expanded tests for namespaces, control‑plane discovery, LB ordering/validation, MachineSync conversion, and CAPI↔MAPI LB translations.

* **Chores**
  * Operator cache includes Machine objects; test env adds ControlPlaneMachineSet CRD.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->