### PR TITLE
OCPCLOUD-2999: AWSMachine status conversion and syncing

### DIFF
--- a/pkg/controllers/machinesync/machine_sync_capi2mapi_infrastructure.go
+++ b/pkg/controllers/machinesync/machine_sync_capi2mapi_infrastructure.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machinesync
+
+import (
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	mapiv1beta1 "github.com/openshift/api/machine/v1beta1"
+	"github.com/openshift/cluster-capi-operator/pkg/conversion/capi2mapi"
+	"github.com/openshift/cluster-capi-operator/pkg/conversion/mapi2capi"
+	"github.com/openshift/cluster-capi-operator/pkg/util"
+)
+
+// setChangedMAPIMachineProviderStatusFields unmarshals the existing and converted ProviderStatus, copies over the fields and marshals it back to the existingMAPIMachine.
+func setChangedMAPIMachineProviderStatusFields(platform configv1.PlatformType, existingMAPIMachine, convertedMAPIMachine *mapiv1beta1.Machine) error {
+	var newProviderStatus interface{}
+
+	switch platform {
+	case configv1.AWSPlatformType:
+		existingStatus, err := mapi2capi.AWSProviderStatusFromRawExtension(existingMAPIMachine.Status.ProviderStatus)
+		if err != nil {
+			return fmt.Errorf("unable to convert RawExtension to AWS ProviderStatus: %w", err)
+		}
+
+		convertedStatus, err := mapi2capi.AWSProviderStatusFromRawExtension(convertedMAPIMachine.Status.ProviderStatus)
+		if err != nil {
+			return fmt.Errorf("unable to convert RawExtension to AWS ProviderStatus: %w", err)
+		}
+
+		for i := range convertedStatus.Conditions {
+			existingStatus.Conditions = util.SetMAPIProviderCondition(existingStatus.Conditions, &convertedStatus.Conditions[i])
+		}
+
+		convertedStatus.Conditions = existingStatus.Conditions
+
+		newProviderStatus = convertedStatus
+	case configv1.OpenStackPlatformType:
+		// TODO(openstack): implement
+		return nil
+	case configv1.PowerVSPlatformType:
+		// TODO(powervs): implement
+		return nil
+	}
+
+	rawExtension, err := capi2mapi.RawExtensionFromInterface(newProviderStatus)
+	if err != nil {
+		return fmt.Errorf("unable to convert ProviderStatus to RawExtension: %w", err)
+	}
+
+	existingMAPIMachine.Status.ProviderStatus = rawExtension
+
+	return nil
+}

