### PR TITLE
NO-JIRA: machine_sync: assorted fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ The repository also includes:
 ### Running Tests
 ```bash
 make unit                                    # All unit tests
-make unit TEST_PACKAGES="./pkg/controllers/machinesync/..."  # Specific package
+make unit TEST_DIRS="./pkg/controllers/machinesync/..."  # Specific package directories/dirs
 ./hack/test.sh "./pkg/..." 10m             # With timeout
 ```
 #### Default ginkgo arguments

--- a/pkg/controllers/machinesync/machine_sync_controller.go
+++ b/pkg/controllers/machinesync/machine_sync_controller.go
@@ -1300,7 +1300,7 @@ func compareMAPIMachines(a, b *machinev1beta1.Machine) (map[string]any, error) {
 		return nil, fmt.Errorf("unable to parse first Machine API machine set providerSpec: %w", err)
 	}
 
-	ps2, err := mapi2capi.AWSProviderSpecFromRawExtension(a.Spec.ProviderSpec.Value)
+	ps2, err := mapi2capi.AWSProviderSpecFromRawExtension(b.Spec.ProviderSpec.Value)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse second Machine API machine set providerSpec: %w", err)
 	}

--- a/pkg/controllers/machinesync/machine_sync_controller.go
+++ b/pkg/controllers/machinesync/machine_sync_controller.go
@@ -917,6 +917,10 @@ func (r *MachineSyncReconciler) convertMAPIMachineOwnerReferencesToCAPI(ctx cont
 func (r *MachineSyncReconciler) convertCAPIMachineOwnerReferencesToMAPI(ctx context.Context, capiMachine *clusterv1.Machine) ([]metav1.OwnerReference, error) {
 	mapiOwnerReferences := []metav1.OwnerReference{}
 
+	if capiMachine.OwnerReferences == nil {
+		return nil, nil
+	}
+
 	if len(capiMachine.OwnerReferences) == 0 {
 		return mapiOwnerReferences, nil
 	}
@@ -964,7 +968,7 @@ func (r *MachineSyncReconciler) convertCAPIMachineOwnerReferencesToMAPI(ctx cont
 		}
 
 		// MAPI doesn't have a cluster, so we don't need to add an owner reference.
-		return mapiOwnerReferences, nil
+		return nil, nil
 	default:
 		return nil, field.Invalid(field.NewPath("metadata", "ownerReferences"), capiMachine.OwnerReferences, errUnsuportedOwnerKindForConversion.Error())
 	}


### PR DESCRIPTION
Adds several fixes to the machine_sync package.
- fix: TEST_DIRS for AGENTS.md
- fix: return nil ownerrefs when empty
- fix: compareMAPIMachines, compare right value
- machine_sync: test: use Eventually instead of Expect where possible
