### PR TITLE
OCPCLOUD-3373: Adds wildcard support for manifests-gen

### DIFF
--- a/pkg/providerimages/mirrors.go
+++ b/pkg/providerimages/mirrors.go
@@ -28,15 +28,15 @@ import (
 
 // getImageRegistryMirrors lists IDMS and ICSP resources from the cluster and
 // builds a map of source registries/repos to their mirror equivalents. If a
-// CRD is not installed on the cluster, it is silently skipped. Unsupported
-// wildcard sources (e.g. *.redhat.io) are removed from the map and returned
-// separately so the caller can log them.
-func getImageRegistryMirrors(ctx context.Context, c client.Reader) (mirrors map[string][]string, skippedWildcards []string, err error) {
-	mirrors = make(map[string][]string)
+// CRD is not installed on the cluster, it is silently skipped. Wildcard
+// sources (e.g. *.redhat.io) are included in the map and handled by
+// resolveImageRef.
+func getImageRegistryMirrors(ctx context.Context, c client.Reader) (map[string][]string, error) {
+	mirrors := make(map[string][]string)
 
 	idmsMirrors, err := getIDMSMirrors(ctx, c)
 	if err != nil && !meta.IsNoMatchError(err) {
-		return nil, nil, err
+		return nil, err
 	}
 
 	for k, v := range idmsMirrors {
@@ -45,21 +45,14 @@ func getImageRegistryMirrors(ctx context.Context, c client.Reader) (mirrors map[
 
 	icspMirrors, err := getICSPMirrors(ctx, c)
 	if err != nil && !meta.IsNoMatchError(err) {
-		return nil, nil, err
+		return nil, err
 	}
 
 	for k, v := range icspMirrors {
 		mirrors[k] = append(mirrors[k], v...)
 	}
 
-	for source := range mirrors {
-		if strings.HasPrefix(source, "*.") {
-			skippedWildcards = append(skippedWildcards, source)
-			delete(mirrors, source)
-		}
-	}
-
-	return mirrors, skippedWildcards, nil
+	return mirrors, nil
 }
 
 // getIDMSMirrors lists ImageDigestMirrorSet resources and returns a map of
@@ -126,17 +119,59 @@ func sourceMatchesRef(ref, source string) bool {
 	return nextChar == '/' || nextChar == '@'
 }
 
-// resolveImageRef rewrites an image reference using the first matching mirror.
-// Uses longest-prefix matching to find the most specific source.
-// Returns the rewritten ref if a mirror matches, or the original ref unchanged.
-func resolveImageRef(imageRef string, mirrors map[string][]string) string {
-	if len(mirrors) == 0 {
-		return imageRef
+// extractHostname splits an image reference into the registry hostname (with
+// port, if present) and the remainder (path and digest/tag).
+func extractHostname(ref string) (hostname, remainder string) {
+	slashIdx := strings.Index(ref, "/")
+	if slashIdx == -1 {
+		return ref, ""
 	}
 
+	return ref[:slashIdx], ref[slashIdx:]
+}
+
+// hostnameWithoutPort strips the port from a registry hostname.
+func hostnameWithoutPort(hostname string) string {
+	colonIdx := strings.LastIndex(hostname, ":")
+	if colonIdx == -1 {
+		return hostname
+	}
+
+	return hostname[:colonIdx]
+}
+
+// wildcardMatchesRef reports whether a wildcard source (e.g. *.redhat.io)
+// matches the hostname of an image reference. The wildcard requires at least
+// one subdomain — *.redhat.io matches registry.redhat.io but not redhat.io.
+// Ports in the ref's hostname are stripped before matching.
+func wildcardMatchesRef(ref, wildcardSource string) bool {
+	suffix := strings.TrimPrefix(wildcardSource, "*")
+
+	hostname, _ := extractHostname(ref)
+	domain := hostnameWithoutPort(hostname)
+
+	return strings.HasSuffix(domain, suffix)
+}
+
+// resolveImageRef rewrites an image reference using the first matching mirror.
+// Literal prefix matches are tried first (longest wins). If no literal match
+// is found, wildcard sources (*.domain) are tried (longest wins). Wildcard
+// replacement swaps the ref's hostname with the mirror, preserving the path.
+// Returns the rewritten ref and the matched source, or the original ref with
+// an empty source if no mirror matches.
+func resolveImageRef(imageRef string, mirrors map[string][]string) (resolved string, matchedSource string) {
+	if len(mirrors) == 0 {
+		return imageRef, ""
+	}
+
+	// Literal prefix matching (most specific wins).
 	var bestSource string
 
 	for source := range mirrors {
+		if strings.HasPrefix(source, "*.") {
+			continue
+		}
+
 		if !sourceMatchesRef(imageRef, source) {
 			continue
 		}
@@ -146,15 +181,32 @@ func resolveImageRef(imageRef string, mirrors map[string][]string) string {
 		}
 	}
 
-	if bestSource == "" || len(mirrors[bestSource]) == 0 {
-		return imageRef
+	if bestSource != "" && len(mirrors[bestSource]) > 0 {
+		suffix := strings.TrimPrefix(imageRef, bestSource)
+		return mirrors[bestSource][0] + suffix, bestSource
 	}
 
-	suffix := strings.TrimPrefix(imageRef, bestSource)
+	// Wildcard matching (longest wildcard wins).
+	var bestWildcard string
 
-	// We can support falling back e.g "quay.io/openshift" => mirrors:
-	// ["mirror-b.local/openshift", "mirror-c.local/openshift"] ut here we're
-	// assuming mirrors are correctly configured, so for simplicity's
-	// sake we're only taking the first.
-	return mirrors[bestSource][0] + suffix
+	for source := range mirrors {
+		if !strings.HasPrefix(source, "*.") {
+			continue
+		}
+
+		if !wildcardMatchesRef(imageRef, source) {
+			continue
+		}
+
+		if len(source) > len(bestWildcard) {
+			bestWildcard = source
+		}
+	}
+
+	if bestWildcard != "" && len(mirrors[bestWildcard]) > 0 {
+		_, remainder := extractHostname(imageRef)
+		return mirrors[bestWildcard][0] + remainder, bestWildcard
+	}
+
+	return imageRef, ""
 }

--- a/pkg/providerimages/mirrors_test.go
+++ b/pkg/providerimages/mirrors_test.go
@@ -52,17 +52,40 @@ var _ = Describe("sourceMatchesRef", func() {
 	)
 })
 
+var _ = Describe("wildcardMatchesRef", func() {
+	DescribeTable("should match wildcard sources against hostnames",
+		func(ref, wildcardSource string, expected bool) {
+			Expect(wildcardMatchesRef(ref, wildcardSource)).To(Equal(expected))
+		},
+		Entry("single subdomain matches",
+			"registry.redhat.io/product/repo@sha256:abc", "*.redhat.io", true),
+		Entry("multi-level subdomain matches",
+			"sub.domain.redhat.io/product/repo@sha256:abc", "*.redhat.io", true),
+		Entry("bare domain does not match",
+			"redhat.io/product/repo@sha256:abc", "*.redhat.io", false),
+		Entry("unrelated domain does not match",
+			"registry.example.com/product/repo@sha256:abc", "*.redhat.io", false),
+		Entry("hostname with port matches",
+			"registry.redhat.io:5000/product/repo@sha256:abc", "*.redhat.io", true),
+	)
+})
+
 var _ = Describe("resolveImageRef", func() {
 	type testInput struct {
-		imageRef string
-		mirrors  map[string][]string
-		expected string
+		imageRef       string
+		mirrors        map[string][]string
+		expected       string
+		expectedSource string
 	}
 
 	DescribeTable("should resolve image references through mirrors",
 		func(tt testInput) {
-			result := resolveImageRef(tt.imageRef, tt.mirrors)
-			Expect(result).To(Equal(tt.expected))
+			resolved, matchedSource := resolveImageRef(tt.imageRef, tt.mirrors)
+			Expect(resolved).To(Equal(tt.expected))
+
+			if tt.expectedSource != "" {
+				Expect(matchedSource).To(Equal(tt.expectedSource))
+			}
 		},
 		Entry("nil mirrors returns original ref", testInput{
 			imageRef: "registry.ci.openshift.org/openshift/aws-cluster-api-controllers@sha256:aabbccdd",
@@ -81,7 +104,8 @@ var _ = Describe("resolveImageRef", func() {
 					"virthost.ostest.test.metalkube.org:5000/localimages/aws-cluster-api-controllers",
 				},
 			},
-			expected: "virthost.ostest.test.metalkube.org:5000/localimages/aws-cluster-api-controllers@sha256:aabbccdd",
+			expected:       "virthost.ostest.test.metalkube.org:5000/localimages/aws-cluster-api-controllers@sha256:aabbccdd",
+			expectedSource: "registry.ci.openshift.org/openshift/aws-cluster-api-controllers",
 		}),
 		Entry("prefix match rewrites with suffix preserved", testInput{
 			imageRef: "registry.ci.openshift.org/openshift/aws-cluster-api-controllers@sha256:aabbccdd",
@@ -102,7 +126,8 @@ var _ = Describe("resolveImageRef", func() {
 					"virthost.ostest.test.metalkube.org:5000/localimages/local-release-image",
 				},
 			},
-			expected: "virthost.ostest.test.metalkube.org:5000/localimages/local-release-image/aws-cluster-api-controllers@sha256:aabbccdd",
+			expected:       "virthost.ostest.test.metalkube.org:5000/localimages/local-release-image/aws-cluster-api-controllers@sha256:aabbccdd",
+			expectedSource: "quay-proxy.ci.openshift.org/openshift/ci",
 		}),
 		Entry("multiple mirrors for one source uses first", testInput{
 			imageRef: "registry.ci.openshift.org/openshift/aws-cluster-api-controllers@sha256:aabbccdd",
@@ -143,6 +168,64 @@ var _ = Describe("resolveImageRef", func() {
 				},
 			},
 			expected: "mirror.local/capi@sha256:aabbccdd",
+		}),
+		Entry("wildcard match rewrites hostname and preserves path", testInput{
+			imageRef: "registry.redhat.io/product/repo@sha256:aabbccdd",
+			mirrors: map[string][]string{
+				"*.redhat.io": {"mirror.local/redhat"},
+			},
+			expected:       "mirror.local/redhat/product/repo@sha256:aabbccdd",
+			expectedSource: "*.redhat.io",
+		}),
+		Entry("literal match takes precedence over wildcard", testInput{
+			imageRef: "registry.redhat.io/product/repo@sha256:aabbccdd",
+			mirrors: map[string][]string{
+				"*.redhat.io":                     {"mirror.local/redhat"},
+				"registry.redhat.io/product/repo": {"mirror.local/specific"},
+			},
+			expected:       "mirror.local/specific@sha256:aabbccdd",
+			expectedSource: "registry.redhat.io/product/repo",
+		}),
+		Entry("hostname-only literal takes precedence over wildcard", testInput{
+			imageRef: "registry.redhat.io/product/repo@sha256:aabbccdd",
+			mirrors: map[string][]string{
+				"*.redhat.io":        {"mirror.local/redhat"},
+				"registry.redhat.io": {"mirror.local/specific"},
+			},
+			expected:       "mirror.local/specific/product/repo@sha256:aabbccdd",
+			expectedSource: "registry.redhat.io",
+		}),
+		Entry("longest wildcard wins", testInput{
+			imageRef: "sub.registry.redhat.io/product/repo@sha256:aabbccdd",
+			mirrors: map[string][]string{
+				"*.redhat.io":          {"mirror.local/redhat"},
+				"*.registry.redhat.io": {"mirror.local/registry"},
+			},
+			expected:       "mirror.local/registry/product/repo@sha256:aabbccdd",
+			expectedSource: "*.registry.redhat.io",
+		}),
+		Entry("wildcard matches ref with port in hostname", testInput{
+			imageRef: "registry.redhat.io:5000/product/repo@sha256:aabbccdd",
+			mirrors: map[string][]string{
+				"*.redhat.io": {"mirror.local/redhat"},
+			},
+			expected: "mirror.local/redhat/product/repo@sha256:aabbccdd",
+		}),
+		Entry("literal with empty mirrors falls through to wildcard", testInput{
+			imageRef: "registry.redhat.io/product/repo@sha256:aabbccdd",
+			mirrors: map[string][]string{
+				"registry.redhat.io/product/repo": {},
+				"*.redhat.io":                     {"mirror.local/redhat"},
+			},
+			expected:       "mirror.local/redhat/product/repo@sha256:aabbccdd",
+			expectedSource: "*.redhat.io",
+		}),
+		Entry("wildcard with empty mirrors slice returns original ref", testInput{
+			imageRef: "registry.redhat.io/product/repo@sha256:aabbccdd",
+			mirrors: map[string][]string{
+				"*.redhat.io": {},
+			},
+			expected: "registry.redhat.io/product/repo@sha256:aabbccdd",
 		}),
 	)
 })
@@ -186,14 +269,15 @@ var _ = Describe("getImageRegistryMirrors", func() {
 			},
 		).Build()
 
-		mirrors, skippedWildcards, err := getImageRegistryMirrors(ctx, c)
+		mirrors, err := getImageRegistryMirrors(ctx, c)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(skippedWildcards).To(BeEmpty())
-		Expect(mirrors).To(HaveLen(2))
-		Expect(mirrors).To(HaveKeyWithValue("registry.ci.openshift.org/openshift",
-			[]string{"virthost.ostest.test.metalkube.org:5000/localimages/local-release-image"}))
-		Expect(mirrors).To(HaveKeyWithValue("quay-proxy.ci.openshift.org/openshift/ci",
-			[]string{"virthost.ostest.test.metalkube.org:5000/localimages/ci"}))
+		Expect(mirrors).To(SatisfyAll(
+			HaveLen(2),
+			HaveKeyWithValue("registry.ci.openshift.org/openshift",
+				[]string{"virthost.ostest.test.metalkube.org:5000/localimages/local-release-image"}),
+			HaveKeyWithValue("quay-proxy.ci.openshift.org/openshift/ci",
+				[]string{"virthost.ostest.test.metalkube.org:5000/localimages/ci"}),
+		))
 	})
 
 	It("should return IDMS results only when ICSP CRD is not installed", func() {
@@ -219,9 +303,8 @@ var _ = Describe("getImageRegistryMirrors", func() {
 			},
 		}).Build()
 
-		mirrors, skippedWildcards, err := getImageRegistryMirrors(ctx, c)
+		mirrors, err := getImageRegistryMirrors(ctx, c)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(skippedWildcards).To(BeEmpty())
 		Expect(mirrors).To(SatisfyAll(
 			HaveLen(1),
 			HaveKeyWithValue("registry.ci.openshift.org/openshift",
@@ -236,13 +319,12 @@ var _ = Describe("getImageRegistryMirrors", func() {
 			},
 		}).Build()
 
-		mirrors, skippedWildcards, err := getImageRegistryMirrors(ctx, c)
+		mirrors, err := getImageRegistryMirrors(ctx, c)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(skippedWildcards).To(BeEmpty())
 		Expect(mirrors).To(BeEmpty())
 	})
 
-	It("should filter out wildcard sources", func() {
+	It("should include wildcard sources in the map", func() {
 		c := fake.NewClientBuilder().WithScheme(fullScheme).WithObjects(
 			&configv1.ImageDigestMirrorSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "idms-wildcard"},
@@ -261,12 +343,45 @@ var _ = Describe("getImageRegistryMirrors", func() {
 			},
 		).Build()
 
-		mirrors, skippedWildcards, err := getImageRegistryMirrors(ctx, c)
+		mirrors, err := getImageRegistryMirrors(ctx, c)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(skippedWildcards).To(ConsistOf("*.redhat.io"))
-		Expect(mirrors).To(HaveLen(1))
-		Expect(mirrors).NotTo(HaveKey("*.redhat.io"))
-		Expect(mirrors).To(HaveKey("registry.ci.openshift.org"))
+		Expect(mirrors).To(SatisfyAll(
+			HaveLen(2),
+			HaveKeyWithValue("*.redhat.io", []string{"mirror.local/redhat"}),
+			HaveKeyWithValue("registry.ci.openshift.org", []string{"mirror.local/openshift"}),
+		))
+	})
+
+	It("should merge wildcard mirrors from both IDMS and ICSP", func() {
+		c := fake.NewClientBuilder().WithScheme(fullScheme).WithObjects(
+			&configv1.ImageDigestMirrorSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "idms-wildcard"},
+				Spec: configv1.ImageDigestMirrorSetSpec{
+					ImageDigestMirrors: []configv1.ImageDigestMirrors{
+						{
+							Source:  "*.redhat.io",
+							Mirrors: []configv1.ImageMirror{"mirror-a.local/redhat"},
+						},
+					},
+				},
+			},
+			&operatorv1alpha1.ImageContentSourcePolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "icsp-wildcard"},
+				Spec: operatorv1alpha1.ImageContentSourcePolicySpec{
+					RepositoryDigestMirrors: []operatorv1alpha1.RepositoryDigestMirrors{
+						{
+							Source:  "*.redhat.io",
+							Mirrors: []string{"mirror-b.local/redhat"},
+						},
+					},
+				},
+			},
+		).Build()
+
+		mirrors, err := getImageRegistryMirrors(ctx, c)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mirrors).To(HaveKeyWithValue("*.redhat.io",
+			[]string{"mirror-a.local/redhat", "mirror-b.local/redhat"}))
 	})
 
 	It("should propagate real API errors", func() {
@@ -277,7 +392,7 @@ var _ = Describe("getImageRegistryMirrors", func() {
 			},
 		}).Build()
 
-		_, _, err := getImageRegistryMirrors(ctx, c)
+		_, err := getImageRegistryMirrors(ctx, c)
 		Expect(err).To(MatchError(expectedErr))
 	})
 })

