### PR TITLE
OCPCLOUD-3162: conversion: do not set ignition version on AWSMachine

### DIFF
--- a/e2e/aws_test.go
+++ b/e2e/aws_test.go
@@ -117,7 +117,6 @@ func newAWSMachineTemplate(mapiProviderSpec *mapiv1.AWSMachineProviderConfig) *a
 			ID: mapiProviderSpec.AMI.ID,
 		},
 		Ignition: &awsv1.Ignition{
-			Version:     "3.4",
 			StorageType: awsv1.IgnitionStorageTypeOptionUnencryptedUserData,
 		},
 		Subnet: &awsv1.AWSResourceReference{

--- a/pkg/conversion/capi2mapi/aws_fuzz_test.go
+++ b/pkg/conversion/capi2mapi/aws_fuzz_test.go
@@ -150,7 +150,6 @@ func awsMachineFuzzerFuncs(codecs runtimeserializer.CodecFactory) []interface{} 
 		func(ignition *awsv1.Ignition, c randfill.Continue) {
 			// We force these fields, so they must be fuzzed in this way.
 			*ignition = awsv1.Ignition{
-				Version:     "3.4",
 				StorageType: awsv1.IgnitionStorageTypeOptionUnencryptedUserData,
 			}
 		},

--- a/pkg/conversion/mapi2capi/aws.go
+++ b/pkg/conversion/mapi2capi/aws.go
@@ -257,7 +257,6 @@ func (m *awsMachineAndInfra) toAWSMachine(providerSpec mapiv1.AWSMachineProvider
 		AdditionalTags:           convertAWSTagsToCAPI(providerSpec.Tags),
 		IAMInstanceProfile:       convertIAMInstanceProfiletoCAPI(providerSpec.IAMInstanceProfile),
 		Ignition: &awsv1.Ignition{
-			Version:     "3.4",                                              // TODO(OCPCLOUD-2719): Should this be extracted from the ignition in the user data secret?
 			StorageType: awsv1.IgnitionStorageTypeOptionUnencryptedUserData, // Hardcoded for OpenShift.
 		},
 


### PR DESCRIPTION
Because the following is merged:

- https://github.com/openshift/cluster-api-provider-aws/pull/569

This is a follow-up to:

- https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/5641



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AWS machine templates and specs no longer force a specific Ignition version; they now rely on the provider’s default, improving compatibility and reducing version-related issues.

* **Tests**
  * Updated end-to-end and fuzz tests to align with the new Ignition version handling, ensuring stable validation without relying on a hardcoded version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->