### PR TITLE
NO-JIRA: Remove stale TODO comment for HostPlacement conversion

### DIFF
--- a/pkg/conversion/capi2mapi/aws.go
+++ b/pkg/conversion/capi2mapi/aws.go
@@ -178,7 +178,7 @@ func (m machineAndAWSMachineAndAWSCluster) toProviderSpec() (*mapiv1beta1.AWSMac
 			Tenancy:          mapaTenancy,
 			Region:           m.awsCluster.Spec.Region,
 		},
-		// HostPlacement: TODO: add conversion from CAPA HostAffinity and HostID to MAPI HostPlacement when the MAPI API is finalized.
+		// HostPlacement - Populated below.
 		LoadBalancers: mapiLoadBalancers,
 		// BlockDevices - Populated below.
 		SpotMarketOptions:       convertAWSSpotMarketOptionsToMAPI(m.awsMachine.Spec.SpotMarketOptions),


### PR DESCRIPTION
## Summary
- Removes a stale TODO comment in `capi2mapi/aws.go` that stated HostPlacement conversion from CAPA HostAffinity/HostID was not yet implemented
- The conversion was implemented in subsequent commits and is called just below at line 193 (`convertAWSDedicatedHostToMAPI`)
- Updates the comment to match the pattern used by other fields populated outside the struct literal (e.g. `// BlockDevices - Populated below.`)

## Test plan
- No functional change — comment-only cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation comments for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->