### PR TITLE
OCPBUGS-84340: Fix e2e flake when workers are in us-west-2b

### DIFF
--- a/e2e/machine_migration_vap_tests.go
+++ b/e2e/machine_migration_vap_tests.go
@@ -39,7 +39,6 @@ const (
 	testLabelValue            = "test-label-value"
 	testInstanceType          = "m5.xlarge"
 	testAMIID                 = "ami-test123456"
-	testAvailabilityZone      = "us-west-2b"
 	testSubnetID              = "subnet-test123456"
 	testSecurityGroupID       = "sg-test123456"
 	testCapacityReservationID = "cr-test123456"
@@ -184,7 +183,7 @@ var _ = Describe("[sig-cluster-lifecycle][OCPFeatureGate:MachineAPIMigration] MA
 
 			It("should prevent updating providerSpec.availabilityZone", func() {
 				verifyAWSProviderSpecUpdatePrevented(testMAPIMachine, "availabilityZone", func(providerSpec *mapiv1beta1.AWSMachineProviderConfig) {
-					providerSpec.Placement.AvailabilityZone = testAvailabilityZone
+					providerSpec.Placement.AvailabilityZone = providerSpec.Placement.AvailabilityZone + "-changed"
 				}, vapSpecLockedMessage)
 			})
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated AWS availability zone enforcement test validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->