### PR TITLE
NO-JIRA: Fix crdcompatibility flakes after webhook creation

### DIFF
--- a/pkg/controllers/crdcompatibility/objectpruning/handle_test.go
+++ b/pkg/controllers/crdcompatibility/objectpruning/handle_test.go
@@ -82,9 +82,19 @@ var _ = Describe("Object Pruning Integration", func() {
 				webhookConfig := createMutatingWebhookConfig(scenario.CompatibilityRequirement, liveCRD)
 				Expect(cl.Create(ctx, webhookConfig)).To(Succeed())
 
+				By("Waiting for the webhook manager cache to observe the CompatibilityRequirement", func() {
+					// The admission handler uses mgr.GetClient(), which reads from the informer cache first.
+					Eventually(func(g Gomega) {
+						cached := &apiextensionsv1alpha1.CompatibilityRequirement{}
+						g.Expect(managerClient.Get(ctx, client.ObjectKeyFromObject(scenario.CompatibilityRequirement), cached)).To(Succeed())
+					}).WithContext(ctx).WithTimeout(defaultEventuallyTimeout).Should(Succeed())
+				})
+
 				By("Creating object through API server (should be pruned by webhook)")
 				// Set the namespace and ensure object matches the CRD GVK
 				gvk := liveCRD.Spec.Versions[0].Name
+
+				// Hydrate scenario.InputObject into an unstructured object.
 				inputObject := &unstructured.Unstructured{
 					Object: runtime.DeepCopyJSON(scenario.InputObject),
 				}
@@ -93,11 +103,7 @@ var _ = Describe("Object Pruning Integration", func() {
 				inputObject.SetNamespace(namespace)
 				inputObject.SetName(fmt.Sprintf("test-pruning-%d", GinkgoRandomSeed()))
 
-				// Status must be handled separately because it's a subresource.
 				status, hasStatus, _ := unstructured.NestedMap(inputObject.Object, "status")
-				if hasStatus {
-					delete(inputObject.Object, "status")
-				}
 
 				DeferCleanup(func(ctx context.Context) {
 					Expect(test.CleanupAndWait(ctx, cl,
@@ -107,45 +113,43 @@ var _ = Describe("Object Pruning Integration", func() {
 					)).To(Succeed())
 				})
 
-				// Create object through API server - webhook should prune it
-				Expect(cl.Create(ctx, inputObject)).To(Succeed())
+				// Create may succeed before the apiserver starts invoking the new MutatingWebhookConfiguration,
+				// leaving an unpruned object in etcd. Retry delete+create until pruning matches.
+				Eventually(func(g Gomega) {
+					retrievedObject := inputObject.DeepCopy()
 
-				// Write the status through the status subresource.
-				if hasStatus {
-					inputObject.Object["status"] = status
-					Expect(cl.Status().Update(ctx, inputObject)).To(Succeed())
-				}
+					// Status must be handled separately because it's a subresource.
+					if hasStatus {
+						delete(retrievedObject.Object, "status")
+					}
 
-				By("Verifying the object was pruned correctly", func() {
-					retrievedObj := &unstructured.Unstructured{}
-					retrievedObj.SetGroupVersionKind(inputObject.GroupVersionKind())
-					retrievedObj.SetName(inputObject.GetName())
-					retrievedObj.SetNamespace(inputObject.GetNamespace())
+					// If a previous loop raced and successfully created the object we need to delete it first.
+					g.Expect(client.IgnoreNotFound(cl.Delete(ctx, retrievedObject))).To(Succeed())
+					g.Expect(cl.Create(ctx, retrievedObject)).To(Succeed())
 
-					Eventually(kWithCtx(ctx).Get(retrievedObj)).WithContext(ctx).Should(Succeed())
+					if hasStatus {
+						retrievedObject.Object["status"] = status
+						g.Expect(cl.Status().Update(ctx, retrievedObject)).To(Succeed())
+					}
 
-					Expect(retrievedObj.Object).To(test.IgnoreFields([]string{"apiVersion", "kind", "metadata"}, Equal(scenario.ExpectedObject)), "Expected object to be pruned correctly")
-				})
+					g.Expect(retrievedObject.Object).To(test.IgnoreFields([]string{"apiVersion", "kind", "metadata"}, Equal(scenario.ExpectedObject)), "Expected object to be pruned correctly")
+				}).WithContext(ctx).WithTimeout(defaultEventuallyTimeout).Should(Succeed())
+
+				retrievedObj := inputObject.DeepCopy()
+				Expect(cl.Get(ctx, client.ObjectKeyFromObject(retrievedObj), retrievedObj)).To(Succeed())
 
 				By("Attempting to update the object, should prune the object again", func() {
-					inputObject.Object["spec"] = runtime.DeepCopyJSONValue(scenario.InputObject["spec"])
-					Expect(cl.Update(ctx, inputObject)).To(Succeed())
+					retrievedObj.Object["spec"] = runtime.DeepCopyJSONValue(scenario.InputObject["spec"])
+					Expect(cl.Update(ctx, retrievedObj)).To(Succeed())
 				})
 
 				// Write the status through the status subresource.
 				if hasStatus {
-					inputObject.Object["status"] = status
-					Expect(cl.Status().Update(ctx, inputObject)).To(Succeed())
+					retrievedObj.Object["status"] = status
+					Expect(cl.Status().Update(ctx, retrievedObj)).To(Succeed())
 				}
 
 				By("Verifying the object was pruned correctly", func() {
-					retrievedObj := &unstructured.Unstructured{}
-					retrievedObj.SetGroupVersionKind(inputObject.GroupVersionKind())
-					retrievedObj.SetName(inputObject.GetName())
-					retrievedObj.SetNamespace(inputObject.GetNamespace())
-
-					Eventually(kWithCtx(ctx).Get(retrievedObj)).WithContext(ctx).Should(Succeed())
-
 					Expect(retrievedObj.Object).To(test.IgnoreFields([]string{"apiVersion", "kind", "metadata"}, Equal(scenario.ExpectedObject)), "Expected object to be pruned correctly")
 				})
 
@@ -165,24 +169,17 @@ var _ = Describe("Object Pruning Integration", func() {
 				})
 
 				By("Updating the object again, should not be pruned", func() {
-					inputObject.Object["spec"] = scenario.InputObject["spec"]
-					Expect(cl.Update(ctx, inputObject)).To(Succeed())
+					retrievedObj.Object["spec"] = scenario.InputObject["spec"]
+					Expect(cl.Update(ctx, retrievedObj)).To(Succeed())
 				})
 
 				// Write the status through the status subresource.
 				if hasStatus {
-					inputObject.Object["status"] = status
-					Expect(cl.Status().Update(ctx, inputObject)).To(Succeed())
+					retrievedObj.Object["status"] = status
+					Expect(cl.Status().Update(ctx, retrievedObj)).To(Succeed())
 				}
 
 				By("Verifying the object was not pruned", func() {
-					retrievedObj := &unstructured.Unstructured{}
-					retrievedObj.SetGroupVersionKind(inputObject.GroupVersionKind())
-					retrievedObj.SetName(inputObject.GetName())
-					retrievedObj.SetNamespace(inputObject.GetNamespace())
-
-					Eventually(kWithCtx(ctx).Get(retrievedObj)).WithContext(ctx).Should(Succeed())
-
 					Expect(retrievedObj.Object).To(test.IgnoreFields([]string{"apiVersion", "kind", "metadata"}, Equal(scenario.InputObject)), "Expected object to be not pruned")
 				})
 			},
@@ -362,8 +359,16 @@ var _ = Describe("Object Pruning Integration", func() {
 
 			By("Verifying error response")
 
-			err := cl.Create(ctx, testObj)
-			Expect(err).To(MatchError(ContainSubstring("CompatibilityRequirement.apiextensions.openshift.io \"non-existent-compat-req\" not found")))
+			Eventually(func(g Gomega) {
+				g.Expect(client.IgnoreNotFound(cl.Delete(ctx, testObj))).To(Succeed())
+
+				err := cl.Create(ctx, testObj)
+				if err == nil {
+					g.Expect(cl.Delete(ctx, testObj)).To(Succeed())
+				}
+
+				g.Expect(err).To(MatchError(ContainSubstring("CompatibilityRequirement.apiextensions.openshift.io \"non-existent-compat-req\" not found")))
+			}).WithContext(ctx).WithTimeout(defaultEventuallyTimeout).Should(Succeed())
 		}, defaultNodeTimeout)
 	})
 })

--- a/pkg/controllers/crdcompatibility/objectpruning/suite_test.go
+++ b/pkg/controllers/crdcompatibility/objectpruning/suite_test.go
@@ -48,7 +48,10 @@ var (
 	emptySuiteCRD      func() *apiextensionsv1.CustomResourceDefinition
 )
 
-var defaultNodeTimeout = NodeTimeout(10 * time.Second)
+var (
+	defaultNodeTimeout       = NodeTimeout(10 * time.Second)
+	defaultEventuallyTimeout = 2 * time.Second
+)
 
 func TestObjectPruning(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/controllers/crdcompatibility/objectvalidation/handle_test.go
+++ b/pkg/controllers/crdcompatibility/objectvalidation/handle_test.go
@@ -73,7 +73,7 @@ var _ = Describe("End-to-End Admission Webhook Integration", Ordered, ContinueOn
 
 	BeforeAll(func() {
 		// Initialize validator and webhook server for all tests
-		_, startWebhookServer = InitValidator(context.Background())
+		_, managerClient, startWebhookServer = InitValidator(context.Background())
 		startWebhookServer()
 	})
 
@@ -91,6 +91,7 @@ var _ = Describe("End-to-End Admission Webhook Integration", Ordered, ContinueOn
 				// Create ValidatingWebhookConfiguration to enable end-to-end testing
 				webhookConfig := createValidatingWebhookConfig(compatibilityRequirement, compatibilityCRD)
 				Expect(cl.Create(ctx, webhookConfig)).To(Succeed())
+				waitForCompatibilityRequirementInWebhookManagerCache(ctx, compatibilityRequirement)
 
 				DeferCleanup(func(ctx context.Context) {
 					Expect(test.CleanupAndWait(ctx, cl,
@@ -138,11 +139,7 @@ var _ = Describe("End-to-End Admission Webhook Integration", Ordered, ContinueOn
 					// Missing requiredField - should be rejected
 					Build()
 
-				// This should fail due to validation webhook
-				err := cl.Create(ctx, invalidObj)
-				Expect(err).To(HaveOccurred())
-				Expect(apierrors.IsInvalid(err)).To(BeTrue())
-				Expect(err).To(MatchError(ContainSubstring("requiredField: Required value")))
+				expectInvalidCreateEventually(ctx, cl, invalidObj, "requiredField: Required value")
 			}, defaultNodeTimeout)
 		})
 	})
@@ -167,6 +164,7 @@ var _ = Describe("End-to-End Admission Webhook Integration", Ordered, ContinueOn
 				// Create ValidatingWebhookConfiguration to enable end-to-end testing
 				webhookConfig := createValidatingWebhookConfig(tighterCompatibilityRequirement, tighterCRD)
 				Expect(cl.Create(ctx, webhookConfig)).To(Succeed())
+				waitForCompatibilityRequirementInWebhookManagerCache(ctx, tighterCompatibilityRequirement)
 
 				DeferCleanup(func(ctx context.Context) {
 					Expect(test.CleanupAndWait(ctx, cl,
@@ -189,11 +187,7 @@ var _ = Describe("End-to-End Admission Webhook Integration", Ordered, ContinueOn
 					// Missing testField which is now required in tighter compatibility requirement
 					Build()
 
-				// Configure webhook to use the tighter compatibility requirement
-				err := cl.Create(ctx, objMissingField)
-				Expect(err).To(HaveOccurred())
-				Expect(apierrors.IsInvalid(err)).To(BeTrue())
-				Expect(err).To(MatchError(ContainSubstring("testField: Required value, optionalNumber: Required value")))
+				expectInvalidCreateEventually(ctx, cl, objMissingField, "testField: Required value, optionalNumber: Required value")
 			}, defaultNodeTimeout)
 
 			It("should allow objects with all required fields through API server", func(ctx context.Context) {
@@ -241,6 +235,7 @@ var _ = Describe("End-to-End Admission Webhook Integration", Ordered, ContinueOn
 				// Create ValidatingWebhookConfiguration to enable end-to-end testing
 				webhookConfig := createValidatingWebhookConfig(looserCompatibilityRequirement, looserCRD)
 				Expect(cl.Create(ctx, webhookConfig)).To(Succeed())
+				waitForCompatibilityRequirementInWebhookManagerCache(ctx, looserCompatibilityRequirement)
 
 				DeferCleanup(func(ctx context.Context) {
 					Expect(test.CleanupAndWait(ctx, cl,
@@ -284,11 +279,7 @@ var _ = Describe("End-to-End Admission Webhook Integration", Ordered, ContinueOn
 					// Missing requiredField which is no longer required in looser compatibility requirement
 					Build()
 
-				// This should fail as the field is still required in the live CRD.
-				err := cl.Create(ctx, objMissingFormerlyRequired)
-				Expect(err).To(HaveOccurred())
-				Expect(apierrors.IsInvalid(err)).To(BeTrue())
-				Expect(err).To(MatchError(ContainSubstring("requiredField: Required value")))
+				expectInvalidCreateEventually(ctx, cl, objMissingFormerlyRequired, "requiredField: Required value")
 			}, defaultNodeTimeout)
 		})
 	})
@@ -355,21 +346,24 @@ var _ = Describe("End-to-End Admission Webhook Integration", Ordered, ContinueOn
 					Expect(cl.Create(ctx, tighterWebhookConfig)).To(Succeed())
 				})
 
+				waitForCompatibilityRequirementInWebhookManagerCache(ctx, tighterCompatibilityRequirement)
+
 				DeferCleanup(func(ctx context.Context) {
 					Expect(test.CleanupAndWait(ctx, cl, tighterWebhookConfig, tighterCompatibilityRequirement)).To(Succeed())
 				})
 			}, defaultNodeTimeout)
 
 			It("should reject updates that remove newly required fields", func(ctx context.Context) {
-				// Try to update by removing a field that's required in the tighter compatibility requirement
-				updateMissingField := existingObj.DeepCopy()
-				delete(updateMissingField.Object, "testField") // Remove field required by tighter validation
-				// Optional number was also changed to required but wasn't present originally, so will flag.
+				Eventually(func(g Gomega) {
+					g.Expect(cl.Get(ctx, client.ObjectKeyFromObject(existingObj), existingObj)).To(Succeed())
+					updateMissingField := existingObj.DeepCopy()
+					delete(updateMissingField.Object, "testField") // Remove field required by tighter validation
 
-				err := cl.Update(ctx, updateMissingField)
-				Expect(err).To(HaveOccurred())
-				Expect(apierrors.IsInvalid(err)).To(BeTrue())
-				Expect(err).To(MatchError(ContainSubstring("testField: Required value, optionalNumber: Required value")))
+					err := cl.Update(ctx, updateMissingField)
+					g.Expect(err).To(HaveOccurred())
+					g.Expect(apierrors.IsInvalid(err)).To(BeTrue())
+					g.Expect(err).To(MatchError(ContainSubstring("testField: Required value, optionalNumber: Required value")))
+				}).WithContext(ctx).WithTimeout(defaultEventuallyTimeout).Should(Succeed())
 			}, defaultNodeTimeout)
 
 			It("should allow updates that include all newly required fields", func(ctx context.Context) {
@@ -450,6 +444,7 @@ var _ = Describe("End-to-End Admission Webhook Integration", Ordered, ContinueOn
 				statusWebhookConfig := createValidatingWebhookConfig(statusCompatibilityRequirement, compatibilityCRD)
 				statusWebhookConfig.Name = fmt.Sprintf("test-status-validation-%s", statusCompatibilityRequirement.Name)
 				Expect(cl.Create(ctx, statusWebhookConfig)).To(Succeed())
+				waitForCompatibilityRequirementInWebhookManagerCache(ctx, statusCompatibilityRequirement)
 
 				DeferCleanup(func(ctx context.Context) {
 					Expect(test.CleanupAndWait(ctx, cl, statusWebhookConfig, statusCompatibilityRequirement)).To(Succeed())
@@ -520,17 +515,9 @@ var _ = Describe("End-to-End Admission Webhook Integration", Ordered, ContinueOn
 					Expect(test.CleanupAndWait(ctx, cl, baseObj)).To(Succeed())
 				})
 
-				// Wait for object to be created
-				Eventually(kWithCtx(ctx).Get(baseObj)).WithContext(ctx).Should(Succeed())
-
-				// Now try to update status with invalid enum value
-				statusUpdate := baseObj.DeepCopy()
-				statusUpdate.Object["status"] = map[string]interface{}{
+				expectStatusUpdateMatchErrorEventually(ctx, baseObj, map[string]interface{}{
 					"phase": "InvalidPhase", // Not in allowed enum values
-				}
-
-				err := cl.Status().Update(ctx, statusUpdate)
-				Expect(err).To(MatchError(ContainSubstring("\"test-object\" is invalid: status.phase: Unsupported value: \"InvalidPhase\": supported values: \"Ready\", \"Pending\", \"Failed\"")))
+				}, "\"test-object\" is invalid: status.phase: Unsupported value: \"InvalidPhase\": supported values: \"Ready\", \"Pending\", \"Failed\"")
 			}, defaultNodeTimeout)
 
 			It("should reject status updates with invalid nested structure when status validation is enabled", func(ctx context.Context) {
@@ -553,12 +540,7 @@ var _ = Describe("End-to-End Admission Webhook Integration", Ordered, ContinueOn
 					Expect(test.CleanupAndWait(ctx, cl, baseObj)).To(Succeed())
 				})
 
-				// Wait for object to be created
-				Eventually(kWithCtx(ctx).Get(baseObj)).WithContext(ctx).Should(Succeed())
-
-				// Now try to update status with invalid nested structure
-				statusUpdate := baseObj.DeepCopy()
-				statusUpdate.Object["status"] = map[string]interface{}{
+				expectStatusUpdateMatchErrorEventually(ctx, baseObj, map[string]interface{}{
 					"phase": "Ready",
 					"conditions": []interface{}{
 						map[string]interface{}{
@@ -566,10 +548,7 @@ var _ = Describe("End-to-End Admission Webhook Integration", Ordered, ContinueOn
 							// Missing required "status" field in condition
 						},
 					},
-				}
-
-				err := cl.Status().Update(ctx, statusUpdate)
-				Expect(err).To(MatchError(ContainSubstring("\"test-object\" is invalid: status.conditions[0].status: Required value")))
+				}, "\"test-object\" is invalid: status.conditions[0].status: Required value")
 			}, defaultNodeTimeout)
 
 			It("should reject status updates with negative readyReplicas when status validation is enabled", func(ctx context.Context) {
@@ -592,18 +571,10 @@ var _ = Describe("End-to-End Admission Webhook Integration", Ordered, ContinueOn
 					Expect(test.CleanupAndWait(ctx, cl, baseObj)).To(Succeed())
 				})
 
-				// Wait for object to be created
-				Eventually(kWithCtx(ctx).Get(baseObj)).WithContext(ctx).Should(Succeed())
-
-				// Now try to update status with negative readyReplicas
-				statusUpdate := baseObj.DeepCopy()
-				statusUpdate.Object["status"] = map[string]interface{}{
+				expectStatusUpdateMatchErrorEventually(ctx, baseObj, map[string]interface{}{
 					"phase":         "Ready",
 					"readyReplicas": int64(-1), // Below minimum value
-				}
-
-				err := cl.Status().Update(ctx, statusUpdate)
-				Expect(err).To(MatchError(ContainSubstring("\"test-object\" is invalid: status.readyReplicas: Invalid value: -1: status.readyReplicas in body should be greater than or equal to 0")))
+				}, "\"test-object\" is invalid: status.readyReplicas: Invalid value: -1: status.readyReplicas in body should be greater than or equal to 0")
 			}, defaultNodeTimeout)
 		})
 	})
@@ -648,6 +619,7 @@ var _ = Describe("End-to-End Admission Webhook Integration", Ordered, ContinueOn
 				scaleWebhookConfig := createValidatingWebhookConfig(scaleCompatibilityRequirement, compatibilityCRD)
 				scaleWebhookConfig.Name = fmt.Sprintf("test-scale-validation-%s", scaleCompatibilityRequirement.Name)
 				Expect(cl.Create(ctx, scaleWebhookConfig)).To(Succeed())
+				waitForCompatibilityRequirementInWebhookManagerCache(ctx, scaleCompatibilityRequirement)
 
 				DeferCleanup(func(ctx context.Context) {
 					Expect(test.CleanupAndWait(ctx, cl, scaleWebhookConfig, scaleCompatibilityRequirement)).To(Succeed())
@@ -718,8 +690,7 @@ var _ = Describe("End-to-End Admission Webhook Integration", Ordered, ContinueOn
 					}).
 					Build()
 
-				err := cl.Create(ctx, objWithTooManyReplicas)
-				Expect(err).To(MatchError(ContainSubstring("\"test-object\" is invalid: spec.replicas: Invalid value: 150: spec.replicas in body should be less than or equal to 100")))
+				expectInvalidCreateEventually(ctx, cl, objWithTooManyReplicas, "\"test-object\" is invalid: spec.replicas: Invalid value: 150: spec.replicas in body should be less than or equal to 100")
 			}, defaultNodeTimeout)
 
 			It("should reject objects with negative replica count when scale validation is enabled", func(ctx context.Context) {
@@ -743,8 +714,7 @@ var _ = Describe("End-to-End Admission Webhook Integration", Ordered, ContinueOn
 					}).
 					Build()
 
-				err := cl.Create(ctx, objWithNegativeReplicas)
-				Expect(err).To(MatchError(ContainSubstring("\"test-object\" is invalid: [spec.replicas: Invalid value: -1: spec.replicas in body should be greater than or equal to 0, .spec.replicas: Invalid value: -1: should be a non-negative integer]")))
+				expectInvalidCreateEventually(ctx, cl, objWithNegativeReplicas, "\"test-object\" is invalid: [spec.replicas: Invalid value: -1: spec.replicas in body should be greater than or equal to 0, .spec.replicas: Invalid value: -1: should be a non-negative integer]")
 			}, defaultNodeTimeout)
 
 			It("should reject status updates with negative readyReplicas when scale validation is enabled", func(ctx context.Context) {
@@ -775,17 +745,9 @@ var _ = Describe("End-to-End Admission Webhook Integration", Ordered, ContinueOn
 					Expect(test.CleanupAndWait(ctx, cl, baseObj)).To(Succeed())
 				})
 
-				// Wait for object to be created
-				Eventually(kWithCtx(ctx).Get(baseObj)).WithContext(ctx).Should(Succeed())
-
-				// Now try to update status with negative readyReplicas
-				statusUpdate := baseObj.DeepCopy()
-				statusUpdate.Object["status"] = map[string]interface{}{
+				expectStatusUpdateMatchErrorEventually(ctx, baseObj, map[string]interface{}{
 					"readyReplicas": int64(-1), // Below minimum of 0
-				}
-
-				err := cl.Status().Update(ctx, statusUpdate)
-				Expect(err).To(MatchError(ContainSubstring("\"test-object\" is invalid: [status.readyReplicas: Invalid value: -1: status.readyReplicas in body should be greater than or equal to 0, .status.readyReplicas: Invalid value: -1: should be a non-negative integer]")))
+				}, "\"test-object\" is invalid: [status.readyReplicas: Invalid value: -1: status.readyReplicas in body should be greater than or equal to 0, .status.readyReplicas: Invalid value: -1: should be a non-negative integer]")
 			}, defaultNodeTimeout)
 		})
 	})
