### PR TITLE
OCPBUGS-63411: machinesync: Create Cluster API InfraMachine if not exists while Cluster API Machine exists

### DIFF
--- a/pkg/controllers/machinesync/machine_sync_controller_test.go
+++ b/pkg/controllers/machinesync/machine_sync_controller_test.go
@@ -1036,20 +1036,19 @@ var _ = Describe("With a running MachineSync Reconciler", func() {
 					})
 
 					Context("and the InfraMachine does not exist", func() {
-						It("should update the synchronized condition on the MAPI machine to False", func() {
-							// TODO: Revert this to a useful error message.
-							// We changed how fetchCAPIInfraResources behaves, so now we fail at a later point in the code.
-							// This still fails, the behaviour is the same - it's just a less useful error for an end user.
-							// We need to revisit fetchCAPIInfraResources.
+						It("should create the Cluster API InfraMachine", func() {
 							Eventually(k.Object(mapiMachine), timeout).Should(
 								HaveField("Status.Conditions", ContainElement(
 									SatisfyAll(
 										HaveField("Type", Equal(consts.SynchronizedCondition)),
-										HaveField("Status", Equal(corev1.ConditionFalse)),
-										HaveField("Reason", Equal("FailedToConvertCAPIMachineToMAPI")),
-										HaveField("Message", ContainSubstring("unexpected InfraMachine type, expected AWSMachine, got <nil>")),
+										HaveField("Status", Equal(corev1.ConditionTrue)),
+										HaveField("Reason", Equal("ResourceSynchronized")),
+										HaveField("Message", ContainSubstring("Successfully synchronized CAPI Machine to MAPI")),
 									))),
 							)
+
+							capiInfraMachine := awsv1resourcebuilder.AWSMachine().WithName(mapiMachine.Name).WithNamespace(capiNamespace.Name).Build()
+							Eventually(k.Get(capiInfraMachine), timeout).Should(Succeed())
 						})
 					})
 				})

--- a/pkg/controllers/machinesync/machine_sync_controller_unit_test.go
+++ b/pkg/controllers/machinesync/machine_sync_controller_unit_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machinesync
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	awsv1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// Unit tests for fetchCAPIInfraResources because reconciling deletion depends on it.
+var _ = Describe("Unit tests for fetchCAPIInfraResources", func() {
+	var reconciler *MachineSyncReconciler
+	var capiMachine *clusterv1.Machine
+
+	BeforeEach(func() {
+		capiMachine = &clusterv1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-machine",
+				Namespace: "test-namespace",
+			},
+			Spec: clusterv1.MachineSpec{
+				ClusterName: "test-cluster",
+				InfrastructureRef: corev1.ObjectReference{
+					Kind:      "AWSMachine",
+					Name:      "test-machine",
+					Namespace: "test-namespace",
+				},
+			},
+		}
+
+		reconciler = &MachineSyncReconciler{
+			Scheme:   testEnv.Scheme,
+			Platform: configv1.AWSPlatformType,
+		}
+	})
+
+	Describe("when fetching Cluster API Infrastructure Resources", func() {
+		Context("when capiMachine is nil", func() {
+			It("should return nil and no error", func() {
+				reconciler.Client = fake.NewClientBuilder().WithScheme(testEnv.Scheme).Build()
+				infraCluster, infraMachine, err := reconciler.fetchCAPIInfraResources(ctx, nil)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(infraCluster).To(BeNil())
+				Expect(infraMachine).To(BeNil())
+			})
+		})
+
+		Context("and Infrastructure Cluster is not present", func() {
+			It("should return nil for both infra cluster and infra machine", func() {
+				reconciler.Client = fake.NewClientBuilder().WithScheme(testEnv.Scheme).Build()
+
+				infraCluster, infraMachine, err := reconciler.fetchCAPIInfraResources(ctx, capiMachine)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(ContainSubstring("failed to get Cluster API infrastructure cluster")))
+				Expect(infraCluster).To(BeNil())
+				Expect(infraMachine).To(BeNil())
+			})
+		})
+
+		Context("and Infrastructure is present", func() {
+			var objs []client.Object
+			BeforeEach(func() {
+				objs = []client.Object{
+					&awsv1.AWSCluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      capiMachine.Spec.ClusterName,
+							Namespace: capiMachine.Namespace,
+						},
+					},
+				}
+			})
+
+			It("should return nil if infrastructure machine is not present", func() {
+				reconciler.Client = fake.NewClientBuilder().WithScheme(testEnv.Scheme).WithObjects(objs...).Build()
+				infraCluster, infraMachine, err := reconciler.fetchCAPIInfraResources(ctx, capiMachine)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(infraCluster).ToNot(BeNil())
+				Expect(infraMachine).To(BeNil())
+			})
+
+			It("should return infrastructure machine if it is present", func() {
+				objs = append(objs, &awsv1.AWSMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      capiMachine.Name,
+						Namespace: capiMachine.Namespace,
+					},
+				})
+				reconciler.Client = fake.NewClientBuilder().WithScheme(testEnv.Scheme).WithObjects(objs...).Build()
+				infraCluster, infraMachine, err := reconciler.fetchCAPIInfraResources(ctx, capiMachine)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(infraCluster).ToNot(BeNil())
+				Expect(infraMachine).ToNot(BeNil())
+			})
+		})
+	})
+})

--- a/pkg/controllers/machinesync/machine_sync_controller_unit_test.go
+++ b/pkg/controllers/machinesync/machine_sync_controller_unit_test.go
@@ -20,10 +20,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	configv1 "github.com/openshift/api/config/v1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	awsv1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -41,10 +40,10 @@ var _ = Describe("Unit tests for fetchCAPIInfraResources", func() {
 			},
 			Spec: clusterv1.MachineSpec{
 				ClusterName: "test-cluster",
-				InfrastructureRef: corev1.ObjectReference{
-					Kind:      "AWSMachine",
-					Name:      "test-machine",
-					Namespace: "test-namespace",
+				InfrastructureRef: clusterv1.ContractVersionedObjectReference{
+					APIGroup: awsv1.GroupVersion.Group,
+					Kind:     "AWSMachine",
+					Name:     "test-machine",
 				},
 			},
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved machine synchronization to detect when the Cluster API infrastructure machine is missing and reconcile/create it when appropriate, preventing sequencing errors and reconciliation failures.
  * Hardened infra-resource retrieval to return consistent results and clearer error behavior across creation/deletion timing.

* **Tests**
  * Updated tests to expect successful infra creation and synchronization under CAPI authority.
  * Added unit tests covering infra cluster/machine presence and absence scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->