### PR TITLE
NO-JIRA: manifests-gen: set scc annotation in providers Deployments spec

### DIFF
--- a/manifests-gen/customizations.go
+++ b/manifests-gen/customizations.go
@@ -19,14 +19,6 @@ import (
 )
 
 var (
-	// Workload annotations are used by the workload admission webhook to modify pod
-	// resources and correctly schedule them while also pinning them to specific CPUSets.
-	// See for more info:
-	// https://github.com/openshift/enhancements/blob/master/enhancements/workload-partitioning/wide-availability-workload-partitioning.md
-	openshiftWorkloadAnnotation = map[string]string{
-		"target.workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
-	}
-
 	// The expected registry for images used by the cluster-capi-operator.
 	expectedRegistry = "registry.ci.openshift.org"
 )
@@ -176,11 +168,6 @@ func customizeDeployment(obj client.Object) (client.Object, error) {
 
 	deployment.Spec.Template.Spec.PriorityClassName = "system-cluster-critical"
 
-	deployment.Spec.Template.Annotations = mergeMaps(
-		deployment.Spec.Template.Annotations,
-		openshiftWorkloadAnnotation,
-	)
-
 	for i := range deployment.Spec.Template.Spec.Containers {
 		container := &deployment.Spec.Template.Spec.Containers[i]
 		// Add resource requests
@@ -228,18 +215,6 @@ func replaceCertMangerServiceSecret(obj client.Object, serviceSecretNames map[st
 		anns["service.beta.openshift.io/serving-cert-secret-name"] = name
 		obj.SetAnnotations(anns)
 	}
-}
-
-// Variadic function to merge maps of like kind.
-// Note: keys of next map will override keys in previous map if previous map contains same key.
-func mergeMaps[K comparable, V any](maps ...map[K]V) map[K]V {
-	result := map[K]V{}
-	for _, m := range maps {
-		for k, v := range m {
-			result[k] = v
-		}
-	}
-	return result
 }
 
 // generateInfraClusterProtectionPolicy generates a Validating Admission Policy and Binding for protecting

--- a/manifests-gen/customizations.go
+++ b/manifests-gen/customizations.go
@@ -176,7 +176,10 @@ func customizeDeployment(obj client.Object) (client.Object, error) {
 
 	deployment.Spec.Template.Spec.PriorityClassName = "system-cluster-critical"
 
-	deployment.Spec.Template.Annotations = mergeMaps(deployment.Spec.Template.Annotations, openshiftWorkloadAnnotation)
+	deployment.Spec.Template.Annotations = mergeMaps(
+		deployment.Spec.Template.Annotations,
+		openshiftWorkloadAnnotation,
+	)
 
 	for i := range deployment.Spec.Template.Spec.Containers {
 		container := &deployment.Spec.Template.Spec.Containers[i]

--- a/manifests-gen/kustomization.yaml
+++ b/manifests-gen/kustomization.yaml
@@ -15,3 +15,19 @@ patches:
       name: __ignored__
       annotations:
         config.kubernetes.io/local-config: "true"
+
+# Set the required SCC annotation on all Deployments' pod templates.
+# Default to the most restrictive SCC, this can be overridden by the providers upon manifest generation.
+# See: https://github.com/openshift/enhancements/blob/master/enhancements/authentication/custom-scc-preemption-prevention.md
+- target:
+    kind: Deployment
+  patch: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: __ignored__
+    spec:
+      template:
+        metadata:
+          annotations:
+            openshift.io/required-scc: "restricted-v2"

--- a/manifests-gen/kustomization.yaml
+++ b/manifests-gen/kustomization.yaml
@@ -16,9 +16,11 @@ patches:
       annotations:
         config.kubernetes.io/local-config: "true"
 
-# Set the required SCC annotation on all Deployments' pod templates.
-# Default to the most restrictive SCC, this can be overridden by the providers upon manifest generation.
-# See: https://github.com/openshift/enhancements/blob/master/enhancements/authentication/custom-scc-preemption-prevention.md
+# Set OpenShift pod annotations on all Deployments' pod templates.
+# - required-scc: pins the SCC (default restricted-v2, providers can override).
+#   See: https://github.com/openshift/enhancements/blob/master/enhancements/authentication/custom-scc-preemption-prevention.md
+# - workload management: enables workload partitioning scheduling.
+#   See: https://github.com/openshift/enhancements/blob/master/enhancements/workload-partitioning/wide-availability-workload-partitioning.md
 - target:
     kind: Deployment
   patch: |
@@ -31,3 +33,4 @@ patches:
         metadata:
           annotations:
             openshift.io/required-scc: "restricted-v2"
+            target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'


### PR DESCRIPTION
The openshift.io/required-scc: restricted-v2 annotation should be set on pods as required by the requiredSCCAnnotationChecker see: https://github.com/openshift/enhancements/blob/master/enhancements/authentication/custom-scc-preemption-prevention.md

more info on scc: 
- https://github.com/openshift/openshift-docs/blob/72420d78d324c3088372ec7c508d933864181336/modules/security-context-constraints-requiring.adoc#L26
- https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/authentication_and_authorization/managing-pod-security-policies#security-context-constraints-about_configuring-internal-oauth

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployments now automatically receive OpenShift pod annotations (openshift.io/required-scc=restricted-v2 and target.workload.openshift.io/management={"effect":"PreferredDuringScheduling"}) via kustomize patches, ensuring these annotations are present on all Deployment pod templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->