--- a/pkg/providerimages/providerimages.go
+++ b/pkg/providerimages/providerimages.go
@@ -134,13 +134,9 @@ func ReadProviderImages(ctx context.Context, k8sClient client.Reader, log logr.L
 		return nil, fmt.Errorf("failed to parse pull secret: %w", err)
 	}
 
-	mirrors, skippedWildcards, err := getImageRegistryMirrors(ctx, k8sClient)
+	mirrors, err := getImageRegistryMirrors(ctx, k8sClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get image registry mirrors: %w", err)
-	}
-
-	for _, source := range skippedWildcards {
-		log.Info("ignoring unsupported wildcard mirror source", "source", source)
 	}
 
 	if len(mirrors) > 0 {
@@ -151,9 +147,11 @@ func ReadProviderImages(ctx context.Context, k8sClient client.Reader, log logr.L
 
 	resolvedImages := make([]string, len(containerImages))
 	for i, img := range containerImages {
-		resolvedImages[i] = resolveImageRef(img, mirrors)
-		if resolvedImages[i] != img {
-			log.Info("image ref resolved through mirror", "original", img, "resolved", resolvedImages[i])
+		resolved, matchedSource := resolveImageRef(img, mirrors)
+		resolvedImages[i] = resolved
+
+		if matchedSource != "" {
+			log.Info("image ref resolved through mirror", "original", img, "resolved", resolved, "matchedSource", matchedSource)
 		}
 	}
 


### PR DESCRIPTION
This was superseded by https://github.com/openshift/cluster-capi-operator/pull/544

----

Image mirrors now support wildcard sources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image registry mirrors now support wildcard hostname matching (e.g. *.domain.com) with hostname rewriting that preserves image path, digest, and tag. Literal (exact) matches take precedence over wildcards.

* **Bug Fixes**
  * Mirror selection and resolution now reliably indicate when a mirror was used, avoiding false positives when no mirror matched.

* **Tests**
  * Expanded coverage for wildcard matching, precedence, multi-level subdomains, and hostnames with ports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->