### PR TITLE
NO-JIRA: Fix continous reconciliation of VAPs due to server-side defaulting

### DIFF
--- a/admission-policies/aws/unsupported-aws-spec-fields.yaml
+++ b/admission-policies/aws/unsupported-aws-spec-fields.yaml
@@ -6,12 +6,14 @@ spec:
   policyName: "openshift-cluster-api-unsupported-aws-spec-fields"
   validationActions: [Deny]
   matchResources:
+    matchPolicy: Equivalent
     namespaceSelector:
       matchExpressions:
       - key: kubernetes.io/metadata.name
         operator: In
         values:
         - openshift-cluster-api
+    objectSelector: {}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
@@ -20,11 +22,15 @@ metadata:
 spec:
   failurePolicy: Fail
   matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
     resourceRules:
     - apiGroups:   ["infrastructure.cluster.x-k8s.io"]
       apiVersions: ["v1beta2"]
       operations:  ["CREATE", "UPDATE"]
       resources:   ["awsmachines", "awsmachinetemplates"]
+      scope: "*"
   variables:
     - name: machineSpec
       expression: "object.kind == 'AWSMachine' ? object.spec : object.spec.template.spec"

--- a/admission-policies/default/authoritative-api-transition-requires-capi-infrastructure-ready.yaml
+++ b/admission-policies/default/authoritative-api-transition-requires-capi-infrastructure-ready.yaml
@@ -4,9 +4,11 @@ metadata:
   name: openshift-mapi-authoritative-api-transition-requires-capi-infrastructure-ready-and-not-deleting
 spec:
   matchResources:
+    matchPolicy: Equivalent
     namespaceSelector:
       matchLabels:
         kubernetes.io/metadata.name: openshift-machine-api
+    objectSelector: {}
   paramRef:
     namespace: openshift-cluster-api
     # We 'Allow' here as we don't want to block MAPI Machine
@@ -30,11 +32,15 @@ spec:
     kind: Machine
 
   matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
     resourceRules:
     - apiGroups:   ["machine.openshift.io"]
       apiVersions: ["v1beta1"]
       operations:  ["UPDATE"]
       resources:   ["machines"]
+      scope: "*"
 
   # Requests must satisfy every matchCondition to reach the validations
   matchConditions:

--- a/admission-policies/default/cluster-api-machine-set-vap.yaml
+++ b/admission-policies/default/cluster-api-machine-set-vap.yaml
@@ -4,9 +4,11 @@ metadata:
   name: cluster-api-machine-set-vap
 spec:
   matchResources:
+    matchPolicy: Equivalent
     namespaceSelector:
       matchLabels:
         kubernetes.io/metadata.name: openshift-cluster-api
+    objectSelector: {}
   paramRef:
     namespace: openshift-machine-api
     # We 'Allow' here as we don't want to block CAPI Machine functionality
@@ -29,11 +31,15 @@ spec:
     kind: MachineSet
 
   matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
     resourceRules:
     - apiGroups:   ["cluster.x-k8s.io"]
       apiVersions: ["v1beta2"]
       operations:  ["UPDATE"]
       resources:   ["machinesets"]
+      scope: "*"
 
   # Requests must satisfy every matchCondition to reach the validations
   matchConditions:

--- a/admission-policies/default/cluster-api-machine-vap.yaml
+++ b/admission-policies/default/cluster-api-machine-vap.yaml
@@ -4,9 +4,11 @@ metadata:
   name: cluster-api-machine-vap
 spec:
   matchResources:
+    matchPolicy: Equivalent
     namespaceSelector:
       matchLabels:
         kubernetes.io/metadata.name: openshift-cluster-api
+    objectSelector: {}
   paramRef:
     namespace: openshift-machine-api
     # We 'Allow' here as we don't want to block CAPI Machine functionality
@@ -29,11 +31,15 @@ spec:
     kind: Machine
 
   matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
     resourceRules:
     - apiGroups:   ["cluster.x-k8s.io"]
       apiVersions: ["v1beta2"]
       operations:  ["UPDATE"]
       resources:   ["machines"]
+      scope: "*"
 
   # Requests must satisfy every matchCondition to reach the validations
   matchConditions:

