### PR TITLE
NO-JIRA: Add Dockerfile.e2e

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,0 +1,18 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
+WORKDIR /go/src/github.com/openshift/cluster-capi-operator
+COPY . .
+RUN go build -mod=vendor -o bin/ginkgo ./vendor/github.com/onsi/ginkgo/v2/ginkgo && \
+    go test -mod=vendor -c -race -o bin/e2e.test ./e2e
+
+FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+COPY --from=builder /go/src/github.com/openshift/cluster-capi-operator/bin/ginkgo /usr/bin/ginkgo
+COPY --from=builder /go/src/github.com/openshift/cluster-capi-operator/bin/e2e.test /usr/bin/e2e.test
+COPY hack/test.sh /test.sh
+RUN chmod 0755 /test.sh /usr/bin/ginkgo /usr/bin/e2e.test
+
+ENV GINKGO=/usr/bin/ginkgo
+ENV TEST_DIRS=/usr/bin/e2e.test
+ENV TIMEOUT=120m
+
+USER 65532
+ENTRYPOINT ["/test.sh"]

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -12,8 +12,8 @@ fi
 
 # Use existing value of TEST_DIRS, or $1 if not set. Makes it easier to target suites.
 TEST_DIRS=${TEST_DIRS:-$1}
-# Use 2nd arg, or 5m.
-TIMEOUT=${2:-"5m"}
+# Use existing value of $2, otherwise TIMEOUT env, otherwise 5m.
+TIMEOUT=${2:-${TIMEOUT:-"5m"}}
 
 OPENSHIFT_CI=${OPENSHIFT_CI:-""}
 ARTIFACT_DIR=${ARTIFACT_DIR:-""}


### PR DESCRIPTION
Adds an image for running e2e tests in other repos.

See also https://github.com/openshift/release/pull/78127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a containerized end-to-end test runtime so E2E tests can be built and executed within a self-contained image, with a scripted entrypoint and non-root runtime.
  * Improved test timeout handling: the timeout now respects an existing environment variable, falls back to a supplied argument, and finally to the default when neither is set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->