@@ -822,6 +784,7 @@ var _ = Describe("End-to-End Admission Webhook Integration", Ordered, ContinueOn
 				warningWebhookConfig := createValidatingWebhookConfig(warningCompatibilityRequirement, compatibilityCRD)
 				warningWebhookConfig.Name = fmt.Sprintf("test-warning-validation-%s", warningCompatibilityRequirement.Name)
 				Expect(warningClient.Create(ctx, warningWebhookConfig)).To(Succeed())
+				waitForCompatibilityRequirementInWebhookManagerCache(ctx, warningCompatibilityRequirement)
 
 				DeferCleanup(func(ctx context.Context) {
 					Expect(test.CleanupAndWait(ctx, warningClient, warningWebhookConfig, warningCompatibilityRequirement)).To(Succeed())
@@ -928,6 +891,7 @@ var _ = Describe("End-to-End Admission Webhook Integration", Ordered, ContinueOn
 				warningStatusWebhookConfig := createValidatingWebhookConfig(warningStatusCompatibilityRequirement, compatibilityCRD)
 				warningStatusWebhookConfig.Name = fmt.Sprintf("test-warning-status-validation-%s", warningStatusCompatibilityRequirement.Name)
 				Expect(warningClient.Create(ctx, warningStatusWebhookConfig)).To(Succeed())
+				waitForCompatibilityRequirementInWebhookManagerCache(ctx, warningStatusCompatibilityRequirement)
 
 				DeferCleanup(func(ctx context.Context) {
 					Expect(test.CleanupAndWait(ctx, warningClient, warningStatusWebhookConfig, warningStatusCompatibilityRequirement)).To(Succeed())
@@ -1094,6 +1058,7 @@ var _ = Describe("End-to-End Admission Webhook Integration", Ordered, ContinueOn
 				warningScaleWebhookConfig := createValidatingWebhookConfig(warningScaleCompatibilityRequirement, compatibilityCRD)
 				warningScaleWebhookConfig.Name = fmt.Sprintf("test-warning-scale-validation-%s", warningScaleCompatibilityRequirement.Name)
 				Expect(warningClient.Create(ctx, warningScaleWebhookConfig)).To(Succeed())
+				waitForCompatibilityRequirementInWebhookManagerCache(ctx, warningScaleCompatibilityRequirement)
 
 				DeferCleanup(func(ctx context.Context) {
 					Expect(test.CleanupAndWait(ctx, cl, warningScaleWebhookConfig, warningScaleCompatibilityRequirement)).To(Succeed())
@@ -1221,6 +1186,39 @@ var _ = Describe("End-to-End Admission Webhook Integration", Ordered, ContinueOn
 		})
 	})
 })
+
+// expectInvalidCreateEventually is like expectCreateMatchErrorEventually but requires apierrors.IsInvalid.
+func expectInvalidCreateEventually(ctx context.Context, c client.Client, obj *unstructured.Unstructured, substr string) {
+	GinkgoHelper()
+
+	Eventually(func(g Gomega) error {
+		g.Expect(client.IgnoreNotFound(c.Delete(ctx, obj))).To(Succeed())
+
+		err := c.Create(ctx, obj)
+		if err == nil {
+			g.Expect(c.Delete(ctx, obj)).To(Succeed())
+		}
+
+		return err
+	}).WithContext(ctx).WithTimeout(defaultEventuallyTimeout).
+		Should(SatisfyAll(
+			MatchError(apierrors.IsInvalid, "IsInvalid"),
+			MatchError(ContainSubstring(substr)),
+		))
+}
+
+// expectStatusUpdateMatchErrorEventually retries status updates until the apiserver returns an error whose message contains substr.
+func expectStatusUpdateMatchErrorEventually(ctx context.Context, baseObj *unstructured.Unstructured, status map[string]interface{}, substr string) {
+	GinkgoHelper()
+	Eventually(func(g Gomega) {
+		g.Expect(cl.Get(ctx, client.ObjectKeyFromObject(baseObj), baseObj)).To(Succeed())
+		statusUpdate := baseObj.DeepCopy()
+		statusUpdate.Object["status"] = status
+		err := cl.Status().Update(ctx, statusUpdate)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err).To(MatchError(ContainSubstring(substr)))
+	}).WithContext(ctx).WithTimeout(defaultEventuallyTimeout).Should(Succeed())
+}
 
 func TestCompatibilityRequirementContext(t *testing.T) {
 	ctx := t.Context()

--- a/pkg/controllers/crdcompatibility/objectvalidation/suite_test.go
+++ b/pkg/controllers/crdcompatibility/objectvalidation/suite_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	apiextensionsv1alpha1 "github.com/openshift/api/apiextensions/v1alpha1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -43,19 +44,24 @@ var (
 	testEnv               *envtest.Environment
 	cfg                   *rest.Config
 	cl                    client.Client
+	managerClient         client.Reader
 	suiteCompatibilityCRD func() *apiextensionsv1.CustomResourceDefinition
 )
 
-var defaultNodeTimeout = NodeTimeout(10 * time.Second)
+var (
+	defaultNodeTimeout       = NodeTimeout(10 * time.Second)
+	defaultEventuallyTimeout = 2 * time.Second
+)
 
 // InitValidator initializes an object validator for testing.
-// It returns the validator and a function to start the webhook server.
+// It returns the validator, the manager client (informer-backed, used by the webhook handler),
+// and a function to start the webhook server.
 //
 // startWebhookServer blocks until the server has started and is ready to be used,
 // which must happen before the context passed to InitValidator is cancelled. It
 // uses DeferCleanup to ensure that the webhook server will be stopped at the
 // appropriate time.
-var InitValidator func(context.Context) (*validator, func())
+var InitValidator func(context.Context) (*validator, client.Reader, func())
 
 func TestObjectValidation(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -86,14 +92,14 @@ var _ = BeforeSuite(func(ctx context.Context) {
 	// Set up komega with the client
 	komega.SetClient(cl)
 
-	InitValidator = func(ctx context.Context) (*validator, func()) {
+	InitValidator = func(ctx context.Context) (*validator, client.Reader, func()) {
 		return initValidator(ctx, cfg, cl.Scheme(), testEnv)
 	}
 
 	suiteCompatibilityCRD = createSuiteCRDs(ctx)
 }, NodeTimeout(30*time.Second))
 
-func initValidator(ctx context.Context, cfg *rest.Config, scheme *runtime.Scheme, testEnv *envtest.Environment) (*validator, func()) {
+func initValidator(ctx context.Context, cfg *rest.Config, scheme *runtime.Scheme, testEnv *envtest.Environment) (*validator, client.Reader, func()) {
 	By("Setting up an object validator with webhook server")
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
@@ -111,9 +117,19 @@ func initValidator(ctx context.Context, cfg *rest.Config, scheme *runtime.Scheme
 	err = objectValidator.SetupWithManager(ctx, mgr)
 	Expect(err).ToNot(HaveOccurred(), "Object Validator should be setup with manager")
 
-	return objectValidator, func() {
+	return objectValidator, mgr.GetClient(), func() {
 		startWebhookServer(ctx, mgr)
 	}
+}
+
+// waitForCompatibilityRequirementInWebhookManagerCache waits until the validating webhook's
+// manager client can read the CompatibilityRequirement from its informer cache. Admission uses mgr.GetClient().
+func waitForCompatibilityRequirementInWebhookManagerCache(ctx context.Context, cr *apiextensionsv1alpha1.CompatibilityRequirement) {
+	GinkgoHelper()
+	Eventually(func(g Gomega) {
+		cached := &apiextensionsv1alpha1.CompatibilityRequirement{}
+		g.Expect(managerClient.Get(ctx, client.ObjectKeyFromObject(cr), cached)).To(Succeed())
+	}).WithContext(ctx).WithTimeout(10 * time.Second).Should(Succeed())
 }
 
 // startWebhookServer starts the webhook server and waits for it to be ready.


### PR DESCRIPTION
The objectpruning and objectvalidation tests both suffer from a race
where we make an API change then immediately assert the resulting
behaviour of the webhook. This change addresses this by both waiting for
the manager's informer cache to have observed the change, and allowing
for retries of the test behaviour.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced validation and pruning suites with robust retry loops to handle timing-sensitive operations and transient failures.
  * Added synchronization steps to ensure the webhook manager cache reflects new rules before assertions run.
  * Introduced retry-based helper routines to replace fragile immediate assertions for create/update flows.
  * Added a short "eventual" timeout and consolidated timeout configuration for clearer timing control.
  * Exposed a test client to support reliable cache polling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->