### PR TITLE
NO-JIRA: fix: re-enable setting/diffing httpProtocolIpv6, CAPA now supports it

### DIFF
--- a/pkg/controllers/machinesetsync/machineset_sync_controller.go
+++ b/pkg/controllers/machinesetsync/machineset_sync_controller.go
@@ -1332,8 +1332,6 @@ func compareCAPIInfraMachineTemplates(platform configv1.PlatformType, infraMachi
 
 	switch platform {
 	case configv1.AWSPlatformType:
-		// TODO(OCPCLOUD-2710): httpProtocolIpv6 is not yet supported by MAPI, ignore it until the CAPA CRD includes the field.
-		diffOpts = append(diffOpts, util.WithIgnoreField("spec", "template", "spec", "instanceMetadataOptions", "httpProtocolIpv6"))
 	case configv1.OpenStackPlatformType:
 	case configv1.PowerVSPlatformType:
 	default:

--- a/pkg/controllers/machinesync/machine_sync_mapi2capi_infrastructure.go
+++ b/pkg/controllers/machinesync/machine_sync_mapi2capi_infrastructure.go
@@ -253,8 +253,6 @@ func compareCAPIInfraMachines(platform configv1.PlatformType, infraMachine1, inf
 	// Make per provider adjustments to the differ.
 	switch platform {
 	case configv1.AWSPlatformType:
-		// TODO(OCPCLOUD-2710): httpProtocolIpv6 is not yet supported by MAPI, ignore it until the CAPA CRD includes the field.
-		diffOpts = append(diffOpts, util.WithIgnoreField("spec", "instanceMetadataOptions", "httpProtocolIpv6"))
 	case configv1.OpenStackPlatformType:
 	case configv1.PowerVSPlatformType:
 	default:

--- a/pkg/conversion/capi2mapi/aws_fuzz_test.go
+++ b/pkg/conversion/capi2mapi/aws_fuzz_test.go
@@ -126,7 +126,7 @@ func awsMachineFuzzerFuncs(codecs runtimeserializer.CodecFactory) []interface{} 
 
 			// TODO(OCPCLOUD-2710): Fields not yet supported by MAPI.
 			imdo.HTTPEndpoint = awsv1.InstanceMetadataEndpointStateEnabled
-			imdo.HTTPProtocolIPv6 = ""
+			imdo.HTTPProtocolIPv6 = awsv1.InstanceMetadataEndpointStateDisabled
 			imdo.HTTPPutResponseHopLimit = 0
 			imdo.InstanceMetadataTags = awsv1.InstanceMetadataEndpointStateDisabled
 		},

--- a/pkg/conversion/mapi2capi/aws.go
+++ b/pkg/conversion/mapi2capi/aws.go
@@ -625,6 +625,7 @@ func convertMetadataServiceOptionstoCAPI(fldPath *field.Path, metad mapiv1beta1.
 
 	capiMetadataOpts := &awsv1.InstanceMetadataOptions{
 		HTTPEndpoint:            awsv1.InstanceMetadataEndpointStateEnabled,  // not present in MAPI, fallback to CAPI default.
+		HTTPProtocolIPv6:        awsv1.InstanceMetadataEndpointStateDisabled, // not present in MAPI, fallback to CAPI default.
 		InstanceMetadataTags:    awsv1.InstanceMetadataEndpointStateDisabled, // not present in MAPI, fallback to CAPI default.
 		HTTPTokens:              httpTokens,
 		HTTPPutResponseHopLimit: 1, // TODO(docs): CAPA defaults to 1 (in the openAPI spec validation) if the field is empty, lossy translation to document.


### PR DESCRIPTION
Now that CAPA supports httpProtocolIpv6 we can revert the previous ignoring of the diffing for httpProtocolIpv6.

This reverts commit e282926f2ae2427598917a44f1c2398770ef8259.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected instance metadata option handling for IPv6 HTTP protocol endpoints. The system now properly tracks and detects changes to IPv6 metadata settings, ensuring machines are accurately updated when these configurations differ.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->