--- a/admission-policies/default/machine-api-machine-set-vap.yaml
+++ b/admission-policies/default/machine-api-machine-set-vap.yaml
@@ -4,9 +4,11 @@ metadata:
   name: machine-api-machine-set-vap
 spec:
   matchResources:
+    matchPolicy: Equivalent
     namespaceSelector:
       matchLabels:
         kubernetes.io/metadata.name: openshift-machine-api
+    objectSelector: {}
   paramRef:
     namespace: openshift-cluster-api
     # We 'Allow' here as we don't want to block MAPI Machine Set 
@@ -30,11 +32,15 @@ spec:
     kind: MachineSet
 
   matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
     resourceRules:
     - apiGroups:   ["machine.openshift.io"]
       apiVersions: ["v1beta1"]
       operations:  ["UPDATE"]
       resources:   ["machinesets"]
+      scope: "*"
 
   # Requests must satisfy every matchCondition to reach the validations
   matchConditions:

--- a/admission-policies/default/machine-api-machine-vap.yaml
+++ b/admission-policies/default/machine-api-machine-vap.yaml
@@ -4,9 +4,11 @@ metadata:
   name: machine-api-machine-vap
 spec:
   matchResources:
+    matchPolicy: Equivalent
     namespaceSelector:
       matchLabels:
         kubernetes.io/metadata.name: openshift-machine-api
+    objectSelector: {}
   paramRef:
     namespace: openshift-cluster-api
     # We 'Allow' here as we don't want to block MAPI Machine 
@@ -30,11 +32,15 @@ spec:
     kind: Machine
 
   matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
     resourceRules:
     - apiGroups:   ["machine.openshift.io"]
       apiVersions: ["v1beta1"]
       operations:  ["UPDATE"]
       resources:   ["machines"]
+      scope: "*"
 
   # Requests must satisfy every matchCondition to reach the validations
   matchConditions:

--- a/admission-policies/default/only-create-mapi-machine-if-authoritative-api-capi.yaml
+++ b/admission-policies/default/only-create-mapi-machine-if-authoritative-api-capi.yaml
@@ -10,11 +10,15 @@ spec:
     kind: Machine
 
   matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
     resourceRules:
       - apiGroups: ["machine.openshift.io"]
         apiVersions: ["*"]
         operations: ["CREATE"]
         resources: ["machines"]
+        scope: "*"
   
   # Requests must satisfy every matchCondition to reach the validations
   matchConditions:
@@ -32,9 +36,11 @@ metadata:
   name: openshift-only-create-mapi-machine-if-authoritative-api-capi
 spec:
   matchResources:
+    matchPolicy: Equivalent
     namespaceSelector:
       matchLabels:
         kubernetes.io/metadata.name: openshift-machine-api
+    objectSelector: {}
   paramRef:
     namespace: openshift-cluster-api
     # We 'Allow' here as we don't want to block MAPI Machine 

--- a/admission-policies/default/prevent-authoritative-mapi-machineset-create-when-capi-exists.yaml
+++ b/admission-policies/default/prevent-authoritative-mapi-machineset-create-when-capi-exists.yaml
@@ -8,11 +8,15 @@ spec:
     apiVersion: cluster.x-k8s.io/v1beta2
     kind: MachineSet
   matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
     resourceRules:
       - apiGroups: ["machine.openshift.io"]
         apiVersions: ["*"]
         operations: ["CREATE"]
         resources: ["machinesets"]
+        scope: "*"
   # Requests must satisfy every matchCondition to reach the validations
   matchConditions:
     - name: check-param-match
@@ -30,9 +34,11 @@ metadata:
   name: openshift-prevent-authoritative-mapi-machineset-create-when-capi-exists
 spec:
   matchResources:
+    matchPolicy: Equivalent
     namespaceSelector:
       matchLabels:
         kubernetes.io/metadata.name: openshift-machine-api
+    objectSelector: {}
   paramRef:
     namespace: openshift-cluster-api
     # We 'Allow' here as we don't want to block MAPI MachineSet

