### PR TITLE
OCPBUGS-62620: kubeconfig controller: do not error on token secret not yet populated

### DIFF
--- a/pkg/controllers/kubeconfig/generate.go
+++ b/pkg/controllers/kubeconfig/generate.go
@@ -37,23 +37,27 @@ type kubeconfigOptions struct {
 	clusterName      string
 }
 
-func generateKubeconfig(options kubeconfigOptions) (*api.Config, error) {
+func validateKubeconfigOptions(options kubeconfigOptions) error {
 	if len(options.token) == 0 {
-		return nil, errTokenEmpty
+		return errTokenEmpty
 	}
 
 	if len(options.caCert) == 0 {
-		return nil, errCACertEmpty
+		return errCACertEmpty
 	}
 
 	if options.apiServerEnpoint == "" {
-		return nil, errAPIServerEndpointEmpty
+		return errAPIServerEndpointEmpty
 	}
 
 	if options.clusterName == "" {
-		return nil, errClusterNameEmpty
+		return errClusterNameEmpty
 	}
 
+	return nil
+}
+
+func generateKubeconfig(options kubeconfigOptions) *api.Config {
 	userName := "cluster-capi-operator"
 	kubeconfig := &api.Config{
 		Clusters: map[string]*api.Cluster{
@@ -77,5 +81,5 @@ func generateKubeconfig(options kubeconfigOptions) (*api.Config, error) {
 		CurrentContext: options.clusterName,
 	}
 
-	return kubeconfig, nil
+	return kubeconfig
 }

--- a/pkg/controllers/kubeconfig/generate_test.go
+++ b/pkg/controllers/kubeconfig/generate_test.go
@@ -36,8 +36,10 @@ var _ = Describe("Generate kubeconfig", func() {
 	})
 
 	It("should generate kubeconfig", func() {
-		kubeconfig, err := generateKubeconfig(*options)
+		err := validateKubeconfigOptions(*options)
 		Expect(err).NotTo(HaveOccurred())
+
+		kubeconfig := generateKubeconfig(*options)
 		Expect(kubeconfig).NotTo(BeNil())
 
 		Expect(kubeconfig.Clusters).To(HaveKey(options.clusterName))
@@ -55,29 +57,25 @@ var _ = Describe("Generate kubeconfig", func() {
 
 	It("should fail with empty token", func() {
 		options.token = nil
-		kubeconfig, err := generateKubeconfig(*options)
-		Expect(err).To((HaveOccurred()))
-		Expect(kubeconfig).To(BeNil())
+		err := validateKubeconfigOptions(*options)
+		Expect(err).To(MatchError(errTokenEmpty))
 	})
 
 	It("should fail with empty ca cert", func() {
 		options.caCert = nil
-		kubeconfig, err := generateKubeconfig(*options)
-		Expect(err).To((HaveOccurred()))
-		Expect(kubeconfig).To(BeNil())
+		err := validateKubeconfigOptions(*options)
+		Expect(err).To(MatchError(errCACertEmpty))
 	})
 
 	It("should fail with empty api server endpoint", func() {
 		options.apiServerEnpoint = ""
-		kubeconfig, err := generateKubeconfig(*options)
-		Expect(err).To((HaveOccurred()))
-		Expect(kubeconfig).To(BeNil())
+		err := validateKubeconfigOptions(*options)
+		Expect(err).To(MatchError(errAPIServerEndpointEmpty))
 	})
 
 	It("should fail with empty cluster name", func() {
 		options.clusterName = ""
-		kubeconfig, err := generateKubeconfig(*options)
-		Expect(err).To((HaveOccurred()))
-		Expect(kubeconfig).To(BeNil())
+		err := validateKubeconfigOptions(*options)
+		Expect(err).To(MatchError(errClusterNameEmpty))
 	})
 })


### PR DESCRIPTION
Context: https://redhat-internal.slack.com/archives/C01CQA76KMX/p1759324876564529

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized input validation before kubeconfig creation to simplify flow and ensure generation only occurs for validated inputs.
* **Bug Fixes**
  * Returns clear, specific validation errors for missing token/CA/endpoint/cluster fields.
  * Avoids producing partial configs on error.
* **Operational Improvements**
  * More resilient reconciliation with refined not-found handling and conditional retry behavior.
* **Tests**
  * Tests updated to validate inputs first and assert new validation error outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

----

## Testing/Verification

This is what the log of the cluster-capi-operator's kubeconfig controller report if we grep for "degraded" / errors before this PR: 

#### Before this PR/change:
```
[~] $ curl -SsL https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_cluster-capi-operator/367/pull-ci-openshift-cluster-capi-operator-main-e2e-aws-capi-techpreview/1973653493688307712/artifacts/e2e-aws-capi-techpreview/gather-extra/artifacts/pods/openshift-cluster-api_cluster-capi-operator-75c4f7784b-tv5nx_cluster-capi-operator.log | grep "error reconciling kubeconfig"
E1002 09:20:28.451757       1 controller.go:347] "Reconciler error" err="error reconciling kubeconfig: error generating kubeconfig: token can't be empty" controller="KubeconfigController" controllerGroup="" controllerKind="Secret" Secret="openshift-cluster-api/cluster-capi-operator-secret" namespace="openshift-cluster-api" name="cluster-capi-operator-secret" reconcileID="f61a1c4b-9827-4de3-bbbc-7780b965ca1a"
E1002 09:54:40.321304       1 controller.go:347] "Reconciler error" err="error reconciling kubeconfig: error generating kubeconfig: token can't be empty" controller="KubeconfigController" controllerGroup="" controllerKind="Secret" Secret="openshift-cluster-api/cluster-capi-operator-secret" namespace="openshift-cluster-api" name="cluster-capi-operator-secret" reconcileID="da0f666b-8493-457d-8090-256a639fcddf"

[~] $ curl -SsL https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_cluster-capi-operator/367/pull-ci-openshift-cluster-capi-operator-main-e2e-aws-capi-techpreview/1973653493688307712/artifacts/e2e-aws-capi-techpreview/gather-extra/artifacts/pods/openshift-cluster-api_cluster-capi-operator-75c4f7784b-tv5nx_cluster-capi-operator.log | grep degraded
I1002 09:20:28.435876       1 operator_status.go:118] "syncing status: degraded" controller="KubeconfigController" controllerGroup="" controllerKind="Secret" Secret="openshift-cluster-api/cluster-capi-operator-secret" namespace="openshift-cluster-api" name="cluster-capi-operator-secret" reconcileID="f61a1c4b-9827-4de3-bbbc-7780b965ca1a" message="Failed to resync for operator: 4.21.0-0.ci-2025-10-02-082851-test-ci-op-4qip8cl3-latest because &{%!e(string=error generating kubeconfig: token can't be empty) %!e(*errors.errorString=&{token can't be empty})}"
I1002 09:54:40.304457       1 operator_status.go:118] "syncing status: degraded" controller="KubeconfigController" controllerGroup="" controllerKind="Secret" Secret="openshift-cluster-api/cluster-capi-operator-secret" namespace="openshift-cluster-api" name="cluster-capi-operator-secret" reconcileID="da0f666b-8493-457d-8090-256a639fcddf" message="Failed to resync for operator: 4.21.0-0.ci-2025-10-02-082851-test-ci-op-4qip8cl3-latest because &{%!e(string=error generating kubeconfig: token can't be empty) %!e(*errors.errorString=&{token can't be empty})}"
```
#### With this PR/change included:
```
[~] $ curl -SsL https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_cluster-capi-operator/373/pull-ci-openshift-cluster-capi-operator-main-e2e-aws-capi-techpreview/1973672898853867520/artifacts/e2e-aws-capi-techpreview/gather-extra/artifacts/pods/openshift-cluster-api_cluster-capi-operator-5dfc7dfbbd-zb6fj_cluster-capi-operator.log | grep "error reconciling kubeconfig"
[~] $

[~] $ curl -SsL https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_cluster-capi-operator/373/pull-ci-openshift-cluster-capi-operator-main-e2e-aws-capi-techpreview/1973672898853867520/artifacts/e2e-aws-capi-techpreview/gather-extra/artifacts/pods/openshift-cluster-api_cluster-capi-operator-5dfc7dfbbd-zb6fj_cluster-capi-operator.log | grep degraded
[~] $ 

[~] $ curl -SsL https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_cluster-capi-operator/373/pull-ci-openshift-cluster-capi-operator-main-e2e-aws-capi-techpreview/1973672898853867520/artifacts/e2e-aws-capi-techpreview/gather-extra/artifacts/pods/openshift-cluster-api_cluster-capi-operator-5dfc7dfbbd-zb6fj_cluster-capi-operator.log | grep populate
I1002 10:08:01.077553       1 kubeconfig.go:169] "Token secret has not been populated by the control plane yet, waiting.." logger="KubeconfigController" controller="KubeconfigController" controllerGroup="" controllerKind="Secret" Secret="openshift-cluster-api/cluster-capi-operator-secret" namespace="openshift-cluster-api" name="cluster-capi-operator-secret" reconcileID="db0e6ba3-9d9f-4f50-85cc-0e2d0e827c72"
I1002 10:42:38.402560       1 kubeconfig.go:169] "Token secret has not been populated by the control plane yet, waiting.." logger="KubeconfigController" controller="KubeconfigController" controllerGroup="" controllerKind="Secret" Secret="openshift-cluster-api/cluster-capi-operator-secret" namespace="openshift-cluster-api" name="cluster-capi-operator-secret" reconcileID="fc02ebfe-4f1b-41b1-85f2-68ab485b3793"
```