### PR TITLE
NO-JIRA: fix shell compatibility in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ vsphere-cluster: ## Create a vSphere cluster for testing
 
 define ensure-home
 	@ export HOME=$${HOME:=/tmp/kubebuilder-testing}; \
-	if [ $${HOME} == "/" ]; then \
+	if [ "$${HOME}" = "/" ]; then \
 	  export HOME=/tmp/kubebuilder-testing; \
 	fi; \
 	$(1)


### PR DESCRIPTION
Use POSIX-compliant `=` instead of `==` and add quotes around the HOME variable in the ensure-home function.

This fixes the error "/bin/sh: 1: [: unexpected operator" that occurs on systems where /bin/sh is symlinked to dash instead of bash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build system stability and portability through improved environment configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->