### PR TITLE
OCPBUGS-85530: Fix failure to start on arm64

### DIFF
--- a/manifests/0000_30_cluster-api-installer_05_deployment.yaml
+++ b/manifests/0000_30_cluster-api-installer_05_deployment.yaml
@@ -62,43 +62,33 @@ spec:
           readOnly: true
         - name: provider-aws
           mountPath: /var/lib/provider-images/aws-cluster-api-controllers
-          subPath: capi-operator-manifests
           readOnly: true
         - name: provider-azure
           mountPath: /var/lib/provider-images/azure-cluster-api-controllers
-          subPath: capi-operator-manifests
           readOnly: true
         - name: provider-baremetal
           mountPath: /var/lib/provider-images/baremetal-cluster-api-controllers
-          subPath: capi-operator-manifests
           readOnly: true
         - name: provider-cluster-capi-controllers
           mountPath: /var/lib/provider-images/cluster-capi-controllers
-          subPath: capi-operator-manifests
           readOnly: true
         - name: provider-cluster-capi-operator
           mountPath: /var/lib/provider-images/cluster-capi-operator
-          subPath: capi-operator-manifests
           readOnly: true
         - name: provider-gcp
           mountPath: /var/lib/provider-images/gcp-cluster-api-controllers
-          subPath: capi-operator-manifests
           readOnly: true
         - name: provider-ibmcloud
           mountPath: /var/lib/provider-images/ibmcloud-cluster-api-controllers
-          subPath: capi-operator-manifests
           readOnly: true
         - name: provider-openstack
           mountPath: /var/lib/provider-images/openstack-cluster-api-controllers
-          subPath: capi-operator-manifests
           readOnly: true
         - name: provider-openstack-resource-controller
           mountPath: /var/lib/provider-images/openstack-resource-controller
-          subPath: capi-operator-manifests
           readOnly: true
         - name: provider-vsphere
           mountPath: /var/lib/provider-images/vsphere-cluster-api-controllers
-          subPath: capi-operator-manifests
           readOnly: true
         livenessProbe:
           httpGet:

