### PR TITLE
OCPBUGS-84673: fix: remove retired Microsoft.ClassicStorage permission

### DIFF
--- a/manifests/0000_30_cluster-api_01_credentials-request.yaml
+++ b/manifests/0000_30_cluster-api_01_credentials-request.yaml
@@ -143,8 +143,6 @@ spec:
     - Microsoft.Resources/subscriptions/resourceGroups/delete
     - Microsoft.Resources/subscriptions/resourceGroups/read
     - Microsoft.Resources/subscriptions/resourceGroups/write
-    - Microsoft.ClassicStorage/storageAccounts/vmImages/read
-    - Microsoft.ClassicStorage/storageAccounts/vmImages/write
 ---
 apiVersion: cloudcredential.openshift.io/v1
 kind: CredentialsRequest


### PR DESCRIPTION
It appears Azure is rejecting the request with `InvalidActionOrNotAction` because `Microsoft.ClassicStorage` is a deprecated/retired Azure resource provider and no longer accepts new role definitions.

This is being seen here:
Jenkins link:- https://jenkins-csb-openshift-qe-mastern.dno.corp.redhat.com/job/ocp-common/job/Flexy-install/374113/

Azure classic storage accounts (Microsoft.ClassicStorage) were fully retired on August 31, 2024. https://learn.microsoft.com/en-us/azure/storage/common/classic-account-migration-overview

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed deprecated storage permissions from Azure cluster API credentials configuration, reducing the scope of granted permissions for improved security posture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->