--- a/admission-policies/default/prevent-capi-fields-unsupported-by-mapi.yaml
+++ b/admission-policies/default/prevent-capi-fields-unsupported-by-mapi.yaml
@@ -5,11 +5,15 @@ metadata:
 spec:
   failurePolicy: Fail
   matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
     resourceRules:
       - apiGroups: ["cluster.x-k8s.io"]
         apiVersions: ["v1beta2"]
         operations: ["CREATE", "UPDATE"]
         resources: ["machines", "machinesets"]
+        scope: "*"
   variables:
     - name: machineSpec
       expression: "object.kind == 'Machine' ? object.spec : object.spec.template.spec"
@@ -27,9 +31,11 @@ metadata:
   name: openshift-cluster-api-prevent-setting-of-capi-fields-unsupported-by-mapi
 spec:
   matchResources:
+    matchPolicy: Equivalent
     namespaceSelector:
       matchLabels:
         kubernetes.io/metadata.name: openshift-cluster-api
+    objectSelector: {}
   policyName: openshift-cluster-api-prevent-setting-of-capi-fields-unsupported-by-mapi
   validationActions:
       - Deny

--- a/admission-policies/default/prevent-migration-when-machine-updating.yaml
+++ b/admission-policies/default/prevent-migration-when-machine-updating.yaml
@@ -5,11 +5,15 @@ metadata:
 spec:
   failurePolicy: Fail
   matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
     resourceRules:
       - apiGroups: ["machine.openshift.io"]
         apiVersions: ["*"]
         operations: ["UPDATE"]
         resources: ["machines"]
+        scope: "*"
 
   # All validations must evaluate to true
   validations:
@@ -24,9 +28,11 @@ metadata:
   name: openshift-prevent-migration-when-machine-updating
 spec:
   matchResources:
+    matchPolicy: Equivalent
     namespaceSelector:
       matchLabels:
         kubernetes.io/metadata.name: openshift-machine-api
+    objectSelector: {}
   policyName: openshift-prevent-migration-when-machine-updating
   validationActions:
       - Deny

--- a/admission-policies/default/provide-warning-when-not-synchronized.yaml
+++ b/admission-policies/default/provide-warning-when-not-synchronized.yaml
@@ -6,11 +6,15 @@ spec:
   failurePolicy: Ignore
 
   matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
     resourceRules:
       - apiGroups: ["machine.openshift.io"]
         apiVersions: ["*"]
         operations: ["UPDATE"]
         resources: ["machines"]
+        scope: "*"
   variables:
     - name: syncCond
       expression: >
@@ -39,9 +43,11 @@ metadata:
   name: openshift-provide-warning-when-not-synchronized
 spec:
   matchResources:
+    matchPolicy: Equivalent
     namespaceSelector:
       matchLabels:
         kubernetes.io/metadata.name: openshift-machine-api
+    objectSelector: {}
   policyName: openshift-provide-warning-when-not-synchronized
   validationActions:
       - Warn

--- a/admission-policies/default/validate-capi-machine-creation.yaml
+++ b/admission-policies/default/validate-capi-machine-creation.yaml
@@ -4,9 +4,11 @@ metadata:
   name: openshift-validate-capi-machine-creation
 spec:
   matchResources:
+    matchPolicy: Equivalent
     namespaceSelector:
       matchLabels:
         kubernetes.io/metadata.name: openshift-cluster-api
+    objectSelector: {}
   paramRef:
     namespace: openshift-machine-api
     parameterNotFoundAction: Allow
@@ -25,11 +27,15 @@ spec:
     apiVersion: machine.openshift.io/v1beta1
     kind: Machine
   matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
     resourceRules:
     - apiGroups:   ["cluster.x-k8s.io"]
       apiVersions: ["v1beta2"]
       operations:  ["CREATE"]
       resources:   ["machines"]
+      scope: "*"
   # Requests must satisfy every matchCondition to reach the validations
   matchConditions:
     - name: check-only-non-service-account-requests

--- a/admission-policies/default/validate-capi-machine-set-creation.yaml
+++ b/admission-policies/default/validate-capi-machine-set-creation.yaml
@@ -4,9 +4,11 @@ metadata:
   name: openshift-validate-capi-machine-set-creation
 spec:
   matchResources:
+    matchPolicy: Equivalent
     namespaceSelector:
       matchLabels:
         kubernetes.io/metadata.name: openshift-cluster-api