--- a/pkg/providerimages/providerimages.go
+++ b/pkg/providerimages/providerimages.go
@@ -28,8 +28,9 @@ import (
 )
 
 const (
-	metadataFile  = "metadata.yaml"
-	manifestsFile = "manifests.yaml"
+	metadataFile             = "metadata.yaml"
+	manifestsFile            = "manifests.yaml"
+	capiOperatorManifestsDir = "capi-operator-manifests"
 
 	// AttributeKeyType is the key for the provider type attribute.
 	AttributeKeyType = providermetadata.AttributeKeyType
@@ -96,7 +97,7 @@ func ScanProviderImages(logger logr.Logger, providerImageDir string, imageRefMap
 				return nil, fmt.Errorf("%w: %s", errImageRefNotFound, subdir)
 			}
 
-			manifestsPath := filepath.Join(subdirPath, profile.Profile, manifestsFile)
+			manifestsPath := filepath.Join(subdirPath, capiOperatorManifestsDir, profile.Profile, manifestsFile)
 
 			result = append(result, ProviderImageManifests{
 				ProviderMetadata: *profile.Metadata,
@@ -156,7 +157,7 @@ type profileManifests struct {
 // Each subdirectory must contain both metadata.yaml and manifests.yaml.
 // Returns an error if no profiles are found or if any profile is incomplete.
 func discoverProfiles(dir string) ([]profileManifests, error) {
-	entries, err := os.ReadDir(dir)
+	entries, err := os.ReadDir(filepath.Join(dir, capiOperatorManifestsDir))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, errNoCapiManifests
@@ -173,7 +174,7 @@ func discoverProfiles(dir string) ([]profileManifests, error) {
 		}
 
 		profileName := entry.Name()
-		profileDir := filepath.Join(dir, profileName)
+		profileDir := filepath.Join(dir, capiOperatorManifestsDir, profileName)
 
 		profile, isProfile, err := loadProfile(profileName, profileDir)
 		if err != nil {

--- a/pkg/providerimages/providerimages_test.go
+++ b/pkg/providerimages/providerimages_test.go
@@ -44,7 +44,7 @@ attributes:
 func writeProfile(t *testing.T, baseDir, provider, profile, metadata, manifests string) {
 	t.Helper()
 
-	profileDir := filepath.Join(baseDir, provider, profile)
+	profileDir := filepath.Join(baseDir, provider, capiOperatorManifestsDir, profile)
 	if err := os.MkdirAll(profileDir, 0o750); err != nil {
 		t.Fatalf("failed to create profile directory: %v", err)
 	}
@@ -246,7 +246,7 @@ func Test_ScanProviderImages(t *testing.T) {
 				g.Expect(manifest.OCPPlatform).To(BeEquivalentTo("aws"))
 				g.Expect(manifest.Profile).To(Equal("default"))
 				g.Expect(manifest.ImageRef).To(Equal("registry.example.com/capi-aws:v1.0.0"))
-				g.Expect(manifest.ManifestsPath).To(ContainSubstring("default/" + manifestsFile))
+				g.Expect(manifest.ManifestsPath).To(ContainSubstring(capiOperatorManifestsDir + "/default/" + manifestsFile))
 
 				content, err := os.ReadFile(manifest.ManifestsPath)
 				g.Expect(err).NotTo(HaveOccurred())
@@ -260,6 +260,29 @@ func Test_ScanProviderImages(t *testing.T) {
 
 				if err := os.MkdirAll(filepath.Join(dir, "empty-provider"), 0o750); err != nil {
 					t.Fatalf("failed to create directory: %v", err)
+				}
+			},
+			imageRefMap: map[string]string{},
+			validate: func(t *testing.T, g Gomega, result []ProviderImageManifests) {
+				t.Helper()
+				g.Expect(result).To(BeEmpty())
+			},
+		},
+		{
+			// This test covers OCPBUGS-85530, where a provider image is
+			// actually a placeholder because the provider is not built for the
+			// current architecture.
+			name: "provider without capi-operator-manifests directory is skipped",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+
+				providerDir := filepath.Join(dir, "no-manifests-provider")
+				if err := os.MkdirAll(filepath.Join(providerDir, "some-other-dir"), 0o750); err != nil {
+					t.Fatalf("failed to create directory: %v", err)
+				}
+
+				if err := os.WriteFile(filepath.Join(providerDir, "some-file.txt"), []byte("not capi manifests"), 0o640); err != nil {
+					t.Fatalf("failed to write file: %v", err)
 				}
 			},
 			imageRefMap: map[string]string{},
@@ -393,7 +416,7 @@ func Test_ScanProviderImages(t *testing.T) {
 					"kind: ConfigMap\n",
 				)
 				// Create a non-profile subdirectory (has a file but not metadata.yaml/manifests.yaml)
-				randomDir := filepath.Join(dir, "with-random-subdir", "randomdir")
+				randomDir := filepath.Join(dir, "with-random-subdir", capiOperatorManifestsDir, "randomdir")
 				if err := os.MkdirAll(randomDir, 0o750); err != nil {
 					t.Fatalf("failed to create directory: %v", err)
 				}


### PR DESCRIPTION
Although we ensure that all providers have /capi-operator-manifests, when a provider image is not built for the current architecture it is substituted by ART with a placeholder image. This placeholder image does not have /capi-operator-manifests, and the pod cannot launch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Chores**
- Reorganized the internal provider configuration directory structure for improved consistency and maintainability across deployments and provider profiles. Provider manifest discovery mechanism now utilizes a consolidated directory hierarchy. Updated deployment manifest configurations and validation tests to properly align with and support the new provider configuration organizational structure for enhanced system maintainability, clarity, and future extensibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->