### PR TITLE
OCPCLOUD-2664: Update operatorstatus to write correct sub-Conditions

### DIFF
--- a/pkg/controllers/installer/helpers_test.go
+++ b/pkg/controllers/installer/helpers_test.go
@@ -40,7 +40,7 @@ import (
 
 const (
 	conditionTypeProgressing = "InstallerControllerProgressing"
-	conditionTypeDegraded    = "InstallerControllerDegraded"
+	conditionTypeAvailable   = "InstallerControllerAvailable"
 )
 
 // Provider profile names used across tests.

--- a/pkg/controllers/installer/installer_controller_test.go
+++ b/pkg/controllers/installer/installer_controller_test.go
@@ -239,8 +239,8 @@ var _ = Describe("InstallerController", Serial, func() {
 				test.HaveCondition(conditionTypeProgressing).
 					WithStatus(configv1.ConditionFalse).
 					WithReason(operatorstatus.ReasonNonRetryableError),
-				test.HaveCondition(conditionTypeDegraded).
-					WithStatus(configv1.ConditionTrue).
+				test.HaveCondition(conditionTypeAvailable).
+					WithStatus(configv1.ConditionFalse).
 					WithReason(operatorstatus.ReasonNonRetryableError),
 			)
 		}, defaultNodeTimeout)
@@ -256,8 +256,8 @@ var _ = Describe("InstallerController", Serial, func() {
 					WithStatus(configv1.ConditionFalse).
 					WithReason(operatorstatus.ReasonNonRetryableError).
 					WithMessage(ContainSubstring("duplicate object found in phases")),
-				test.HaveCondition(conditionTypeDegraded).
-					WithStatus(configv1.ConditionTrue),
+				test.HaveCondition(conditionTypeAvailable).
+					WithStatus(configv1.ConditionFalse),
 			))
 		}, defaultNodeTimeout)
 