+    objectSelector: {}
   paramRef:
     namespace: openshift-machine-api
     parameterNotFoundAction: Allow
@@ -25,11 +27,15 @@ spec:
     apiVersion: machine.openshift.io/v1beta1
     kind: MachineSet
   matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
     resourceRules:
     - apiGroups:   ["cluster.x-k8s.io"]
       apiVersions: ["v1beta2"]
       operations:  ["CREATE"]
       resources:   ["machinesets"]
+      scope: "*"
   # Requests must satisfy every matchCondition to reach the validations
   matchConditions:
     - name: check-only-non-service-account-requests

--- a/capi-operator-manifests/aws/manifests.yaml
+++ b/capi-operator-manifests/aws/manifests.yaml
@@ -4,12 +4,14 @@ metadata:
   name: openshift-cluster-api-unsupported-aws-spec-fields
 spec:
   matchResources:
+    matchPolicy: Equivalent
     namespaceSelector:
       matchExpressions:
       - key: kubernetes.io/metadata.name
         operator: In
         values:
         - openshift-cluster-api
+    objectSelector: {}
   policyName: openshift-cluster-api-unsupported-aws-spec-fields
   validationActions:
   - Deny
@@ -21,6 +23,9 @@ metadata:
 spec:
   failurePolicy: Fail
   matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
     resourceRules:
     - apiGroups:
       - infrastructure.cluster.x-k8s.io
@@ -32,6 +37,7 @@ spec:
       resources:
       - awsmachines
       - awsmachinetemplates
+      scope: '*'
   validations:
   - expression: '!has(variables.machineSpec.ami.eksLookupType)'
     messageExpression: variables.specPath + '.ami.eksLookupType is a forbidden field'

--- a/capi-operator-manifests/default/manifests.yaml
+++ b/capi-operator-manifests/default/manifests.yaml
@@ -4,9 +4,11 @@ metadata:
   name: machine-api-machine-vap
 spec:
   matchResources:
+    matchPolicy: Equivalent
     namespaceSelector:
       matchLabels:
         kubernetes.io/metadata.name: openshift-machine-api
+    objectSelector: {}
   paramRef:
     namespace: openshift-cluster-api
     parameterNotFoundAction: Allow
@@ -34,6 +36,9 @@ spec:
   - expression: object.metadata.name == params.metadata.name
     name: check-param-match
   matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
     resourceRules:
     - apiGroups:
       - machine.openshift.io
@@ -43,6 +48,7 @@ spec:
       - UPDATE
       resources:
       - machines
+      scope: '*'
   paramKind:
     apiVersion: cluster.x-k8s.io/v1beta2
     kind: Machine
@@ -125,9 +131,11 @@ metadata:
   name: machine-api-machine-set-vap
 spec:
   matchResources:
+    matchPolicy: Equivalent
     namespaceSelector:
       matchLabels:
         kubernetes.io/metadata.name: openshift-machine-api
+    objectSelector: {}
   paramRef:
     namespace: openshift-cluster-api
     parameterNotFoundAction: Allow
@@ -155,6 +163,9 @@ spec:
   - expression: object.metadata.name == params.metadata.name
     name: check-param-match
   matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
     resourceRules:
     - apiGroups:
       - machine.openshift.io
@@ -164,6 +175,7 @@ spec:
       - UPDATE
       resources:
       - machinesets
+      scope: '*'
   paramKind:
     apiVersion: cluster.x-k8s.io/v1beta2
     kind: MachineSet
@@ -244,9 +256,11 @@ metadata:
   name: cluster-api-machine-vap
 spec:
   matchResources:
+    matchPolicy: Equivalent
     namespaceSelector:
       matchLabels:
         kubernetes.io/metadata.name: openshift-cluster-api
+    objectSelector: {}
   paramRef:
     namespace: openshift-machine-api
     parameterNotFoundAction: Allow
@@ -274,6 +288,9 @@ spec:
   - expression: params.?status.authoritativeAPI.orValue("") == "MachineAPI"
     name: check-authoritativeAPI-machineapi
   matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
     resourceRules:
     - apiGroups:
       - cluster.x-k8s.io
@@ -283,6 +300,7 @@ spec:
       - UPDATE
       resources:
       - machines