--- a/pkg/controllers/machinesync/machine_sync_mapi2capi_infrastructure.go
+++ b/pkg/controllers/machinesync/machine_sync_mapi2capi_infrastructure.go
@@ -1,0 +1,393 @@
+/*
+Copyright 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machinesync
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-test/deep"
+	configv1 "github.com/openshift/api/config/v1"
+	mapiv1beta1 "github.com/openshift/api/machine/v1beta1"
+	"github.com/openshift/cluster-capi-operator/pkg/util"
+
+	corev1 "k8s.io/api/core/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	awsv1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	ibmpowervsv1 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
+	openstackv1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// createOrUpdateCAPIInfraMachine creates a Cluster API infra machine from a Machine API machine, or updates if it exists and it is out of date.
+// syncronizationIsProgressing will be set to true if an existing Cluster API Infrastructure Machine was deleted for later recreation due to immutable changes.
+//
+//nolint:unparam
+func (r *MachineSyncReconciler) createOrUpdateCAPIInfraMachine(ctx context.Context, sourceMAPIMachine *mapiv1beta1.Machine, existingCAPIInfraMachine client.Object, convertedCAPIInfraMachine client.Object) (res ctrl.Result, zc bool, err error) {
+	logger := logf.FromContext(ctx)
+	// This const signals whether or not we are still progressing
+	// towards syncronizing the Machine API machine with the Cluster API infra machine.
+	// It is then passed up the stack so the syncronized condition can be set accordingly.
+	const syncronizationIsProgressingFalse = false
+
+	// If there is an existing Cluster API Infrastructure machine, no need to create one.
+	if util.IsNilObject(existingCAPIInfraMachine) {
+		// If there is no existing Cluster API Infrastructure machine, create a new one.
+		existingCAPIInfraMachine, err = r.ensureCAPIInfraMachine(ctx, sourceMAPIMachine, convertedCAPIInfraMachine)
+		if err != nil {
+			return ctrl.Result{}, syncronizationIsProgressingFalse, fmt.Errorf("failed to ensure Cluster API Infrastructure machine: %w", err)
+		}
+	}
+
+	// Compare the existing Cluster API Infrastructure machine with the converted Cluster API Infrastructure machine to check for changes.
+	diff, err := compareCAPIInfraMachines(r.Platform, existingCAPIInfraMachine, convertedCAPIInfraMachine)
+	if err != nil {
+		return ctrl.Result{}, syncronizationIsProgressingFalse, fmt.Errorf("failed to compare Cluster API Infrastructure machines: %w", err)
+	}
+
+	// Infrastructure machines are immutable so we delete it for spec changes.
+	// The next reconciliation will create it with the expected changes.
+	// Note: this could be improved to only trigger deletion on known immutable changes.
+	if hasSpecChanges(diff) {
+		logger.Info("Deleting the corresponding Cluster API Infrastructure machine as it is out of date, it will be recreated", "diff", fmt.Sprintf("%+v", diff))
+
+		syncronizationIsProgressing, err := r.ensureCAPIInfraMachineDeleted(ctx, sourceMAPIMachine, existingCAPIInfraMachine)
+
+		return ctrl.Result{}, syncronizationIsProgressing, err
+	}
+
+	// Update Cluster API Infrastructure machine metadata if needed.
+	metadataUpdated, err := r.ensureCAPIInfraMachineMetadataUpdated(ctx, sourceMAPIMachine, diff, convertedCAPIInfraMachine)
+	if err != nil {
+		return ctrl.Result{}, syncronizationIsProgressingFalse, fmt.Errorf("failed to update Cluster API Infrastructure machine metadata: %w", err)
+	}
+
+	// Update Cluster API Infrastructure machine status if needed.
+	statusUpdated, err := r.ensureCAPIInfraMachineStatusUpdated(ctx, sourceMAPIMachine, existingCAPIInfraMachine, convertedCAPIInfraMachine, diff, metadataUpdated)
+	if err != nil {
+		return ctrl.Result{}, syncronizationIsProgressingFalse, fmt.Errorf("failed to update Cluster API Infrastructure machine status: %w", err)
+	}
+
+	if metadataUpdated || statusUpdated {
+		logger.Info("Successfully updated Cluster API machine")
+	} else {
+		logger.Info("No changes detected for Cluster API machine")
+	}
+
+	return ctrl.Result{}, syncronizationIsProgressingFalse, nil
+}
+
+// ensureCAPIInfraMachine creates a new Cluster API Infrastructure machine if one doesn't exist and returns the created one.
+func (r *MachineSyncReconciler) ensureCAPIInfraMachine(ctx context.Context, sourceMAPIMachine *mapiv1beta1.Machine, convertedCAPIInfraMachine client.Object) (client.Object, error) {
+	logger := logf.FromContext(ctx)
+
+	var ok bool
+
+	createdCAPIInfraMachine, ok := convertedCAPIInfraMachine.DeepCopyObject().(client.Object)
+	if !ok {
+		return nil, fmt.Errorf("failed to assert convertedCAPIInfraMachine: %w", errAssertingInfrasMachineClientObject)
+	}
+
+	if err := r.Create(ctx, createdCAPIInfraMachine); err != nil {
+		logger.Error(err, "Failed to create Cluster API Infrastructure machine")
+
+		createErr := fmt.Errorf("failed to create Cluster API Infrastructure machine: %w", err)
+		if condErr := r.applySynchronizedConditionWithPatch(
+			ctx, sourceMAPIMachine, corev1.ConditionFalse, reasonFailedToCreateCAPIMachine, createErr.Error(), nil); condErr != nil {
+			return nil, utilerrors.NewAggregate([]error{createErr, condErr})
+		}
+
+		return nil, createErr
+	}
+
+	logger.Info("Successfully created Cluster API Infrastructure machine", "name", createdCAPIInfraMachine.GetName())
+
+	return createdCAPIInfraMachine, nil
+}
+
+// ensureCAPIInfraMachineMetadataUpdated updates the Cluster API Infrastructure machine if changes are detected to the metadata or spec (if possible).
+func (r *MachineSyncReconciler) ensureCAPIInfraMachineMetadataUpdated(ctx context.Context, mapiMachine *mapiv1beta1.Machine, diff map[string]any, updatedOrCreatedCAPIInfraMachine client.Object) (bool, error) {
+	logger := logf.FromContext(ctx)
+
+	// If there are no spec changes, return early.
+	if !hasMetadataChanges(diff) {
+		return false, nil
+	}
+
+	logger.Info("Changes detected for Cluster API Infrastructure machine. Updating it", "diff", fmt.Sprintf("%+v", diff))
+
+	if err := r.Update(ctx, updatedOrCreatedCAPIInfraMachine); err != nil {
+		logger.Error(err, "Failed to update Cluster API Infrastructure machine")
+
+		updateErr := fmt.Errorf("failed to update Cluster API Infrastructure machine: %w", err)
+
+		if condErr := r.applySynchronizedConditionWithPatch(ctx, mapiMachine, corev1.ConditionFalse, reasonFailedToUpdateCAPIMachine, updateErr.Error(), nil); condErr != nil {
+			return false, utilerrors.NewAggregate([]error{updateErr, condErr})
+		}
+
+		return false, updateErr
+	}
+
+	return true, nil
+}
+
+func (r *MachineSyncReconciler) ensureCAPIInfraMachineStatusUpdated(ctx context.Context, mapiMachine *mapiv1beta1.Machine, existingCAPIInfraMachine, convertedCAPIInfraMachine client.Object, diff map[string]any, specUpdated bool) (bool, error) {
+	logger := logf.FromContext(ctx)
+
+	// If there are no status changes and the spec has not been updated, return early.
+	if !hasStatusChanges(diff) && !specUpdated {
+		return false, nil
+	}
+
+	// If the source API object (MAPI Machine) status.synchronizedGeneration does not match the objectmeta.generation
+	// it means the source API object status has not yet caught up with the desired spec,
+	// so we don't want to update the Cluster API Infrastructure machine status until that has happened.
+	if mapiMachine.Status.SynchronizedGeneration != mapiMachine.ObjectMeta.Generation {
+		logger.Info("Changes detected for Cluster API Infrastructure machine status, but the MAPI machine spec has not been observed yet, skipping status update")
+
+		return false, nil
+	}
+
+	target, ok := existingCAPIInfraMachine.DeepCopyObject().(client.Object)
+	if !ok {
+		return false, fmt.Errorf("failed to assert existingCAPIInfraMachine: %w", errAssertingInfrasMachineClientObject)
+	}
+
+	patchBase := client.MergeFrom(target)
+
+	if err := setChangedCAPIInfraMachineStatusFields(r.Platform, existingCAPIInfraMachine, convertedCAPIInfraMachine); err != nil {
+		return false, fmt.Errorf("failed to set Cluster API Infrastructure Machine status: %w", err)
+	}
+
+	// // Update the observed generation to match the updated source API object generation.
+	// existingCAPIInfraMachine.Status.ObservedGeneration = updatedOrCreatedCAPIInfraMachine.ObjectMeta.Generation
+
+	isPatchRequired, err := util.IsPatchRequired(existingCAPIInfraMachine, patchBase)
+	if err != nil {
+		return false, fmt.Errorf("failed to check if patch is required: %w", err)
+	}
+
+	if !isPatchRequired {
+		// If the patch is not required, return early.
+		return false, nil
+	}
+
+	logger.Info("Changes detected for Cluster API Infrastructure machine status. Updating it")
+
+	if err := r.Status().Patch(ctx, existingCAPIInfraMachine, patchBase); err != nil {
+		logger.Error(err, "Failed to update Cluster API Infrastructure machine status")
+		updateErr := fmt.Errorf("failed to update status: %w", err)
+
+		if condErr := r.applySynchronizedConditionWithPatch(ctx, mapiMachine, corev1.ConditionFalse, reasonFailedToUpdateCAPIMachine, updateErr.Error(), nil); condErr != nil {
+			return false, utilerrors.NewAggregate([]error{updateErr, condErr})
+		}
+
+		return false, updateErr
+	}
+
+	return true, nil
+}
+
+// ensureCAPIInfraMachineDeleted deletes the Cluster API Infrastructure machine if changes are detected to the spec which is immutable.
+func (r *MachineSyncReconciler) ensureCAPIInfraMachineDeleted(ctx context.Context, sourceMAPIMachine *mapiv1beta1.Machine, existingCAPIInfraMachine client.Object) (bool, error) {
+	logger := logf.FromContext(ctx)
+
+	// Trigger deletion
+	if err := r.Delete(ctx, existingCAPIInfraMachine); err != nil {
+		logger.Error(err, "Failed to delete Cluster API Infrastructure machine")
+
+		deleteErr := fmt.Errorf("failed to delete Cluster API Infrastructure machine: %w", err)
+
+		if condErr := r.applySynchronizedConditionWithPatch(
+			ctx, sourceMAPIMachine, corev1.ConditionFalse, reasonFailedToUpdateCAPIInfraMachine, deleteErr.Error(), nil); condErr != nil {
+			return false, utilerrors.NewAggregate([]error{deleteErr, condErr})
+		}
+
+		return false, deleteErr
+	}
+
+	// Remove finalizers from the deleting Cluster API infraMachine, it is not authoritative.
+	existingCAPIInfraMachine.SetFinalizers(nil)
+
+	if err := r.Update(ctx, existingCAPIInfraMachine); err != nil {
+		logger.Error(err, "Failed to remove finalizer for deleting Cluster API Infrastructure machine")
+
+		deleteErr := fmt.Errorf("failed to remove finalizer for deleting Cluster API Infrastructure machine: %w", err)
+
+		if condErr := r.applySynchronizedConditionWithPatch(
+			ctx, sourceMAPIMachine, corev1.ConditionFalse, reasonFailedToUpdateCAPIInfraMachine, deleteErr.Error(), nil); condErr != nil {
+			return false, utilerrors.NewAggregate([]error{deleteErr, condErr})
+		}
+
+		return false, deleteErr
+	}
+
+	logger.Info("Successfully deleted outdated Cluster API Infrastructure machine")
+
+	// Return with syncronized as progressing to signal the caller
+	// we are still progressing and aren't fully synced yet.
+	return true, nil
+}
+
+// compareCAPIInfraMachines compares Cluster API infra machines a and b, and returns a list of differences, or none if there are none.
+//
+//nolint:funlen,gocognit
+func compareCAPIInfraMachines(platform configv1.PlatformType, infraMachine1, infraMachine2 client.Object) (map[string]any, error) {
+	diff := make(map[string]any)
+
+	switch platform {
+	case configv1.AWSPlatformType:
+		typedInfraMachine1, ok := infraMachine1.(*awsv1.AWSMachine)
+		if !ok {
+			return nil, errAssertingCAPIAWSMachine
+		}
+
+		typedinfraMachine2, ok := infraMachine2.(*awsv1.AWSMachine)
+		if !ok {
+			return nil, errAssertingCAPIAWSMachine
+		}
+
+		if diffSpec := deep.Equal(typedInfraMachine1.Spec, typedinfraMachine2.Spec); len(diffSpec) > 0 {
+			diff[".spec"] = diffSpec
+		}
+
+		if diffMetadata := util.ObjectMetaEqual(typedInfraMachine1.ObjectMeta, typedinfraMachine2.ObjectMeta); len(diffMetadata) > 0 {
+			diff[".metadata"] = diffMetadata
+		}
+
+		if diffStatus := deep.Equal(typedInfraMachine1.Status, typedinfraMachine2.Status); len(diffStatus) > 0 {
+			diff[".status"] = diffStatus
+		}
+	case configv1.OpenStackPlatformType:
+		typedInfraMachine1, ok := infraMachine1.(*openstackv1.OpenStackMachine)
+		if !ok {
+			return nil, errAssertingCAPIOpenStackMachine
+		}
+
+		typedinfraMachine2, ok := infraMachine2.(*openstackv1.OpenStackMachine)
+		if !ok {
+			return nil, errAssertingCAPIOpenStackMachine
+		}
+
+		if diffSpec := deep.Equal(typedInfraMachine1.Spec, typedinfraMachine2.Spec); len(diffSpec) > 0 {
+			diff[".spec"] = diffSpec
+		}
+
+		if diffMetadata := util.ObjectMetaEqual(typedInfraMachine1.ObjectMeta, typedinfraMachine2.ObjectMeta); len(diffMetadata) > 0 {
+			diff[".metadata"] = diffMetadata
+		}
+
+		if diffStatus := deep.Equal(typedInfraMachine1.Status, typedinfraMachine2.Status); len(diffStatus) > 0 {
+			diff[".status"] = diffStatus
+		}
+	case configv1.PowerVSPlatformType:
+		typedInfraMachine1, ok := infraMachine1.(*ibmpowervsv1.IBMPowerVSMachine)
+		if !ok {
+			return nil, errAssertingCAPIIBMPowerVSMachine
+		}
+
+		typedinfraMachine2, ok := infraMachine2.(*ibmpowervsv1.IBMPowerVSMachine)
+		if !ok {
+			return nil, errAssertingCAPIIBMPowerVSMachine
+		}
+
+		if diffSpec := deep.Equal(typedInfraMachine1.Spec, typedinfraMachine2.Spec); len(diffSpec) > 0 {
+			diff[".spec"] = diffSpec
+		}
+
+		if diffMetadata := util.ObjectMetaEqual(typedInfraMachine1.ObjectMeta, typedinfraMachine2.ObjectMeta); len(diffMetadata) > 0 {
+			diff[".metadata"] = diffMetadata
+		}
+
+		if diffStatus := deep.Equal(typedInfraMachine1.Status, typedinfraMachine2.Status); len(diffStatus) > 0 {
+			diff[".status"] = diffStatus
+		}
+
+	default:
+		return nil, fmt.Errorf("%w: %s", errPlatformNotSupported, platform)
+	}
+
+	return diff, nil
+}
+
+// setChangedCAPIInfraMachineStatusFields sets the updated fields in the Cluster API Infrastructure machine status.
+func setChangedCAPIInfraMachineStatusFields(platform configv1.PlatformType, existingCAPIInfraMachine, convertedCAPIInfraMachine client.Object) error {
+	switch platform {
+	case configv1.AWSPlatformType:
+		existing, ok := existingCAPIInfraMachine.(*awsv1.AWSMachine)
+		if !ok {
+			return errAssertingCAPIAWSMachine
+		}
+
+		converted, ok := convertedCAPIInfraMachine.(*awsv1.AWSMachine)
+		if !ok {
+			return errAssertingCAPIAWSMachine
+		}
+
+		util.EnsureCAPIConditions(existing, converted)
+
+		// No need to merge v1beta2 conditions because they don't exist for AWSMachine's.
+
+		// Finally overwrite the entire existingCAPIMachine status with the convertedCAPIMachine status.
+		existing.Status = converted.Status
+
+		return nil
+	case configv1.OpenStackPlatformType:
+		existing, ok := existingCAPIInfraMachine.(*openstackv1.OpenStackMachine)
+		if !ok {
+			return errAssertingCAPIOpenStackMachine
+		}
+
+		converted, ok := convertedCAPIInfraMachine.(*openstackv1.OpenStackMachine)
+		if !ok {
+			return errAssertingCAPIOpenStackMachine
+		}
+
+		util.EnsureCAPIConditions(existing, converted)
+
+		// No need to merge v1beta2 conditions because they don't exist for OpenstackMachine's.
+
+		// Finally overwrite the entire existingCAPIMachine status with the convertedCAPIMachine status.
+		existing.Status = converted.Status
+
+		return nil
+	case configv1.PowerVSPlatformType:
+		existing, ok := existingCAPIInfraMachine.(*ibmpowervsv1.IBMPowerVSMachine)
+		if !ok {
+			return errAssertingCAPIIBMPowerVSMachine
+		}
+
+		converted, ok := convertedCAPIInfraMachine.(*ibmpowervsv1.IBMPowerVSMachine)
+		if !ok {
+			return errAssertingCAPIIBMPowerVSMachine
+		}
+
+		util.EnsureCAPIConditions(existing, converted)
+
+		// Merge the v1beta2 conditions.
+		util.EnsureCAPIV1Beta2Conditions(existing, converted)
+
+		// Finally overwrite the entire existing status with the convertedCAPIMachine status.
+		existing.Status = converted.Status
+
+		return nil
+	default:
+		return fmt.Errorf("%w: %s", errPlatformNotSupported, platform)
+	}
+}

--- a/pkg/conversion/capi2mapi/common.go
+++ b/pkg/conversion/capi2mapi/common.go
@@ -27,15 +27,15 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
-// RawExtensionFromProviderSpec marshals the machine provider spec.
-func RawExtensionFromProviderSpec(spec interface{}) (*runtime.RawExtension, error) {
+// RawExtensionFromInterface marshals the machine provider spec.
+func RawExtensionFromInterface(spec interface{}) (*runtime.RawExtension, error) {
 	if spec == nil {
-		return &runtime.RawExtension{}, nil
+		return nil, nil //nolint:nilnil
 	}
 
 	rawBytes, err := json.Marshal(spec)
 	if err != nil {
-		return nil, fmt.Errorf("error marshalling providerSpec: %w", err)
+		return nil, fmt.Errorf("failed to marshal from RawExtension: %w", err)
 	}
 
 	return &runtime.RawExtension{

--- a/pkg/conversion/capi2mapi/powervs.go
+++ b/pkg/conversion/capi2mapi/powervs.go
@@ -95,7 +95,7 @@ func (m machineAndPowerVSMachineAndPowerVSCluster) ToMachine() (*mapiv1beta1.Mac
 		errors = append(errors, err...)
 	}
 
-	powerVSRawExt, errRaw := RawExtensionFromProviderSpec(mapiPowerVSSpec)
+	powerVSRawExt, errRaw := RawExtensionFromInterface(mapiPowerVSSpec)
 	if errRaw != nil {
 		return nil, nil, fmt.Errorf("unable to convert PowerVS providerSpec to raw extension: %w", errRaw)
 	}

--- a/pkg/conversion/mapi2capi/aws_fuzz_test.go
+++ b/pkg/conversion/mapi2capi/aws_fuzz_test.go
@@ -76,7 +76,7 @@ var _ = Describe("AWS Fuzz (mapi2capi)", func() {
 			mapi2capi.FromAWSMachineAndInfra,
 			fromMachineAndAWSMachineAndAWSCluster,
 			conversiontest.ObjectMetaFuzzerFuncs(mapiNamespace),
-			conversiontest.MAPIMachineFuzzerFuncs(&mapiv1beta1.AWSMachineProviderConfig{}, awsProviderIDFuzzer),
+			conversiontest.MAPIMachineFuzzerFuncs(&mapiv1beta1.AWSMachineProviderConfig{}, &mapiv1beta1.AWSMachineProviderStatus{}, awsProviderIDFuzzer),
 			awsProviderSpecFuzzerFuncs,
 		)
 	})
@@ -99,7 +99,7 @@ var _ = Describe("AWS Fuzz (mapi2capi)", func() {
 			mapi2capi.FromAWSMachineSetAndInfra,
 			fromMachineSetAndAWSMachineTemplateAndAWSCluster,
 			conversiontest.ObjectMetaFuzzerFuncs(mapiNamespace),
-			conversiontest.MAPIMachineFuzzerFuncs(&mapiv1beta1.AWSMachineProviderConfig{}, awsProviderIDFuzzer),
+			conversiontest.MAPIMachineFuzzerFuncs(&mapiv1beta1.AWSMachineProviderConfig{}, &mapiv1beta1.AWSMachineProviderStatus{}, awsProviderIDFuzzer),
 			conversiontest.MAPIMachineSetFuzzerFuncs(),
 			awsProviderSpecFuzzerFuncs,
 		)

--- a/pkg/conversion/mapi2capi/machine.go
+++ b/pkg/conversion/mapi2capi/machine.go
@@ -141,11 +141,8 @@ func convertMAPIMachineStatusToCAPIMachineV1Beta2Status(mapiMachine *mapiv1beta1
 //
 //nolint:funlen
 func convertMAPIMachineConditionsToCAPIMachineConditions(mapiMachine *mapiv1beta1.Machine) clusterv1.Conditions {
-	capiConditions := []clusterv1.Condition{}
-
 	// According to CAPI v1beta1 machine conditions, there are three main conditions:
 	// Ready, BootstrapReady, InfrastructureReady
-
 	readyCondition := clusterv1.Condition{
 		Type: clusterv1.ReadyCondition,
 		Status: func() corev1.ConditionStatus {
@@ -210,9 +207,7 @@ func convertMAPIMachineConditionsToCAPIMachineConditions(mapiMachine *mapiv1beta
 		// LastTransitionTime will be set by the condition utilities.
 	}
 
-	capiConditions = append(capiConditions, readyCondition, bootstrapReadyCondition, infrastructureReadyCondition)
-
-	return capiConditions
+	return []clusterv1.Condition{readyCondition, bootstrapReadyCondition, infrastructureReadyCondition}
 }
 
 // convertMAPIMachineConditionsToCAPIMachineV1Beta2StatusConditions converts MAPI conditions to CAPI v1beta2 conditions.

--- a/pkg/conversion/mapi2capi/openstack_fuzz_test.go
+++ b/pkg/conversion/mapi2capi/openstack_fuzz_test.go
@@ -73,7 +73,7 @@ var _ = Describe("OpenStack Fuzz (mapi2capi)", func() {
 			mapi2capi.FromOpenStackMachineAndInfra,
 			fromMachineAndOpenStackMachineAndOpenStackCluster,
 			conversiontest.ObjectMetaFuzzerFuncs(mapiNamespace),
-			conversiontest.MAPIMachineFuzzerFuncs(&mapiv1alpha1.OpenstackProviderSpec{}, openstackProviderIDFuzzer),
+			conversiontest.MAPIMachineFuzzerFuncs(&mapiv1alpha1.OpenstackProviderSpec{}, nil, openstackProviderIDFuzzer),
 			openstackProviderSpecFuzzerFuncs,
 		)
 	})
@@ -96,7 +96,7 @@ var _ = Describe("OpenStack Fuzz (mapi2capi)", func() {
 			mapi2capi.FromOpenStackMachineSetAndInfra,
 			fromMachineSetAndOpenStackMachineTemplateAndOpenStackCluster,
 			conversiontest.ObjectMetaFuzzerFuncs(mapiNamespace),
-			conversiontest.MAPIMachineFuzzerFuncs(&mapiv1alpha1.OpenstackProviderSpec{}, openstackProviderIDFuzzer),
+			conversiontest.MAPIMachineFuzzerFuncs(&mapiv1alpha1.OpenstackProviderSpec{}, nil, openstackProviderIDFuzzer),
 			conversiontest.MAPIMachineSetFuzzerFuncs(),
 			openstackProviderSpecFuzzerFuncs,
 		)

--- a/pkg/conversion/mapi2capi/powervs_fuzz_test.go
+++ b/pkg/conversion/mapi2capi/powervs_fuzz_test.go
@@ -75,7 +75,7 @@ var _ = Describe("PowerVS Fuzz (mapi2capi)", func() {
 			mapi2capi.FromPowerVSMachineAndInfra,
 			fromMachineAndPowerVSMachineAndPowerVSCluster,
 			conversiontest.ObjectMetaFuzzerFuncs(mapiNamespace),
-			conversiontest.MAPIMachineFuzzerFuncs(&mapiv1.PowerVSMachineProviderConfig{}, powerVSProviderIDFuzzer),
+			conversiontest.MAPIMachineFuzzerFuncs(&mapiv1.PowerVSMachineProviderConfig{}, &mapiv1.PowerVSMachineProviderStatus{}, powerVSProviderIDFuzzer),
 			powerVSProviderSpecFuzzerFuncs,
 		)
 	})
@@ -98,7 +98,7 @@ var _ = Describe("PowerVS Fuzz (mapi2capi)", func() {
 			mapi2capi.FromPowerVSMachineSetAndInfra,
 			fromMachineSetAndPowerVSMachineTemplateAndPowerVSCluster,
 			conversiontest.ObjectMetaFuzzerFuncs(mapiNamespace),
-			conversiontest.MAPIMachineFuzzerFuncs(&mapiv1.PowerVSMachineProviderConfig{}, powerVSProviderIDFuzzer),
+			conversiontest.MAPIMachineFuzzerFuncs(&mapiv1.PowerVSMachineProviderConfig{}, &mapiv1.PowerVSMachineProviderStatus{}, powerVSProviderIDFuzzer),
 			conversiontest.MAPIMachineSetFuzzerFuncs(),
 			powerVSProviderSpecFuzzerFuncs,
 		)

--- a/pkg/util/conditions_test.go
+++ b/pkg/util/conditions_test.go
@@ -1,0 +1,475 @@
+/*
+Copyright 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package util
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	mapiv1beta1 "github.com/openshift/api/machine/v1beta1"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+//nolint:funlen
+func TestSetMAPICondition(t *testing.T) {
+	t1 := time.Now().UTC().Truncate(time.Second).Add(-1 * time.Hour)
+
+	tests := []struct {
+		name               string
+		existingConditions []mapiv1beta1.Condition
+		newCondition       *mapiv1beta1.Condition
+		expectedConditions []mapiv1beta1.Condition
+	}{
+		{
+			name:               "add new condition to empty list",
+			existingConditions: []mapiv1beta1.Condition{},
+			newCondition: &mapiv1beta1.Condition{
+				Type:    "Ready",
+				Status:  corev1.ConditionTrue,
+				Reason:  "AllGood",
+				Message: "Everything is working",
+			},
+			expectedConditions: []mapiv1beta1.Condition{
+				{
+					Type:    "Ready",
+					Status:  corev1.ConditionTrue,
+					Reason:  "AllGood",
+					Message: "Everything is working",
+				},
+			},
+		},
+		{
+			name: "add new condition to existing list",
+			existingConditions: []mapiv1beta1.Condition{
+				{
+					Type:               "Available",
+					Status:             corev1.ConditionTrue,
+					Reason:             "Available",
+					Message:            "Service is available",
+					LastTransitionTime: metav1.NewTime(t1),
+				},
+			},
+			newCondition: &mapiv1beta1.Condition{
+				Type:    "Ready",
+				Status:  corev1.ConditionTrue,
+				Reason:  "AllGood",
+				Message: "Everything is working",
+			},
+			expectedConditions: []mapiv1beta1.Condition{
+				{
+					Type:               "Available",
+					Status:             corev1.ConditionTrue,
+					Reason:             "Available",
+					Message:            "Service is available",
+					LastTransitionTime: metav1.NewTime(t1),
+				},
+				{
+					Type:    "Ready",
+					Status:  corev1.ConditionTrue,
+					Reason:  "AllGood",
+					Message: "Everything is working",
+				},
+			},
+		},
+		{
+			name: "update existing condition with status change",
+			existingConditions: []mapiv1beta1.Condition{
+				{
+					Type:               "Ready",
+					Status:             corev1.ConditionTrue,
+					Reason:             "AllGood",
+					Message:            "Everything is working",
+					LastTransitionTime: metav1.NewTime(t1),
+				},
+			},
+			newCondition: &mapiv1beta1.Condition{
+				Type:    "Ready",
+				Status:  corev1.ConditionFalse,
+				Reason:  "Error",
+				Message: "Something went wrong",
+			},
+			expectedConditions: []mapiv1beta1.Condition{
+				{
+					Type:    "Ready",
+					Status:  corev1.ConditionFalse,
+					Reason:  "Error",
+					Message: "Something went wrong",
+				},
+			},
+		},
+		{
+			name: "update existing condition with reason change",
+			existingConditions: []mapiv1beta1.Condition{
+				{
+					Type:               "Ready",
+					Status:             corev1.ConditionTrue,
+					Reason:             "AllGood",
+					Message:            "Everything is working",
+					LastTransitionTime: metav1.NewTime(t1),
+				},
+			},
+			newCondition: &mapiv1beta1.Condition{
+				Type:    "Ready",
+				Status:  corev1.ConditionTrue,
+				Reason:  "Updated",
+				Message: "Everything is working",
+			},
+			expectedConditions: []mapiv1beta1.Condition{
+				{
+					Type:    "Ready",
+					Status:  corev1.ConditionTrue,
+					Reason:  "Updated",
+					Message: "Everything is working",
+				},
+			},
+		},
+		{
+			name: "update existing condition with message change",
+			existingConditions: []mapiv1beta1.Condition{
+				{
+					Type:               "Ready",
+					Status:             corev1.ConditionTrue,
+					Reason:             "AllGood",
+					Message:            "Everything is working",
+					LastTransitionTime: metav1.NewTime(t1),
+				},
+			},
+			newCondition: &mapiv1beta1.Condition{
+				Type:    "Ready",
+				Status:  corev1.ConditionTrue,
+				Reason:  "AllGood",
+				Message: "Everything is still working",
+			},
+			expectedConditions: []mapiv1beta1.Condition{
+				{
+					Type:    "Ready",
+					Status:  corev1.ConditionTrue,
+					Reason:  "AllGood",
+					Message: "Everything is still working",
+				},
+			},
+		},
+		{
+			name: "update existing condition with no state change preserves time",
+			existingConditions: []mapiv1beta1.Condition{
+				{
+					Type:               "Ready",
+					Status:             corev1.ConditionTrue,
+					Reason:             "AllGood",
+					Message:            "Everything is working",
+					LastTransitionTime: metav1.NewTime(t1),
+				},
+			},
+			newCondition: &mapiv1beta1.Condition{
+				Type:    "Ready",
+				Status:  corev1.ConditionTrue,
+				Reason:  "AllGood",
+				Message: "Everything is working",
+			},
+			expectedConditions: []mapiv1beta1.Condition{
+				{
+					Type:               "Ready",
+					Status:             corev1.ConditionTrue,
+					Reason:             "AllGood",
+					Message:            "Everything is working",
+					LastTransitionTime: metav1.NewTime(t1),
+				},
+			},
+		},
+		{
+			name: "update existing condition with provided LastTransitionTime",
+			existingConditions: []mapiv1beta1.Condition{
+				{
+					Type:               "Ready",
+					Status:             corev1.ConditionTrue,
+					Reason:             "AllGood",
+					Message:            "Everything is working",
+					LastTransitionTime: metav1.NewTime(t1),
+				},
+			},
+			newCondition: &mapiv1beta1.Condition{
+				Type:               "Ready",
+				Status:             corev1.ConditionFalse,
+				Reason:             "Error",
+				Message:            "Something went wrong",
+				LastTransitionTime: metav1.NewTime(t1),
+			},
+			expectedConditions: []mapiv1beta1.Condition{
+				{
+					Type:               "Ready",
+					Status:             corev1.ConditionFalse,
+					Reason:             "Error",
+					Message:            "Something went wrong",
+					LastTransitionTime: metav1.NewTime(t1),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			before := metav1.NewTime(time.Now().UTC().Truncate(time.Second).Add(-1 * time.Second))
+			result := SetMAPICondition(tt.existingConditions, tt.newCondition)
+
+			g.Expect(result).To(HaveLen(len(tt.expectedConditions)))
+
+			for i, expected := range tt.expectedConditions {
+				actual := result[i]
+
+				g.Expect(actual.Type).To(Equal(expected.Type))
+				g.Expect(actual.Status).To(Equal(expected.Status))
+				g.Expect(actual.Reason).To(Equal(expected.Reason))
+				g.Expect(actual.Message).To(Equal(expected.Message))
+
+				if !expected.LastTransitionTime.IsZero() {
+					g.Expect(actual.LastTransitionTime).To(Equal(expected.LastTransitionTime))
+				} else {
+					g.Expect(actual.LastTransitionTime.After(before.Time)).To(BeTrue(), "LastTransitionTime should be set to something newer than before running the function")
+				}
+
+				g.Expect(actual.LastTransitionTime.Time.Nanosecond()).To(Equal(0), "LastTransitionTime should always be truncated to seconds")
+			}
+		})
+	}
+}
+
+//nolint:funlen
+func TestSetMAPIProviderCondition(t *testing.T) {
+	t1 := time.Now().UTC().Truncate(time.Second).Add(-1 * time.Hour)
+
+	tests := []struct {
+		name               string
+		existingConditions []metav1.Condition
+		newCondition       *metav1.Condition
+		expectedConditions []metav1.Condition
+	}{
+		{
+			name:               "add new condition to empty list",
+			existingConditions: []metav1.Condition{},
+			newCondition: &metav1.Condition{
+				Type:    "Ready",
+				Status:  metav1.ConditionTrue,
+				Reason:  "AllGood",
+				Message: "Everything is working",
+			},
+			expectedConditions: []metav1.Condition{
+				{
+					Type:    "Ready",
+					Status:  metav1.ConditionTrue,
+					Reason:  "AllGood",
+					Message: "Everything is working",
+				},
+			},
+		},
+		{
+			name: "add new condition to existing list",
+			existingConditions: []metav1.Condition{
+				{
+					Type:               "Available",
+					Status:             metav1.ConditionTrue,
+					Reason:             "Available",
+					Message:            "Service is available",
+					LastTransitionTime: metav1.NewTime(t1),
+				},
+			},
+			newCondition: &metav1.Condition{
+				Type:    "Ready",
+				Status:  metav1.ConditionTrue,
+				Reason:  "AllGood",
+				Message: "Everything is working",
+			},
+			expectedConditions: []metav1.Condition{
+				{
+					Type:               "Available",
+					Status:             metav1.ConditionTrue,
+					Reason:             "Available",
+					Message:            "Service is available",
+					LastTransitionTime: metav1.NewTime(t1),
+				},
+				{
+					Type:    "Ready",
+					Status:  metav1.ConditionTrue,
+					Reason:  "AllGood",
+					Message: "Everything is working",
+				},
+			},
+		},
+		{
+			name: "update existing condition with status change",
+			existingConditions: []metav1.Condition{
+				{
+					Type:               "Ready",
+					Status:             metav1.ConditionTrue,
+					Reason:             "AllGood",
+					Message:            "Everything is working",
+					LastTransitionTime: metav1.NewTime(t1),
+				},
+			},
+			newCondition: &metav1.Condition{
+				Type:    "Ready",
+				Status:  metav1.ConditionFalse,
+				Reason:  "Error",
+				Message: "Something went wrong",
+			},
+			expectedConditions: []metav1.Condition{
+				{
+					Type:    "Ready",
+					Status:  metav1.ConditionFalse,
+					Reason:  "Error",
+					Message: "Something went wrong",
+				},
+			},
+		},
+		{
+			name: "update existing condition with reason change",
+			existingConditions: []metav1.Condition{
+				{
+					Type:               "Ready",
+					Status:             metav1.ConditionTrue,
+					Reason:             "AllGood",
+					Message:            "Everything is working",
+					LastTransitionTime: metav1.NewTime(t1),
+				},
+			},
+			newCondition: &metav1.Condition{
+				Type:    "Ready",
+				Status:  metav1.ConditionTrue,
+				Reason:  "Updated",
+				Message: "Everything is working",
+			},
+			expectedConditions: []metav1.Condition{
+				{
+					Type:    "Ready",
+					Status:  metav1.ConditionTrue,
+					Reason:  "Updated",
+					Message: "Everything is working",
+				},
+			},
+		},
+		{
+			name: "update existing condition with message change",
+			existingConditions: []metav1.Condition{
+				{
+					Type:               "Ready",
+					Status:             metav1.ConditionTrue,
+					Reason:             "AllGood",
+					Message:            "Everything is working",
+					LastTransitionTime: metav1.NewTime(t1),
+				},
+			},
+			newCondition: &metav1.Condition{
+				Type:    "Ready",
+				Status:  metav1.ConditionTrue,
+				Reason:  "AllGood",
+				Message: "Everything is still working",
+			},
+			expectedConditions: []metav1.Condition{
+				{
+					Type:    "Ready",
+					Status:  metav1.ConditionTrue,
+					Reason:  "AllGood",
+					Message: "Everything is still working",
+				},
+			},
+		},
+		{
+			name: "update existing condition with no state change preserves time",
+			existingConditions: []metav1.Condition{
+				{
+					Type:               "Ready",
+					Status:             metav1.ConditionTrue,
+					Reason:             "AllGood",
+					Message:            "Everything is working",
+					LastTransitionTime: metav1.NewTime(t1),
+				},
+			},
+			newCondition: &metav1.Condition{
+				Type:    "Ready",
+				Status:  metav1.ConditionTrue,
+				Reason:  "AllGood",
+				Message: "Everything is working",
+			},
+			expectedConditions: []metav1.Condition{
+				{
+					Type:               "Ready",
+					Status:             metav1.ConditionTrue,
+					Reason:             "AllGood",
+					Message:            "Everything is working",
+					LastTransitionTime: metav1.NewTime(t1),
+				},
+			},
+		},
+		{
+			name: "update existing condition with provided LastTransitionTime",
+			existingConditions: []metav1.Condition{
+				{
+					Type:               "Ready",
+					Status:             metav1.ConditionTrue,
+					Reason:             "AllGood",
+					Message:            "Everything is working",
+					LastTransitionTime: metav1.NewTime(t1),
+				},
+			},
+			newCondition: &metav1.Condition{
+				Type:               "Ready",
+				Status:             metav1.ConditionFalse,
+				Reason:             "Error",
+				Message:            "Something went wrong",
+				LastTransitionTime: metav1.NewTime(t1),
+			},
+			expectedConditions: []metav1.Condition{
+				{
+					Type:               "Ready",
+					Status:             metav1.ConditionFalse,
+					Reason:             "Error",
+					Message:            "Something went wrong",
+					LastTransitionTime: metav1.NewTime(t1),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			before := metav1.NewTime(time.Now().UTC().Truncate(time.Second).Add(-1 * time.Second))
+			result := SetMAPIProviderCondition(tt.existingConditions, tt.newCondition)
+
+			g.Expect(result).To(HaveLen(len(tt.expectedConditions)))
+
+			for i, expected := range tt.expectedConditions {
+				actual := result[i]
+
+				g.Expect(actual.Type).To(Equal(expected.Type))
+				g.Expect(actual.Status).To(Equal(expected.Status))
+				g.Expect(actual.Reason).To(Equal(expected.Reason))
+				g.Expect(actual.Message).To(Equal(expected.Message))
+
+				if !expected.LastTransitionTime.IsZero() {
+					g.Expect(actual.LastTransitionTime).To(Equal(expected.LastTransitionTime))
+				} else {
+					g.Expect(actual.LastTransitionTime.After(before.Time)).To(BeTrue(), "LastTransitionTime should be set to something newer than before running the function")
+				}
+
+				g.Expect(actual.LastTransitionTime.Time.Nanosecond()).To(Equal(0), "LastTransitionTime should always be truncated to seconds")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implements conversion and syncing for status of AWS's Machine's <-> AWS providerStatus
Bases on top of:

- #365 

So that one needs to merge first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved infra-machine reconciliation across AWS, OpenStack and PowerVS with provider-status propagation and platform-aware infra creation/update flows.

* **Bug Fixes**
  * More reliable merging of provider conditions and correct LastTransitionTime semantics.

* **Refactor**
  * Centralized, diff-driven condition and status update utilities to simplify status propagation.

* **Tests**
  * Expanded unit and fuzz tests for provider-status round-trips and condition handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->