### PR TITLE
OCPCLOUD-2992: Enable MAPI machine synchronized e2e tests (re-enable after OCPBUGS-54703 fix)

### DIFF
--- a/e2e/machine_migration_test.go
+++ b/e2e/machine_migration_test.go
@@ -59,8 +59,7 @@ var _ = Describe("[sig-cluster-lifecycle][OCPFeatureGate:MachineAPIMigration] Ma
 			It("should find MAPI Machine .status.authoritativeAPI to equal ClusterAPI", func() {
 				verifyMachineAuthoritative(newMapiMachine, machinev1beta1.MachineAuthorityClusterAPI)
 			})
-			//there is a bug for this https://issues.redhat.com/browse/OCPBUGS-54703
-			PIt("should verify MAPI Machine Synchronized condition is True", func() {
+			It("should verify MAPI Machine Synchronized condition is True", func() {
 				verifyMachineSynchronizedCondition(newMapiMachine, machinev1beta1.MachineAuthorityClusterAPI)
 			})
 			It("should verify MAPI Machine Paused condition is True", func() {
@@ -93,8 +92,7 @@ var _ = Describe("[sig-cluster-lifecycle][OCPFeatureGate:MachineAPIMigration] Ma
 			It("should find MAPI Machine .status.authoritativeAPI to equal ClusterAPI", func() {
 				verifyMachineAuthoritative(newMapiMachine, machinev1beta1.MachineAuthorityClusterAPI)
 			})
-			//there is a bug for this https://issues.redhat.com/browse/OCPBUGS-54703
-			PIt("should verify MAPI Machine Synchronized condition is True", func() {
+			It("should verify MAPI Machine Synchronized condition is True", func() {
 				verifyMachineSynchronizedCondition(newMapiMachine, machinev1beta1.MachineAuthorityClusterAPI)
 			})
 			It("should verify MAPI Machine Paused condition is True", func() {


### PR DESCRIPTION
As bug https://issues.redhat.com/browse/OCPBUGS-54703 already fixed, so enable the relevant code.
tested in my local and it works. @sunzhaohua2 @miyadav @damdo PTAL, thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled two previously pending end-to-end checks that validate machine synchronization status, increasing test coverage and strengthening CI feedback.
  * Removed an outdated reference linked to a known issue to reflect the tests’ active status.
  * No runtime behavior changes; these updates only affect test execution and reporting, improving confidence in build quality without impacting users directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->