+      scope: '*'
   paramKind:
     apiVersion: machine.openshift.io/v1beta1
     kind: Machine
@@ -350,9 +368,11 @@ metadata:
   name: cluster-api-machine-set-vap
 spec:
   matchResources:
+    matchPolicy: Equivalent
     namespaceSelector:
       matchLabels:
         kubernetes.io/metadata.name: openshift-cluster-api
+    objectSelector: {}
   paramRef:
     namespace: openshift-machine-api
     parameterNotFoundAction: Allow
@@ -380,6 +400,9 @@ spec:
   - expression: params.?status.?authoritativeAPI.orValue("") == "MachineAPI"
     name: check-authoritativeAPI-machineapi
   matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
     resourceRules:
     - apiGroups:
       - cluster.x-k8s.io
@@ -389,6 +412,7 @@ spec:
       - UPDATE
       resources:
       - machinesets
+      scope: '*'
   paramKind:
     apiVersion: machine.openshift.io/v1beta1
     kind: MachineSet
@@ -455,6 +479,9 @@ metadata:
 spec:
   failurePolicy: Fail
   matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
     resourceRules:
     - apiGroups:
       - cluster.x-k8s.io
@@ -466,6 +493,7 @@ spec:
       resources:
       - machines
       - machinesets
+      scope: '*'
   validations:
   - expression: '!has(variables.machineSpec.version)'
     messageExpression: variables.specPath + '.version is a forbidden field'
@@ -483,9 +511,11 @@ metadata:
   name: openshift-cluster-api-prevent-setting-of-capi-fields-unsupported-by-mapi
 spec:
   matchResources:
+    matchPolicy: Equivalent
     namespaceSelector:
       matchLabels:
         kubernetes.io/metadata.name: openshift-cluster-api
+    objectSelector: {}
   policyName: openshift-cluster-api-prevent-setting-of-capi-fields-unsupported-by-mapi
   validationActions:
   - Deny
@@ -500,6 +530,9 @@ spec:
   - expression: object.metadata.name == params.metadata.name
     name: check-param-match
   matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
     resourceRules:
     - apiGroups:
       - machine.openshift.io
@@ -509,6 +542,7 @@ spec:
       - CREATE
       resources:
       - machines
+      scope: '*'
   paramKind:
     apiVersion: cluster.x-k8s.io/v1beta2
     kind: Machine
@@ -524,9 +558,11 @@ metadata:
   name: openshift-only-create-mapi-machine-if-authoritative-api-capi
 spec:
   matchResources:
+    matchPolicy: Equivalent
     namespaceSelector:
       matchLabels:
         kubernetes.io/metadata.name: openshift-machine-api
+    objectSelector: {}
   paramRef:
     namespace: openshift-cluster-api
     parameterNotFoundAction: Allow
@@ -545,6 +581,9 @@ spec:
   - expression: object.metadata.name == params.metadata.name
     name: check-param-match
   matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
     resourceRules:
     - apiGroups:
       - machine.openshift.io
@@ -554,6 +593,7 @@ spec:
       - CREATE
       resources:
       - machinesets
+      scope: '*'
   paramKind:
     apiVersion: cluster.x-k8s.io/v1beta2
     kind: MachineSet
@@ -569,9 +609,11 @@ metadata:
   name: openshift-prevent-authoritative-mapi-machineset-create-when-capi-exists
 spec:
   matchResources:
+    matchPolicy: Equivalent
     namespaceSelector:
       matchLabels:
         kubernetes.io/metadata.name: openshift-machine-api
+    objectSelector: {}
   paramRef:
     namespace: openshift-cluster-api
     parameterNotFoundAction: Allow
@@ -586,9 +628,11 @@ metadata:
   name: openshift-validate-capi-machine-creation
 spec:
   matchResources:
+    matchPolicy: Equivalent
     namespaceSelector:
       matchLabels:
         kubernetes.io/metadata.name: openshift-cluster-api
+    objectSelector: {}
   paramRef:
     namespace: openshift-machine-api
     parameterNotFoundAction: Allow
@@ -614,6 +658,9 @@ spec:
   - expression: object.metadata.name == params.metadata.name
     name: check-param-match
   matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
     resourceRules:
     - apiGroups:
       - cluster.x-k8s.io
