### PR TITLE
NO-JIRA: build: add podman support to container image targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 IMG ?= controller:latest
+CONTAINER_TOOL ?= docker
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
@@ -94,11 +95,11 @@ lint: ## Run linter checks
 vendor: ## Vendor dependencies
 	./hack/vendor.sh
 
-image: ## Build the Docker image
-	docker build -t ${IMG} .
+image: ## Build the container image
+	$(CONTAINER_TOOL) build -f Dockerfile.rhel -t ${IMG} .
 
-push: ## Push the Docker image
-	docker push ${IMG}
+push: ## Push the container image
+	$(CONTAINER_TOOL) push ${IMG}
 
 aws-cluster: ## Create an AWS cluster for testing
 	./hack/clusters/create-aws.sh


### PR DESCRIPTION
Add `CONTAINER_TOOL` variable to support both Docker and podman for building and pushing container images. Explicitly specify `Dockerfile.rhel` with `-f` flag for unambiguous file selection.

Podman only auto-discovers files named exactly `Dockerfile` or `Containerfile`, not `Dockerfile.rhel`. This change ensures the build works with both native Docker and podman (including via podman-docker compatibility package).

```
Usage:
  make image                           # uses docker (default)
  make image CONTAINER_TOOL=podman     # uses podman
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced container build system to support multiple container tools for greater flexibility.
  * Implemented RHEL-specific container configuration for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->