### PR TITLE
OCPBUGS-78476: Adds nutanix to images.json

### DIFF
--- a/manifests/0000_30_cluster-api-installer_04_images.configmap.yaml
+++ b/manifests/0000_30_cluster-api-installer_04_images.configmap.yaml
@@ -19,6 +19,7 @@ data:
       "ibmcloud-cluster-api-controllers": "registry.ci.openshift.org/openshift:ibmcloud-cluster-api-controllers",
       "openstack-cluster-api-controllers": "registry.ci.openshift.org/openshift:openstack-cluster-api-controllers",
       "vsphere-cluster-api-controllers": "registry.ci.openshift.org/openshift:vsphere-cluster-api-controllers",
+      "nutanix-cluster-api-controllers": "registry.ci.openshift.org/openshift:nutanix-cluster-api-controllers",
       "baremetal-cluster-api-controllers": "registry.ci.openshift.org/openshift:baremetal-cluster-api-controllers",
       "kube-rbac-proxy": "registry.ci.openshift.org/openshift:kube-rbac-proxy"
     }

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -42,6 +42,10 @@ spec:
     from:
       kind: DockerImage
       name: registry.ci.openshift.org/openshift:vsphere-cluster-api-controllers
+  - name: nutanix-cluster-api-controllers
+    from:
+      kind: DockerImage
+      name: registry.ci.openshift.org/openshift:nutanix-cluster-api-controllers
   - name: baremetal-cluster-api-controllers
     from:
       kind: DockerImage


### PR DESCRIPTION
We need nutanix to be in images.json for the new installer / manifests-gen tooling to work