### PR TITLE
Sync master-user-data secret

### DIFF
--- a/docs/controllers/secretsync.md
+++ b/docs/controllers/secretsync.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-[Secret sync controller](../../pkg/controllers/secretsync/secret_sync_controller.go) is responsible for syncing `worker-user-data` secret that is created by installer in `openshift-machine-api` namespace. The secret is used to store ignition configuration data for worker nodes.
+[Secret sync controller](../../pkg/controllers/secretsync/secret_sync_controller.go) is responsible for syncing `worker-user-data` and `master-user-data` secrets created by the installer in the `openshift-machine-api` namespace. These secrets store ignition configuration data for worker and control plane nodes, respectively.
 
 ## Behavior
 

--- a/pkg/controllers/secretsync/watch_predicates.go
+++ b/pkg/controllers/secretsync/watch_predicates.go
@@ -19,27 +19,28 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-func toUserDataSecret(ctx context.Context, obj client.Object) []reconcile.Request {
-	secret, ok := obj.(*corev1.Secret)
-	if !ok {
-		return nil
-	}
+func toUserDataSecret(namespace string) func(context.Context, client.Object) []reconcile.Request {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		secret, ok := obj.(*corev1.Secret)
+		if !ok {
+			return nil
+		}
 
-	// Map the source secret to the target secret with the same name
-	return []reconcile.Request{{
-		NamespacedName: client.ObjectKey{Name: secret.GetName(), Namespace: SecretSourceNamespace},
-	}}
+		// Map the source secret to the target secret with the same name
+		return []reconcile.Request{{
+			NamespacedName: client.ObjectKey{Name: secret.GetName(), Namespace: namespace},
+		}}
+	}
 }
 
 func userDataSecretPredicate(targetNamespace string) predicate.Funcs {
-	isOwnedUserDataSecret := func(obj runtime.Object) bool {
+	isOwnedUserDataSecret := func(obj client.Object) bool {
 		secret, ok := obj.(*corev1.Secret)
 		if !ok {
 			return false


### PR DESCRIPTION
Updates secret sync controller to sync `master-user-data` secret. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Secret sync now supports both worker and master user-data secrets with per-secret reconciliation for more reliable syncing.

* **Improvements**
  * Added validation to restrict syncing to recognized user-data secrets and improved per-secret error reporting and logging to reduce unintended actions.

* **Documentation**
  * Overview updated to note support for master-user-data secrets.

* **Tests**
  * Test coverage expanded to exercise both worker and master user-data synchronization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->