@@ -623,6 +670,7 @@ spec:
       - CREATE
       resources:
       - machines
+      scope: '*'
   paramKind:
     apiVersion: machine.openshift.io/v1beta1
     kind: Machine
@@ -658,9 +706,11 @@ metadata:
   name: openshift-validate-capi-machine-set-creation
 spec:
   matchResources:
+    matchPolicy: Equivalent
     namespaceSelector:
       matchLabels:
         kubernetes.io/metadata.name: openshift-cluster-api
+    objectSelector: {}
   paramRef:
     namespace: openshift-machine-api
     parameterNotFoundAction: Allow
@@ -686,6 +736,9 @@ spec:
   - expression: object.metadata.name == params.metadata.name
     name: check-param-match
   matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
     resourceRules:
     - apiGroups:
       - cluster.x-k8s.io
@@ -695,6 +748,7 @@ spec:
       - CREATE
       resources:
       - machinesets
+      scope: '*'
   paramKind:
     apiVersion: machine.openshift.io/v1beta1
     kind: MachineSet
@@ -731,6 +785,9 @@ metadata:
 spec:
   failurePolicy: Fail
   matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
     resourceRules:
     - apiGroups:
       - machine.openshift.io
@@ -740,6 +797,7 @@ spec:
       - UPDATE
       resources:
       - machines
+      scope: '*'
   validations:
   - expression: '!(has(object.status) && has(object.status.phase) && object.status.phase
       == "Provisioning" && (oldObject.spec.authoritativeAPI != object.spec.authoritativeAPI))'
@@ -756,9 +814,11 @@ metadata:
   name: openshift-prevent-migration-when-machine-updating
 spec:
   matchResources:
+    matchPolicy: Equivalent
     namespaceSelector:
       matchLabels:
         kubernetes.io/metadata.name: openshift-machine-api
+    objectSelector: {}
   policyName: openshift-prevent-migration-when-machine-updating
   validationActions:
   - Deny
@@ -770,6 +830,9 @@ metadata:
 spec:
   failurePolicy: Ignore
   matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
     resourceRules:
     - apiGroups:
       - machine.openshift.io
@@ -779,6 +842,7 @@ spec:
       - UPDATE
       resources:
       - machines
+      scope: '*'
   validations:
   - expression: '!variables.authAPIChanged || (variables.syncCond && !variables.syncBad)'
     message: Updating .spec.authoritativeAPI when the Synchronized condition is not
@@ -804,9 +868,11 @@ metadata:
   name: openshift-provide-warning-when-not-synchronized
 spec:
   matchResources:
+    matchPolicy: Equivalent
     namespaceSelector:
       matchLabels:
         kubernetes.io/metadata.name: openshift-machine-api
+    objectSelector: {}
   policyName: openshift-provide-warning-when-not-synchronized
   validationActions:
   - Warn
@@ -817,9 +883,11 @@ metadata:
   name: openshift-mapi-authoritative-api-transition-requires-capi-infrastructure-ready-and-not-deleting
 spec:
   matchResources:
+    matchPolicy: Equivalent
     namespaceSelector:
       matchLabels:
         kubernetes.io/metadata.name: openshift-machine-api
+    objectSelector: {}
   paramRef:
     namespace: openshift-cluster-api
     parameterNotFoundAction: Allow
@@ -845,6 +913,9 @@ spec:
   - expression: object.metadata.name == params.metadata.name
     name: check-param-match
   matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
     resourceRules:
     - apiGroups:
       - machine.openshift.io
@@ -854,6 +925,7 @@ spec:
       - UPDATE
       resources:
       - machines
+      scope: '*'
   paramKind:
     apiVersion: cluster.x-k8s.io/v1beta2
     kind: Machine


### PR DESCRIPTION
matchConstraints has several fields which have server-side defaults. If omitted, these trigger a continuous reconciliation of all managed objects because the spec doesn't match the manifest. There is unfortunately no good way to detect server-side defaulted values, so the easiest solution is to specify them explicitly.

This is a non-functional change. All the added values are just the defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Improved consistency and standardized behavior for cluster resource validation policies across creation and update operations, ensuring more uniform policy application across namespaces and resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->