### PR TITLE
[release-4.12] NO-JIRA: Allow sustaining engineering to self serve dependency updates

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,25 @@
 approvers:
-  - JoelSpeed
-  - Fedosin
-  - elmiko
-  - lobziik
-  - alexander-demichev
+- cluster-api-approvers
+reviewers:
+- cluster-api-reviewers
+component: Cloud Compute
+subcomponent: Cluster API Providers
 
-component: "Cloud Compute"
-subcomponent: "Cluster API"
+# File-specific ownership patterns
+filters:
+  # Dependency files at any level - require different approval
+  "(^|.*/)go\\.(mod|sum|work|work.sum)$":
+    reviewers:
+      - sustaining-reviewers
+    approvers:
+      - sustaining-approvers
+      - cluster-api-approvers
+
+  # Vendor directory changes at any level
+  "(^|.*/)vendor/.*":
+    reviewers:
+      - sustaining-reviewers
+    approvers:
+      - sustaining-approvers
+      - cluster-api-approvers
+

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,41 @@
+# OWNERS_ALIASES for openshift/cluster-capi-operator
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+aliases:
+  # Default Cluster API maintainers
+  cluster-api-approvers:
+    - JoelSpeed
+    - RadekManak
+    - damdo
+    - mdbooth
+    - nrb
+    - racheljpg
+    - stephenfin
+    - theobarberbany
+  cluster-api-reviewers:
+    - RadekManak
+    - damdo
+    - mdbooth
+    - nrb
+    - racheljpg
+    - theobarberbany
+
+  # Allow sustaining engineering to approve dependency changes
+  sustaining-approvers:
+    - sghai
+    - shannon
+    - jkaurredhat
+    - san7ket
+    - germanparente
+    - prabhapa
+    - ppostler
+
+  sustaining-reviewers:
+    - sghai
+    - shannon
+    - jkaurredhat
+    - san7ket
+    - germanparente
+    - prabhapa
+    - ppostler
+


### PR DESCRIPTION
This updates the owners file to allow the sustaining engineering team to self service any PR that only updates dependencies. This will allow them to self serve on CVE fixes that they are proposing for this repository

This is a backport of #553 to release-4.12.

CC @damdo @germanparente