### PR TITLE
NO-JIRA: manifests-gen: scope provider webhooks to capi namespace

### DIFF
--- a/manifests-gen/kustomization.yaml
+++ b/manifests-gen/kustomization.yaml
@@ -3,6 +3,31 @@ kind: Component
 
 namespace: openshift-cluster-api
 
+resources:
+  - webhook-namespace-selector.yaml
+
+# Scope all provider webhooks to the openshift-cluster-api namespace.
+# This prevents webhooks from intercepting requests in other namespaces,
+# which would fail on unsupported platforms where the webhook server is not running.
+replacements:
+  - source:
+      kind: ConfigMap
+      name: webhook-namespace-selector
+      fieldPath: data.namespace
+    targets:
+      - select:
+          kind: ValidatingWebhookConfiguration
+        fieldPaths:
+          - webhooks.*.namespaceSelector.matchLabels.kubernetes\.io/metadata\.name
+        options:
+          create: true
+      - select:
+          kind: MutatingWebhookConfiguration
+        fieldPaths:
+          - webhooks.*.namespaceSelector.matchLabels.kubernetes\.io/metadata\.name
+        options:
+          create: true
+
 patches:
 
 # Retain Secrets internally for reference tracking, but don't emit them
@@ -14,6 +39,7 @@ patches:
     metadata:
       name: __ignored__
       annotations:
+        # Marks this resource as local-only so kustomize excludes it from the final output.
         config.kubernetes.io/local-config: "true"
 
 # Set OpenShift pod annotations on all Deployments' pod templates.

--- a/manifests-gen/webhook-namespace-selector.yaml
+++ b/manifests-gen/webhook-namespace-selector.yaml
@@ -1,0 +1,14 @@
+# This ConfigMap is a kustomize workaround: replacements need a concrete source resource
+# to read a value from, but there is no real resource that holds the target namespace.
+# This ConfigMap acts as that source, providing the namespace value to inject into webhook
+# namespaceSelector fields via the replacements defined in kustomization.yaml.
+# It is marked as local-config so kustomize never emits it in the final output.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: webhook-namespace-selector
+  annotations:
+    # Marks this resource as local-only so kustomize excludes it from the final output.
+    config.kubernetes.io/local-config: "true"
+data:
+  namespace: openshift-cluster-api


### PR DESCRIPTION
Add a kustomize replacement that injects namespaceSelector on all ValidatingWebhookConfiguration and MutatingWebhookConfiguration entries, restricting them to the openshift-cluster-api namespace.

This applies to all CAPI providers that consume the manifests-gen kustomize component, preventing their webhooks from intercepting requests in other namespaces where the webhook server may not be running (e.g. on unsupported platforms).

A dummy ConfigMap is used as the value source for the kustomize replacement because kustomize replacements require a concrete resource to source field values from. The ConfigMap is annotated with config.kubernetes.io/local-config: "true" so it is not emitted in the final output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a local configuration source to define a default namespace selector for webhooks.
  * Updated manifest generation to inject namespaceSelector values into validating and mutating webhook configurations so policies can target specific namespaces.
  * Marked a retained secret as local-only so it’s excluded from final output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->