### PR TITLE
OCPCLOUD-2641,OCPCLOUD-3188: add e2e tests to verify ValidatingAdmissionPolicy

### DIFF
--- a/e2e/machine_migration_mapi_authoritative_test.go
+++ b/e2e/machine_migration_mapi_authoritative_test.go
@@ -29,6 +29,26 @@ var _ = Describe("[sig-cluster-lifecycle][OCPFeatureGate:MachineAPIMigration] Ma
 		var newCapiMachine *clusterv1.Machine
 		var newMapiMachine *mapiv1beta1.Machine
 
+		Context("With spec.authoritativeAPI: MachineAPI and existing CAPI Machine with that name", func() {
+			BeforeAll(func() {
+				newCapiMachine = createCAPIMachine(ctx, cl, mapiMachineAuthMAPIName)
+
+				DeferCleanup(func() {
+					By("Cleaning up machine resources")
+					cleanupMachineResources(
+						ctx,
+						cl,
+						[]*clusterv1.Machine{newCapiMachine},
+						[]*mapiv1beta1.Machine{},
+					)
+				})
+			})
+
+			It("should reject creation of MAPI Machine with same name as existing CAPI Machine", func() {
+				createSameNameMachineBlockedByVAPAuthMapi(ctx, cl, mapiMachineAuthMAPIName, mapiv1beta1.MachineAuthorityMachineAPI, "a Cluster API Machine with the same name already exists")
+			})
+		})
+
 		Context("With spec.authoritativeAPI: MachineAPI and no existing CAPI Machine with that name", func() {
 			BeforeAll(func() {
 				newMapiMachine = createMAPIMachineWithAuthority(ctx, cl, mapiMachineAuthMAPIName, mapiv1beta1.MachineAuthorityMachineAPI)

--- a/e2e/machineset_migration_capi_authoritative_test.go
+++ b/e2e/machineset_migration_capi_authoritative_test.go
@@ -58,8 +58,7 @@ var _ = Describe("[sig-cluster-lifecycle][OCPFeatureGate:MachineAPIMigration] Ma
 				verifyMachineSetPausedCondition(mapiMachineSet, mapiv1beta1.MachineAuthorityClusterAPI)
 			})
 
-			// bug https://issues.redhat.com/browse/OCPBUGS-55337
-			PIt("should verify that the non-authoritative MAPI MachineSet providerSpec has been updated to reflect the authoritative CAPI MachineSet mirror values", func() {
+			It("should verify that the non-authoritative MAPI MachineSet providerSpec has been updated to reflect the authoritative CAPI MachineSet mirror values", func() {
 				verifyMAPIMachineSetProviderSpec(mapiMachineSet, HaveField("InstanceType", Equal(instanceType)))
 			})
 		})

--- a/e2e/machineset_migration_mapi_authoritative_test.go
+++ b/e2e/machineset_migration_mapi_authoritative_test.go
@@ -55,10 +55,8 @@ var _ = Describe("[sig-cluster-lifecycle][OCPFeatureGate:MachineAPIMigration] Ma
 				})
 			})
 
-			// https://issues.redhat.com/browse/OCPCLOUD-3188
-			PIt("should reject creation of MAPI MachineSet with same name as existing CAPI MachineSet", func() {
-				By("Creating a same name MAPI MachineSet")
-				createMAPIMachineSetWithAuthoritativeAPI(ctx, cl, 0, existingCAPIMSAuthorityMAPIName, mapiv1beta1.MachineAuthorityMachineAPI, mapiv1beta1.MachineAuthorityMachineAPI)
+			It("should reject creation of MAPI MachineSet with same name as existing CAPI MachineSet", func() {
+				createSameNameMachineSetBlockedByVAPAuthMapi(ctx, cl, 0, existingCAPIMSAuthorityMAPIName, mapiv1beta1.MachineAuthorityMachineAPI, mapiv1beta1.MachineAuthorityMachineAPI, "a Cluster API MachineSet with the same name already exists")
 			})
 		})
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added scenarios verifying MAPI Machine creation is blocked when a CAPI Machine with the same name exists.
  * Added scenarios verifying MAPI MachineSet creation is blocked when a CAPI MachineSet with the same name exists.
  * Activated a previously disabled test validating non-authoritative MAPI MachineSet provider spec mirrors authoritative values.
  * Added test helpers to assert expected failure behavior and error messages for these blocking cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->