@@ -318,8 +318,8 @@ var _ = Describe("InstallerController", Serial, func() {
 				test.HaveCondition(conditionTypeProgressing).
 					WithStatus(configv1.ConditionFalse).
 					WithReason(operatorstatus.ReasonNonRetryableError),
-				test.HaveCondition(conditionTypeDegraded).
-					WithStatus(configv1.ConditionTrue).
+				test.HaveCondition(conditionTypeAvailable).
+					WithStatus(configv1.ConditionFalse).
 					WithReason(operatorstatus.ReasonNonRetryableError).
 					WithMessage(ContainSubstring("invalid")),
 			)
@@ -345,8 +345,8 @@ var _ = Describe("InstallerController", Serial, func() {
 				test.HaveCondition(conditionTypeProgressing).
 					WithStatus(configv1.ConditionFalse).
 					WithReason(operatorstatus.ReasonNonRetryableError),
-				test.HaveCondition(conditionTypeDegraded).
-					WithStatus(configv1.ConditionTrue).
+				test.HaveCondition(conditionTypeAvailable).
+					WithStatus(configv1.ConditionFalse).
 					WithReason(operatorstatus.ReasonNonRetryableError).
 					WithMessage(ContainSubstring("collision")),
 			)
@@ -383,13 +383,13 @@ var _ = Describe("InstallerController", Serial, func() {
 			Expect(cl.Status().Update(ctx, clusterAPI)).To(Succeed())
 
 			// The head revision is invalid so isComplete=false with a terminal error.
-			// The controller reports NonRetryableError: Progressing=False, Degraded=True.
+			// The controller reports NonRetryableError: Progressing=False, Available=False.
 			waitForConditions(ctx,
 				test.HaveCondition(conditionTypeProgressing).
 					WithStatus(configv1.ConditionFalse).
 					WithReason(operatorstatus.ReasonNonRetryableError),
-				test.HaveCondition(conditionTypeDegraded).
-					WithStatus(configv1.ConditionTrue).
+				test.HaveCondition(conditionTypeAvailable).
+					WithStatus(configv1.ConditionFalse).
 					WithReason(operatorstatus.ReasonNonRetryableError),
 			)
 

--- a/pkg/controllers/revision/revision_controller_test.go
+++ b/pkg/controllers/revision/revision_controller_test.go
@@ -51,7 +51,7 @@ var (
 
 const (
 	conditionTypeProgressing = "RevisionControllerProgressing"
-	conditionTypeDegraded    = "RevisionControllerDegraded"
+	conditionTypeAvailable   = "RevisionControllerAvailable"
 
 	subResourceStatus = "status"
 )
@@ -166,8 +166,8 @@ var _ = Describe("RevisionController", Serial, func() {
 		Expect(co.Status.Conditions).To(test.HaveCondition(conditionTypeProgressing).
 			WithStatus(configv1.ConditionFalse).
 			WithReason(operatorstatus.ReasonAsExpected))
-		Expect(co.Status.Conditions).To(test.HaveCondition(conditionTypeDegraded).
-			WithStatus(configv1.ConditionFalse).
+		Expect(co.Status.Conditions).To(test.HaveCondition(conditionTypeAvailable).
+			WithStatus(configv1.ConditionTrue).
 			WithReason(operatorstatus.ReasonAsExpected))
 	}, defaultNodeTimeout)
 
@@ -194,8 +194,8 @@ var _ = Describe("RevisionController", Serial, func() {
 			test.HaveCondition(conditionTypeProgressing).
 				WithStatus(configv1.ConditionFalse).
 				WithReason(operatorstatus.ReasonAsExpected),
-			test.HaveCondition(conditionTypeDegraded).
-				WithStatus(configv1.ConditionFalse).
+			test.HaveCondition(conditionTypeAvailable).
+				WithStatus(configv1.ConditionTrue).
 				WithReason(operatorstatus.ReasonAsExpected),
 		)
 
@@ -329,7 +329,7 @@ var _ = Describe("RevisionController", Serial, func() {
 		Expect(clusterAPI.Status.ObservedRevisionGeneration).To(Equal(clusterAPI.Generation))
 	}, defaultNodeTimeout)
 
-	It("sets Degraded=True with NonRetryableError when max revisions reached", func(ctx context.Context) {
+	It("sets Available=False with NonRetryableError when max revisions reached", func(ctx context.Context) {
 		// Refresh the clusterAPI object before updating the revisions
 		Expect(kWithCtx(ctx).Get(clusterAPI)()).To(Succeed())
 
@@ -368,8 +368,8 @@ var _ = Describe("RevisionController", Serial, func() {
 			test.HaveCondition(conditionTypeProgressing).
 				WithStatus(configv1.ConditionFalse).
 				WithReason(operatorstatus.ReasonNonRetryableError),
-			test.HaveCondition(conditionTypeDegraded).
-				WithStatus(configv1.ConditionTrue).
+			test.HaveCondition(conditionTypeAvailable).
+				WithStatus(configv1.ConditionFalse).
 				WithReason(operatorstatus.ReasonNonRetryableError),
 		)
 
@@ -379,7 +379,7 @@ var _ = Describe("RevisionController", Serial, func() {
 		Expect(updatedClusterAPI.Status.Revisions).To(HaveLen(16))
 	}, defaultNodeTimeout)
 
-	It("sets Degraded=True with NonRetryableError when manifest has invalid adopt-existing annotation", func(ctx context.Context) {
+	It("sets Available=False with NonRetryableError when manifest has invalid adopt-existing annotation", func(ctx context.Context) {
 		// Stop first manager (created by BeforeEach with valid providers)
 		mgr.stop()
 
@@ -390,8 +390,8 @@ var _ = Describe("RevisionController", Serial, func() {
 			test.HaveCondition(conditionTypeProgressing).
 				WithStatus(configv1.ConditionFalse).
 				WithReason(operatorstatus.ReasonNonRetryableError),
-			test.HaveCondition(conditionTypeDegraded).
-				WithStatus(configv1.ConditionTrue).
+			test.HaveCondition(conditionTypeAvailable).
+				WithStatus(configv1.ConditionFalse).
 				WithReason(operatorstatus.ReasonNonRetryableError).
 				WithMessage(ContainSubstring("invalid")),
 		)
@@ -573,8 +573,5 @@ var _ = Describe("RevisionController error handling", Serial, func() {
 			WithStatus(configv1.ConditionTrue).
 			WithReason(operatorstatus.ReasonEphemeralError).
 			WithMessage(ContainSubstring(testErr.Error())))
-		Expect(co.Status.Conditions).To(test.HaveCondition(conditionTypeDegraded).
-			WithStatus(configv1.ConditionFalse).
-			WithReason(operatorstatus.ReasonProgressing))
 	}, defaultNodeTimeout)
 })

--- a/pkg/operatorstatus/controller_status.go
+++ b/pkg/operatorstatus/controller_status.go
@@ -59,6 +59,14 @@ const (
 
 	// ReasonNonRetryableError indicates that the controller encountered a non-retryable error.
 	ReasonNonRetryableError = "NonRetryableError"
+
+	// ConditionAvailableSuffix is the suffix added to a controller prefix to
+	// form the controller's available condition type.
+	ConditionAvailableSuffix = "Available"
+
+	// ConditionProgressingSuffix is the suffix added to a controller prefix to
+	// form the controller's progressing condition type.
+	ConditionProgressingSuffix = "Progressing"
 )
 
 // CAPIFieldOwner returns a qualifiedclient.FieldOwner for the given qualifier.
@@ -68,16 +76,46 @@ func CAPIFieldOwner[S ~string](qualifier S) client.FieldOwner {
 	return client.FieldOwner(CAPIOperatorIdentifierDomain + "/" + qualifier)
 }
 
+type partialCondition struct {
+	status  configv1.ConditionStatus
+	reason  string
+	message string
+}
+
 // ReconcileResult represents the result of a controller's reconciliation.
 // As well as returning a reconcile.Result to controller-runtime, it can also
 // write the result as conditions on the ClusterOperator.
 type ReconcileResult struct {
 	ControllerResultGenerator
 
-	progressing  *configv1apply.ClusterOperatorStatusConditionApplyConfiguration
-	degraded     *configv1apply.ClusterOperatorStatusConditionApplyConfiguration
+	// a ReconcileResult must always have an explicit progressing condition
+	progressing partialCondition
+
+	// the available condition is optional, and will be maintained from the
+	// current state if not set explicitly
+	available *partialCondition
+
 	err          error
 	requeueAfter time.Duration
+}
+
+// Internal constructors for ReconcileResult. Callers do not set these properties directly.
+
+func newReconcileResult(controllerResultGenerator ControllerResultGenerator, progressingStatus configv1.ConditionStatus, reason, message string) ReconcileResult {
+	return ReconcileResult{
+		ControllerResultGenerator: controllerResultGenerator,
+		progressing:               partialCondition{progressingStatus, reason, message},
+	}
+}
+
+func (r ReconcileResult) withAvailable(status configv1.ConditionStatus, reason, message string) ReconcileResult {
+	r.available = &partialCondition{status, reason, message}
+	return r
+}
+
+func (r ReconcileResult) withError(err error) ReconcileResult {
+	r.err = err
+	return r
 }
 
 // Result returns a reconcile.Result for controller-runtime.
@@ -107,12 +145,8 @@ type ControllerResultGenerator string
 // Success returns a ReconcileResult indicating that the controller has succeeded.
 // Returning this result will not requeue the controller.
 func (c ControllerResultGenerator) Success() ReconcileResult {
-	return ReconcileResult{
-		ControllerResultGenerator: c,
-		progressing:               c.progressingCondition(configv1.ConditionFalse, ReasonAsExpected, "Success"),
-		degraded:                  c.degradedCondition(configv1.ConditionFalse, ReasonAsExpected, "Success"),
-		err:                       nil,
-	}
+	return newReconcileResult(c, configv1.ConditionFalse, ReasonAsExpected, "Success").
+		withAvailable(configv1.ConditionTrue, ReasonAsExpected, "Success")
 }
 
 // SuccessP is a convenience wrapper around Success that returns a pointer to the ReconcileResult.
@@ -125,12 +159,7 @@ func (c ControllerResultGenerator) SuccessP() *ReconcileResult {
 // immediately, for example after writing status to a watched resource.
 // Returning this result will not requeue the controller directly.
 func (c ControllerResultGenerator) Progressing(message string) ReconcileResult {
-	return ReconcileResult{
-		ControllerResultGenerator: c,
-		progressing:               c.progressingCondition(configv1.ConditionTrue, ReasonProgressing, message),
-		degraded:                  c.degradedCondition(configv1.ConditionFalse, ReasonProgressing, message),
-		err:                       nil,
-	}
+	return newReconcileResult(c, configv1.ConditionTrue, ReasonProgressing, message)
 }
 
 // ProgressingP is a convenience wrapper around Progressing that returns a pointer to the ReconcileResult.
@@ -145,12 +174,7 @@ func (c ControllerResultGenerator) ProgressingP(message string) *ReconcileResult
 func (c ControllerResultGenerator) WaitingOnExternal(waitDescription string) ReconcileResult {
 	message := fmt.Sprintf("Waiting on %s", waitDescription)
 
-	return ReconcileResult{
-		ControllerResultGenerator: c,
-		progressing:               c.progressingCondition(configv1.ConditionTrue, ReasonWaitingOnExternal, message),
-		degraded:                  c.degradedCondition(configv1.ConditionFalse, ReasonWaitingOnExternal, message),
-		err:                       nil,
-	}
+	return newReconcileResult(c, configv1.ConditionTrue, ReasonWaitingOnExternal, message)
 }
 
 // WaitingOnExternalP is a convenience wrapper around WaitingOnExternal that returns a pointer to the ReconcileResult.
@@ -166,12 +190,8 @@ func (c ControllerResultGenerator) Error(err error) ReconcileResult {
 		return c.nonRetryableError(err)
 	}
 
-	return ReconcileResult{
-		ControllerResultGenerator: c,
-		progressing:               c.progressingCondition(configv1.ConditionTrue, ReasonEphemeralError, err.Error()),
-		degraded:                  c.degradedCondition(configv1.ConditionFalse, ReasonProgressing, "Controller encountered a retryable error"),
-		err:                       err,
-	}
+	return newReconcileResult(c, configv1.ConditionTrue, ReasonEphemeralError, err.Error()).
+		withError(err)
 }
 
 // ErrorP is a convenience wrapper around Error that returns a pointer to the ReconcileResult.
@@ -196,29 +216,22 @@ func (c ControllerResultGenerator) NonRetryableErrorP(err error) *ReconcileResul
 	return ptr.To(c.NonRetryableError(err))
 }
 
-func (c ControllerResultGenerator) nonRetryableError(termErr error) ReconcileResult {
-	return ReconcileResult{
-		ControllerResultGenerator: c,
-		progressing:               c.progressingCondition(configv1.ConditionFalse, ReasonNonRetryableError, termErr.Error()),
-		degraded:                  c.degradedCondition(configv1.ConditionTrue, ReasonNonRetryableError, termErr.Error()),
-		err:                       termErr,
-	}
+func (c ControllerResultGenerator) nonRetryableError(terminalErr error) ReconcileResult {
+	return newReconcileResult(c, configv1.ConditionFalse, ReasonNonRetryableError, terminalErr.Error()).
+		withAvailable(configv1.ConditionFalse, ReasonNonRetryableError, terminalErr.Error()).
+		withError(terminalErr)
 }
 
-func (c ControllerResultGenerator) condition(condType configv1.ClusterStatusConditionType, status configv1.ConditionStatus, reason, message string) *configv1apply.ClusterOperatorStatusConditionApplyConfiguration {
+func (c ControllerResultGenerator) condition(condType string, status configv1.ConditionStatus, reason, message string) *configv1apply.ClusterOperatorStatusConditionApplyConfiguration {
 	return configv1apply.ClusterOperatorStatusCondition().
-		WithType(condType).
+		WithType(c.conditionType(condType)).
 		WithStatus(status).
 		WithReason(reason).
 		WithMessage(message)
 }
 
-func (c ControllerResultGenerator) progressingCondition(status configv1.ConditionStatus, reason, message string) *configv1apply.ClusterOperatorStatusConditionApplyConfiguration {
-	return c.condition(configv1.ClusterStatusConditionType(c+"Progressing"), status, reason, message)
-}
-
-func (c ControllerResultGenerator) degradedCondition(status configv1.ConditionStatus, reason, message string) *configv1apply.ClusterOperatorStatusConditionApplyConfiguration {
-	return c.condition(configv1.ClusterStatusConditionType(c+"Degraded"), status, reason, message)
+func (c ControllerResultGenerator) conditionType(condType string) configv1.ClusterStatusConditionType {
+	return configv1.ClusterStatusConditionType(string(c) + condType)
 }
 
 // WriteClusterOperatorStatus writes the reconcile result as conditions on the ClusterOperator.
@@ -229,10 +242,43 @@ func (r *ReconcileResult) WriteClusterOperatorStatus(ctx context.Context, log lo
 		return fmt.Errorf("failed to get ClusterOperator: %w", err)
 	}
 
-	// Build conditions based on reconcile result
+	// The following behaviours are intended to implement the semantics of
+	// - configv1.ClusterOperatorStatusAvailable
+	// - configv1.ClusterOperatorStatusProgressing
+	// as described in the godoc of those constants.
+	//
+	// ReconcileResult always contains an explicit Progressing condition, so we
+	// we use that directly.
+	//
+	// Where an explicit Available condition is set, we use that directly.
+	// Otherwise, we calculate it based on existing state and the Progressing
+	// condition.
+	//
+	// During installation, we don't want to declare Available=True until the
+	// first time we have successfully reconciled. We achieve this by initially
+	// not setting the Available condition at all. The condition aggregator will
+	// interpret this correctly.
+	//
+	// After we have become Available for the first time, we don't want to
+	// declare Available=False except for conditions which require an
+	// administrator's intervention. Currently we set it for non-retryable
+	// errors. Otherwise we copy the previous state of the Available condition
+	// if it exists.
+
 	conditions := []*configv1apply.ClusterOperatorStatusConditionApplyConfiguration{
-		r.progressing,
-		r.degraded,
+		r.condition(ConditionProgressingSuffix, r.progressing.status, r.progressing.reason, r.progressing.message),
+	}
+
+	if r.available != nil {
+		// Explicitly set Available condition
+		conditions = append(conditions, r.condition(ConditionAvailableSuffix, r.available.status, r.available.reason, r.available.message))
+	} else {
+		// Infer Available condition from existing state, don't write if not
+		// already present
+		currentAvailable := findClusterOperatorCondition(r.conditionType(ConditionAvailableSuffix), co.Status.Conditions)
+		if currentAvailable != nil {
+			conditions = append(conditions, r.condition(ConditionAvailableSuffix, currentAvailable.Status, currentAvailable.Reason, currentAvailable.Message))
+		}
 	}
 
 	updated := mergeConditions(conditions, co.Status.Conditions)
@@ -253,21 +299,21 @@ func (r *ReconcileResult) WriteClusterOperatorStatus(ctx context.Context, log lo
 	return nil
 }
 
+func findClusterOperatorCondition(condType configv1.ClusterStatusConditionType, conditions []configv1.ClusterOperatorStatusCondition) *configv1.ClusterOperatorStatusCondition {
+	for i := range conditions {
+		if conditions[i].Type == condType {
+			return &conditions[i]
+		}
+	}
+
+	return nil
+}
+
 // mergeConditions sets LastTransitionTime on each new condition based on the
 // existing conditions. If a condition's Status/Reason/Message are unchanged,
 // LastTransitionTime is preserved from the existing condition.
 func mergeConditions(newConditions []*configv1apply.ClusterOperatorStatusConditionApplyConfiguration, existingConditions []configv1.ClusterOperatorStatusCondition) bool {
 	now := metav1.Now()
-
-	findClusterOperatorCondition := func(condType configv1.ClusterStatusConditionType) *configv1.ClusterOperatorStatusCondition {
-		for i := range existingConditions {
-			if existingConditions[i].Type == condType {
-				return &existingConditions[i]
-			}
-		}
-
-		return nil
-	}
 
 	updated := false
 
@@ -277,7 +323,7 @@ func mergeConditions(newConditions []*configv1apply.ClusterOperatorStatusConditi
 			panic(fmt.Sprintf("condition is missing required fields: %+v", cond))
 		}
 
-		existing := findClusterOperatorCondition(*cond.Type)
+		existing := findClusterOperatorCondition(*cond.Type, existingConditions)
 
 		switch {
 		case existing == nil:

--- a/pkg/operatorstatus/controller_status_test.go
+++ b/pkg/operatorstatus/controller_status_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
 	. "github.com/onsi/gomega"
 	configv1 "github.com/openshift/api/config/v1"
 	configv1apply "github.com/openshift/client-go/config/applyconfigurations/config/v1"
@@ -34,8 +34,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	"github.com/openshift/cluster-capi-operator/pkg/test"
 )
 
 const testResultGenerator ControllerResultGenerator = "Test"
@@ -44,15 +42,17 @@ func TestSuccess(t *testing.T) {
 	g := NewWithT(t)
 	result := testResultGenerator.Success()
 
-	g.Expect(result.progressing).To(test.BeCondition("TestProgressing").
-		WithStatus(configv1.ConditionFalse).
-		WithReason(ReasonAsExpected).
-		WithMessage("Success"))
+	g.Expect(result.progressing).To(Equal(partialCondition{
+		status:  configv1.ConditionFalse,
+		reason:  ReasonAsExpected,
+		message: "Success",
+	}))
 
-	g.Expect(result.degraded).To(test.BeCondition("TestDegraded").
-		WithStatus(configv1.ConditionFalse).
-		WithReason(ReasonAsExpected).
-		WithMessage("Success"))
+	g.Expect(result.available).To(HaveValue(Equal(partialCondition{
+		status:  configv1.ConditionTrue,
+		reason:  ReasonAsExpected,
+		message: "Success",
+	})))
 
 	g.Expect(result.err).To(BeNil())
 
@@ -65,15 +65,13 @@ func TestProgressing(t *testing.T) {
 	g := NewWithT(t)
 	result := testResultGenerator.Progressing("installing components")
 
-	g.Expect(result.progressing).To(test.BeCondition("TestProgressing").
-		WithStatus(configv1.ConditionTrue).
-		WithReason(ReasonProgressing).
-		WithMessage("installing components"))
+	g.Expect(result.progressing).To(Equal(partialCondition{
+		status:  configv1.ConditionTrue,
+		reason:  ReasonProgressing,
+		message: "installing components",
+	}))
 
-	g.Expect(result.degraded).To(test.BeCondition("TestDegraded").
-		WithStatus(configv1.ConditionFalse).
-		WithReason(ReasonProgressing).
-		WithMessage("installing components"))
+	g.Expect(result.available).To(BeNil())
 
 	g.Expect(result.err).To(BeNil())
 }
@@ -82,15 +80,13 @@ func TestWaitingOnExternal(t *testing.T) {
 	g := NewWithT(t)
 	result := testResultGenerator.WaitingOnExternal("infrastructure")
 
-	g.Expect(result.progressing).To(test.BeCondition("TestProgressing").
-		WithStatus(configv1.ConditionTrue).
-		WithReason(ReasonWaitingOnExternal).
-		WithMessage("Waiting on infrastructure"))
+	g.Expect(result.progressing).To(Equal(partialCondition{
+		status:  configv1.ConditionTrue,
+		reason:  ReasonWaitingOnExternal,
+		message: "Waiting on infrastructure",
+	}))
 
-	g.Expect(result.degraded).To(test.BeCondition("TestDegraded").
-		WithStatus(configv1.ConditionFalse).
-		WithReason(ReasonWaitingOnExternal).
-		WithMessage("Waiting on infrastructure"))
+	g.Expect(result.available).To(BeNil())
 
 	g.Expect(result.err).To(BeNil())
 }
@@ -101,15 +97,13 @@ func TestError(t *testing.T) {
 		testErr := fmt.Errorf("connection refused")
 		result := testResultGenerator.Error(testErr)
 
-		g.Expect(result.progressing).To(test.BeCondition("TestProgressing").
-			WithStatus(configv1.ConditionTrue).
-			WithReason(ReasonEphemeralError).
-			WithMessage("connection refused"))
+		g.Expect(result.progressing).To(Equal(partialCondition{
+			status:  configv1.ConditionTrue,
+			reason:  ReasonEphemeralError,
+			message: "connection refused",
+		}))
 
-		g.Expect(result.degraded).To(test.BeCondition("TestDegraded").
-			WithStatus(configv1.ConditionFalse).
-			WithReason(ReasonProgressing).
-			WithMessage("Controller encountered a retryable error"))
+		g.Expect(result.available).To(BeNil())
 
 		g.Expect(result.err).To(Equal(testErr))
 		g.Expect(errors.Is(result.err, reconcile.TerminalError(nil))).To(BeFalse())
@@ -121,15 +115,17 @@ func TestError(t *testing.T) {
 		termErr := reconcile.TerminalError(innerErr)
 		result := testResultGenerator.Error(termErr)
 
-		g.Expect(result.progressing).To(test.BeCondition("TestProgressing").
-			WithStatus(configv1.ConditionFalse).
-			WithReason(ReasonNonRetryableError).
-			WithMessage(termErr.Error()))
+		g.Expect(result.progressing).To(Equal(partialCondition{
+			status:  configv1.ConditionFalse,
+			reason:  ReasonNonRetryableError,
+			message: termErr.Error(),
+		}))
 
-		g.Expect(result.degraded).To(test.BeCondition("TestDegraded").
-			WithStatus(configv1.ConditionTrue).
-			WithReason(ReasonNonRetryableError).
-			WithMessage(termErr.Error()))
+		g.Expect(result.available).To(HaveValue(Equal(partialCondition{
+			status:  configv1.ConditionFalse,
+			reason:  ReasonNonRetryableError,
+			message: termErr.Error(),
+		})))
 
 		g.Expect(errors.Is(result.err, reconcile.TerminalError(nil))).To(BeTrue())
 	})
@@ -141,15 +137,17 @@ func TestNonRetryableError(t *testing.T) {
 		testErr := fmt.Errorf("bad config")
 		result := testResultGenerator.NonRetryableError(testErr)
 
-		g.Expect(result.progressing).To(test.BeCondition("TestProgressing").
-			WithStatus(configv1.ConditionFalse).
-			WithReason(ReasonNonRetryableError).
-			WithMessage("terminal error: bad config"))
+		g.Expect(result.progressing).To(Equal(partialCondition{
+			status:  configv1.ConditionFalse,
+			reason:  ReasonNonRetryableError,
+			message: "terminal error: bad config",
+		}))
 
-		g.Expect(result.degraded).To(test.BeCondition("TestDegraded").
-			WithStatus(configv1.ConditionTrue).
-			WithReason(ReasonNonRetryableError).
-			WithMessage("terminal error: bad config"))
+		g.Expect(result.available).To(HaveValue(Equal(partialCondition{
+			status:  configv1.ConditionFalse,
+			reason:  ReasonNonRetryableError,
+			message: "terminal error: bad config",
+		})))
 
 		g.Expect(errors.Is(result.err, reconcile.TerminalError(nil))).To(BeTrue())
 	})
@@ -160,11 +158,17 @@ func TestNonRetryableError(t *testing.T) {
 		termErr := reconcile.TerminalError(innerErr)
 		result := testResultGenerator.NonRetryableError(termErr)
 
-		g.Expect(result.progressing).To(test.BeCondition("TestProgressing").
-			WithMessage("terminal error: already wrapped"))
+		g.Expect(result.progressing).To(Equal(partialCondition{
+			status:  configv1.ConditionFalse,
+			reason:  ReasonNonRetryableError,
+			message: "terminal error: already wrapped",
+		}))
 
-		g.Expect(result.degraded).To(test.BeCondition("TestDegraded").
-			WithMessage("terminal error: already wrapped"))
+		g.Expect(result.available).To(HaveValue(Equal(partialCondition{
+			status:  configv1.ConditionFalse,
+			reason:  ReasonNonRetryableError,
+			message: "terminal error: already wrapped",
+		})))
 
 		g.Expect(errors.Is(result.err, reconcile.TerminalError(nil))).To(BeTrue())
 		// The error should not be re-wrapped: result.err should be the same terminal error
@@ -393,52 +397,70 @@ func newFakeClient(objs ...client.Object) client.WithWatch {
 }
 
 func TestWriteClusterOperatorStatus(t *testing.T) {
-	log := logr.Discard()
+	log := testr.New(t)
+
+	type expectedCondition struct {
+		status  configv1.ConditionStatus
+		reason  string
+		message string
+	}
+
+	existingAvailable := []configv1.ClusterOperatorStatusCondition{
+		{
+			Type:               "TestAvailable",
+			Status:             configv1.ConditionTrue,
+			Reason:             ReasonAsExpected,
+			Message:            "Success",
+			LastTransitionTime: metav1.Now(),
+		},
+	}
 
 	for _, tc := range []struct {
-		name            string
-		conditions      []configv1.ClusterOperatorStatusCondition
-		wantPatchCalled bool
+		name               string
+		existingConditions []configv1.ClusterOperatorStatusCondition
+		result             ReconcileResult
+		wantProgressing    expectedCondition
+		wantAvailable      *expectedCondition
 	}{
 		{
-			name: "skips patch when conditions unchanged",
-			conditions: []configv1.ClusterOperatorStatusCondition{
-				{
-					Type:               "TestProgressing",
-					Status:             configv1.ConditionFalse,
-					Reason:             ReasonAsExpected,
-					Message:            "Success",
-					LastTransitionTime: metav1.Now(),
-				},
-				{
-					Type:               "TestDegraded",
-					Status:             configv1.ConditionFalse,
-					Reason:             ReasonAsExpected,
-					Message:            "Success",
-					LastTransitionTime: metav1.Now(),
-				},
-			},
-			wantPatchCalled: false,
+			name:            "Success writes Progressing and Available conditions",
+			result:          testResultGenerator.Success(),
+			wantProgressing: expectedCondition{configv1.ConditionFalse, ReasonAsExpected, "Success"},
+			wantAvailable:   &expectedCondition{configv1.ConditionTrue, ReasonAsExpected, "Success"},
 		},
 		{
-			name: "patches when conditions changed",
-			conditions: []configv1.ClusterOperatorStatusCondition{
-				{
-					Type:               "TestProgressing",
-					Status:             configv1.ConditionTrue,
-					Reason:             ReasonProgressing,
-					Message:            "installing components",
-					LastTransitionTime: metav1.Now(),
-				},
-				{
-					Type:               "TestDegraded",
-					Status:             configv1.ConditionFalse,
-					Reason:             ReasonProgressing,
-					Message:            "installing components",
-					LastTransitionTime: metav1.Now(),
-				},
-			},
-			wantPatchCalled: true,
+			name:            "Progressing without existing Available does not write Available",
+			result:          testResultGenerator.Progressing("installing components"),
+			wantProgressing: expectedCondition{configv1.ConditionTrue, ReasonProgressing, "installing components"},
+			wantAvailable:   nil,
+		},
+		{
+			name:               "Progressing with existing Available preserves Available",
+			existingConditions: existingAvailable,
+			result:             testResultGenerator.Progressing("installing components"),
+			wantProgressing:    expectedCondition{configv1.ConditionTrue, ReasonProgressing, "installing components"},
+			wantAvailable:      &expectedCondition{configv1.ConditionTrue, ReasonAsExpected, "Success"},
+		},
+		{
+			name:               "Error with existing Available preserves Available",
+			existingConditions: existingAvailable,
+			result:             testResultGenerator.Error(fmt.Errorf("connection refused")),
+			wantProgressing:    expectedCondition{configv1.ConditionTrue, ReasonEphemeralError, "connection refused"},
+			wantAvailable:      &expectedCondition{configv1.ConditionTrue, ReasonAsExpected, "Success"},
+		},
+		{
+			name:               "WaitingOnExternal with existing Available preserves Available",
+			existingConditions: existingAvailable,
+			result:             testResultGenerator.WaitingOnExternal("infrastructure"),
+			wantProgressing:    expectedCondition{configv1.ConditionTrue, ReasonWaitingOnExternal, "Waiting on infrastructure"},
+			wantAvailable:      &expectedCondition{configv1.ConditionTrue, ReasonAsExpected, "Success"},
+		},
+		{
+			name:               "NonRetryableError explicitly sets Available=False",
+			existingConditions: existingAvailable,
+			result:             testResultGenerator.NonRetryableError(fmt.Errorf("bad config")),
+			wantProgressing:    expectedCondition{configv1.ConditionFalse, ReasonNonRetryableError, "terminal error: bad config"},
+			wantAvailable:      &expectedCondition{configv1.ConditionFalse, ReasonNonRetryableError, "terminal error: bad config"},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -450,24 +472,119 @@ func TestWriteClusterOperatorStatus(t *testing.T) {
 					UID:  types.UID("test-uid"),
 				},
 				Status: configv1.ClusterOperatorStatus{
-					Conditions: tc.conditions,
+					Conditions: tc.existingConditions,
 				},
 			}
 
-			patchCalled := false
-			cl := interceptor.NewClient(newFakeClient(co), interceptor.Funcs{
-				SubResourcePatch: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
-					patchCalled = true
-					return c.SubResource(subResourceName).Patch(ctx, obj, patch, opts...)
-				},
-			})
+			cl := newFakeClient(co)
 
-			result := testResultGenerator.Success()
+			result := tc.result
 			err := result.WriteClusterOperatorStatus(t.Context(), log, cl)
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(patchCalled).To(Equal(tc.wantPatchCalled))
+
+			g.Expect(cl.Get(t.Context(), client.ObjectKeyFromObject(co), co)).To(Succeed())
+
+			progressing := findClusterOperatorCondition("TestProgressing", co.Status.Conditions)
+			g.Expect(progressing).ToNot(BeNil())
+			g.Expect(progressing.Status).To(Equal(tc.wantProgressing.status))
+			g.Expect(progressing.Reason).To(Equal(tc.wantProgressing.reason))
+			g.Expect(progressing.Message).To(Equal(tc.wantProgressing.message))
+
+			available := findClusterOperatorCondition("TestAvailable", co.Status.Conditions)
+			if tc.wantAvailable == nil {
+				g.Expect(available).To(BeNil())
+			} else {
+				g.Expect(available).ToNot(BeNil())
+				g.Expect(available.Status).To(Equal(tc.wantAvailable.status))
+				g.Expect(available.Reason).To(Equal(tc.wantAvailable.reason))
+				g.Expect(available.Message).To(Equal(tc.wantAvailable.message))
+			}
 		})
 	}
+
+	t.Run("skips patch when conditions unchanged", func(t *testing.T) {
+		g := NewWithT(t)
+
+		co := &configv1.ClusterOperator{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ClusterOperatorName,
+				UID:  types.UID("test-uid"),
+			},
+			Status: configv1.ClusterOperatorStatus{
+				Conditions: []configv1.ClusterOperatorStatusCondition{
+					{
+						Type:               "TestProgressing",
+						Status:             configv1.ConditionFalse,
+						Reason:             ReasonAsExpected,
+						Message:            "Success",
+						LastTransitionTime: metav1.Now(),
+					},
+					{
+						Type:               "TestAvailable",
+						Status:             configv1.ConditionTrue,
+						Reason:             ReasonAsExpected,
+						Message:            "Success",
+						LastTransitionTime: metav1.Now(),
+					},
+				},
+			},
+		}
+
+		patchCalled := false
+		cl := interceptor.NewClient(newFakeClient(co), interceptor.Funcs{
+			SubResourcePatch: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+				patchCalled = true
+				return c.SubResource(subResourceName).Patch(ctx, obj, patch, opts...)
+			},
+		})
+
+		result := testResultGenerator.Success()
+		err := result.WriteClusterOperatorStatus(t.Context(), log, cl)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(patchCalled).To(BeFalse())
+	})
+
+	t.Run("patches when conditions changed", func(t *testing.T) {
+		g := NewWithT(t)
+
+		co := &configv1.ClusterOperator{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ClusterOperatorName,
+				UID:  types.UID("test-uid"),
+			},
+			Status: configv1.ClusterOperatorStatus{
+				Conditions: []configv1.ClusterOperatorStatusCondition{
+					{
+						Type:               "TestProgressing",
+						Status:             configv1.ConditionTrue,
+						Reason:             ReasonProgressing,
+						Message:            "installing components",
+						LastTransitionTime: metav1.Now(),
+					},
+					{
+						Type:               "TestAvailable",
+						Status:             configv1.ConditionTrue,
+						Reason:             ReasonAsExpected,
+						Message:            "Success",
+						LastTransitionTime: metav1.Now(),
+					},
+				},
+			},
+		}
+
+		patchCalled := false
+		cl := interceptor.NewClient(newFakeClient(co), interceptor.Funcs{
+			SubResourcePatch: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+				patchCalled = true
+				return c.SubResource(subResourceName).Patch(ctx, obj, patch, opts...)
+			},
+		})
+
+		result := testResultGenerator.Success()
+		err := result.WriteClusterOperatorStatus(t.Context(), log, cl)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(patchCalled).To(BeTrue())
+	})
 
 	t.Run("returns error when ClusterOperator not found", func(t *testing.T) {
 		g := NewWithT(t)
@@ -479,5 +596,39 @@ func TestWriteClusterOperatorStatus(t *testing.T) {
 		err := result.WriteClusterOperatorStatus(t.Context(), log, cl)
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("failed to get ClusterOperator"))
+	})
+}
+
+func TestFindClusterOperatorCondition(t *testing.T) {
+	t.Run("returns matching condition", func(t *testing.T) {
+		g := NewWithT(t)
+
+		conditions := []configv1.ClusterOperatorStatusCondition{
+			{Type: "TestProgressing", Status: configv1.ConditionFalse},
+			{Type: "TestAvailable", Status: configv1.ConditionTrue},
+		}
+
+		result := findClusterOperatorCondition("TestAvailable", conditions)
+		g.Expect(result).ToNot(BeNil())
+		g.Expect(result.Type).To(Equal(configv1.ClusterStatusConditionType("TestAvailable")))
+		g.Expect(result.Status).To(Equal(configv1.ConditionTrue))
+	})
+
+	t.Run("returns nil when not found", func(t *testing.T) {
+		g := NewWithT(t)
+
+		conditions := []configv1.ClusterOperatorStatusCondition{
+			{Type: "TestProgressing", Status: configv1.ConditionFalse},
+		}
+
+		result := findClusterOperatorCondition("TestAvailable", conditions)
+		g.Expect(result).To(BeNil())
+	})
+
+	t.Run("returns nil for empty slice", func(t *testing.T) {
+		g := NewWithT(t)
+
+		g.Expect(findClusterOperatorCondition("TestAvailable", nil)).To(BeNil())
+		g.Expect(findClusterOperatorCondition("TestAvailable", []configv1.ClusterOperatorStatusCondition{})).To(BeNil())
 	})
 }

--- a/vendor/github.com/go-logr/logr/testr/testr.go
+++ b/vendor/github.com/go-logr/logr/testr/testr.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2019 The logr Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package testr provides support for using logr in tests.
+package testr
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
+)
+
+// New returns a logr.Logger that prints through a testing.T object.
+// Info logs are only enabled at V(0).
+func New(t *testing.T) logr.Logger {
+	return NewWithOptions(t, Options{})
+}
+
+// Options carries parameters which influence the way logs are generated.
+type Options struct {
+	// LogTimestamp tells the logger to add a "ts" key to log
+	// lines. This has some overhead, so some users might not want
+	// it.
+	LogTimestamp bool
+
+	// Verbosity tells the logger which V logs to be write.
+	// Higher values enable more logs.
+	Verbosity int
+}
+
+// NewWithOptions returns a logr.Logger that prints through a testing.T object.
+// In contrast to the simpler New, output formatting can be configured.
+func NewWithOptions(t *testing.T, opts Options) logr.Logger {
+	l := &testlogger{
+		testloggerInterface: newLoggerInterfaceWithOptions(t, opts),
+	}
+	return logr.New(l)
+}
+
+// TestingT is an interface wrapper around testing.T, testing.B and testing.F.
+type TestingT interface {
+	Helper()
+	Log(args ...any)
+}
+
+// NewWithInterface returns a logr.Logger that prints through a
+// TestingT object.
+// In contrast to the simpler New, output formatting can be configured.
+func NewWithInterface(t TestingT, opts Options) logr.Logger {
+	l := newLoggerInterfaceWithOptions(t, opts)
+	return logr.New(&l)
+}
+
+func newLoggerInterfaceWithOptions(t TestingT, opts Options) testloggerInterface {
+	return testloggerInterface{
+		t: t,
+		Formatter: funcr.NewFormatter(funcr.Options{
+			LogTimestamp: opts.LogTimestamp,
+			Verbosity:    opts.Verbosity,
+		}),
+	}
+}
+
+// Underlier exposes access to the underlying testing.T instance. Since
+// callers only have a logr.Logger, they have to know which
+// implementation is in use, so this interface is less of an
+// abstraction and more of a way to test type conversion.
+type Underlier interface {
+	GetUnderlying() *testing.T
+}
+
+// UnderlierInterface exposes access to the underlying TestingT instance. Since
+// callers only have a logr.Logger, they have to know which
+// implementation is in use, so this interface is less of an
+// abstraction and more of a way to test type conversion.
+type UnderlierInterface interface {
+	GetUnderlying() TestingT
+}
+
+// Info logging implementation shared between testLogger and testLoggerInterface.
+func logInfo(t TestingT, formatInfo func(int, string, []any) (string, string), level int, msg string, kvList ...any) {
+	prefix, args := formatInfo(level, msg, kvList)
+	t.Helper()
+	if prefix != "" {
+		args = prefix + ": " + args
+	}
+	t.Log(args)
+}
+
+// Error logging implementation shared between testLogger and testLoggerInterface.
+func logError(t TestingT, formatError func(error, string, []any) (string, string), err error, msg string, kvList ...any) {
+	prefix, args := formatError(err, msg, kvList)
+	t.Helper()
+	if prefix != "" {
+		args = prefix + ": " + args
+	}
+	t.Log(args)
+}
+
+// This type exists to wrap and modify the method-set of testloggerInterface.
+// In particular, it changes the GetUnderlying() method.
+type testlogger struct {
+	testloggerInterface
+}
+
+func (l testlogger) GetUnderlying() *testing.T {
+	// This method is defined on testlogger, so the only type this could
+	// possibly be is testing.T, even though that's not guaranteed by the type
+	// system itself.
+	return l.t.(*testing.T) //nolint:forcetypeassert
+}
+
+type testloggerInterface struct {
+	funcr.Formatter
+	t TestingT
+}
+
+func (l testloggerInterface) WithName(name string) logr.LogSink {
+	l.AddName(name) // via Formatter
+	return &l
+}
+
+func (l testloggerInterface) WithValues(kvList ...any) logr.LogSink {
+	l.AddValues(kvList) // via Formatter
+	return &l
+}
+
+func (l testloggerInterface) GetCallStackHelper() func() {
+	return l.t.Helper
+}
+
+func (l testloggerInterface) Info(level int, msg string, kvList ...any) {
+	l.t.Helper()
+	logInfo(l.t, l.FormatInfo, level, msg, kvList...)
+}
+
+func (l testloggerInterface) Error(err error, msg string, kvList ...any) {
+	l.t.Helper()
+	logError(l.t, l.FormatError, err, msg, kvList...)
+}
+
+func (l testloggerInterface) GetUnderlying() TestingT {
+	return l.t
+}
+
+// Assert conformance to the interfaces.
+var _ logr.LogSink = &testlogger{}
+var _ logr.CallStackHelperLogSink = &testlogger{}
+var _ Underlier = &testlogger{}
+
+var _ logr.LogSink = &testloggerInterface{}
+var _ logr.CallStackHelperLogSink = &testloggerInterface{}
+var _ UnderlierInterface = &testloggerInterface{}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -414,6 +414,7 @@ github.com/go-errors/errors
 github.com/go-logr/logr
 github.com/go-logr/logr/funcr
 github.com/go-logr/logr/slogr
+github.com/go-logr/logr/testr
 # github.com/go-logr/stdr v1.2.2
 ## explicit; go 1.16
 github.com/go-logr/stdr


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined operator status condition handling: Progressing is always tracked; Available is only set when explicitly determined.
  * Internal condition representation simplified; degraded condition removed.

* **Bug Fixes**
  * Prevents asserting Available=True before first explicit availability reconciliation.

* **Tests**
  * Updated and added tests to reflect new Available/Progressing semantics and condition lookup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->