### PR TITLE
OCPCLOUD-1645: Scope capi-controllers RBAC to least-privilege

### DIFF
--- a/.claude/skills/rbac-review/SKILL.md
+++ b/.claude/skills/rbac-review/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: rbac-review
+description: "Use when the user wants to audit, update, or regenerate RBAC permissions for a controller or service account. Covers: adding new permissions after code changes, auditing a service account for least privilege, periodic RBAC reviews, or regenerating RBAC manifests after adding new CRD types or controllers. Trigger on any mention of \"rbac\" in the context of updating or reviewing permissions."
+disable-model-invocation: false
+---
+
+Audit and regenerate RBAC permissions for a ServiceAccount. Requires an active cluster connection (`oc whoami` must succeed).
+
+The target ServiceAccount is specified via `$ARGUMENTS` (e.g., `/rbac-review openshift-cluster-api:capi-controllers`). If not provided, ask the user.
+
+## Prerequisites
+
+Verify before starting:
+```bash
+oc whoami
+which audit2rbac || echo "audit2rbac not found — install with: go install github.com/liggitt/audit2rbac/cmd/audit2rbac@latest"
+```
+
+If `oc whoami` fails, stop and ask the user to connect to a cluster first.
+
+If `audit2rbac` is not found, build from source (go install fails due to replace directives):
+```bash
+cd /tmp && git clone https://github.com/liggitt/audit2rbac.git audit2rbac-build \
+  && cd audit2rbac-build && go build -o ~/go/bin/audit2rbac ./cmd/audit2rbac
+```
+
+## Steps 1 & 2: Run in parallel
+
+Step 1 (e2e + audit2rbac) and Step 2 (static analysis) are independent. Start e2e first (it takes ~20 minutes), then do static analysis while it runs. Merge results in Step 3.
+
+### Step 1: Run e2e tests and collect audit2rbac baseline
+
+The cluster must have RBAC that doesn't cause controllers to crash on 403s (so all code paths are exercised).
+
+**Restart the target Deployment before running e2e** so that startup-only operations (pod self-read, initial lease create, ClusterOperator create) appear in the audit window. Without this, those operations are "Code only" in the gap report.
+
+```bash
+oc rollout restart deployment/<name> -n <namespace>
+oc rollout status deployment/<name> -n <namespace> --timeout=120s
+make e2e 2>&1 | tee /tmp/e2e-baseline.log
+```
+
+Collect and clean audit logs. `oc adm node-logs` prefixes each line with the node hostname, which breaks audit2rbac's JSON parser — strip it with `sed`:
+
+```bash
+oc adm node-logs --role=master --path=kube-apiserver/audit.log \
+  | sed 's/^[^ ]* //' > /tmp/audit-clean.log
+audit2rbac --filename=/tmp/audit-clean.log \
+  --serviceaccount=<namespace>:<name> | tee /tmp/audit2rbac-output.yaml
+```
+
+### Step 2: Static analysis of controller code
+
+Find all Deployments that use the target ServiceAccount (search `manifests/` for `serviceAccountName`). From each Deployment, identify its containers and binaries, then find all controllers each binary registers. For each controller, trace resource access:
+
+- `client.Get/List/Create/Update/Patch/Delete` — determines verbs. Note: controller-runtime backs `client.Get` with an informer cache, so any resource accessed via `Get` also needs `list` and `watch`
+- `Status().Patch/Update` — requires `/status` subresource rule
+- `builder.For/Watches/Owns` in `SetupWithManager()` — requires `get, list, watch`
+- `Recorder.Event/Eventf` — requires `events` create/patch
+- `ownerReference` with `blockOwnerDeletion: true` — requires `update` on the owner's `/finalizers` subresource (invisible to audit2rbac)
+- `ValidatingAdmissionPolicyBinding` with `spec.paramRef` — the API server requires `list` permission on the `spec.paramKind` resource type in the `spec.paramRef.namespace` when creating or updating the binding. This is invisible to both audit2rbac and naive code tracing. Check what `paramKind` each VAP uses and add `list` for those resource types.
+- Leader election leases and feature gate informers
+
+For vendored libraries (boxcutter, controller-runtime, etc.), trust audit2rbac over static analysis for verb accuracy. These libraries may use `update` (PUT) internally even when the calling code only shows `patch` calls.
+
+Map each resource to the namespace where it's accessed. Check `pkg/util/platform.go` for the full list of platform-specific infra types.
+
+## Step 3: Gap report
+
+Wait for **both** Step 1 and Step 2 to complete before presenting the gap report. Present it once, not incrementally.
+
+Compare audit2rbac output against static analysis. Produce a table with columns: API Group, Resource, Verbs, Scope, Code evidence, Status.
+
+Status values:
+- **Confirmed** — in both audit2rbac and code
+- **Code only** — in code but not audit2rbac. Must be justified (different platform, first-install path, `blockOwnerDeletion`, VAP paramRef authorization, etc.)
+- **Audit only** — in audit2rbac but not code. Investigate.
+
+Present the gap report and wait for user approval before proceeding.
+
+## Step 4: Build new RBAC
+
+Find the existing RBAC manifests for the target ServiceAccount (search `manifests/` for ClusterRole/Role and ClusterRoleBinding/RoleBinding referencing the SA). Update them following the scoping principle: ClusterRole for cluster-scoped resources, namespace-scoped Roles for everything else.
+
+## Step 5: Verify by running e2e tests
+
+Use `oc replace` (not `oc apply`) to deploy the updated RBAC manifests — `oc apply` on CVO-managed resources does not fully replace rules because the `last-applied-configuration` annotation is missing, so old wildcard rules survive alongside new enumerated rules, giving false confidence.
+
+```bash
+oc replace -f <roles-manifest>
+oc replace -f <bindings-manifest>
+```
+
+For new Roles/RoleBindings that don't exist yet on the cluster, use `oc create` first or `oc replace --force` (which deletes and recreates).
+
+Then restart the Deployments that use the SA, check controller logs for `forbidden`/`403` errors, and run `make e2e`.
+
+## Step 6: Update docs/rbac.md
+
+Update `docs/rbac.md` to reflect the new RBAC structure — which Roles/ClusterRoles exist, their scopes, and what they cover.

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -8,8 +8,9 @@ The `capi-operator` and `capi-installer` ServiceAccounts (in `openshift-cluster-
 
 | Manifest | Kind | Scope | SA | Purpose |
 |----------|------|-------|----|---------|
-| `0000_30_cluster-api-operator_03_clusterrole.yaml` | ClusterRole `openshift-capi-operator` | cluster-wide | `capi-operator` | config.openshift.io resources, ClusterOperator management, ClusterAPI/ConfigMap/Deployment read |
-| `0000_30_cluster-api-operator_03_clusterrole.yaml` | Role `capi-operator` | `openshift-cluster-api-operator` | `capi-operator` | Leader election leases, Deployment write (capi-installer), pod self-read, events |
+| `0000_30_cluster-api-operator_03_clusterrole.yaml` | ClusterRole `openshift-capi-operator` | cluster-wide | `capi-operator` | config.openshift.io resources, ClusterOperator management, ClusterAPI CR read |
+| `0000_30_cluster-api-operator_03_clusterrole.yaml` | Role `capi-operator` | `openshift-cluster-api-operator` | `capi-operator` | Leader election leases, Deployment write (capi-installer), ConfigMap read, pod self-read, events |
+| `0000_30_cluster-api-operator_03_clusterrole.yaml` | Role `capi-operator` | `openshift-cluster-api` | `capi-operator` | Deployment read, ConfigMap read |
 | `0000_30_cluster-api-operator_03_capi-installer-clusterrole.yaml` | ClusterRole `openshift-capi-installer` | cluster-wide | `capi-installer` | CRDs, admission resources, cluster RBAC, config.openshift.io, ClusterAPI/ClusterOperator status, tracking cache informers |
 | `0000_30_cluster-api-operator_03_capi-installer-clusterrole.yaml` | Role `capi-installer` | `openshift-cluster-api-operator` | `capi-installer` | Leader election leases, pod self-read, ConfigMap read, events |
 | `0000_30_cluster-api-operator_03_capi-installer-clusterrole.yaml` | Role `capi-installer` | `openshift-cluster-api` | `capi-installer` | boxcutter-managed resources (ServiceAccounts, Services, Deployments, Roles, RoleBindings), VAP paramRef list |
@@ -23,11 +24,13 @@ The `capi-controllers` ServiceAccount (used by both the `capi-controllers` and `
 
 | Manifest | Kind | Scope | Purpose |
 |----------|------|-------|---------|
-| `03_rbac_roles.yaml` | ClusterRole `openshift-capi-controllers` | cluster-wide | Cluster-scoped resources only: infrastructures, clusteroperators, featuregates, clusterversions, nodes, CRDs |
-| `03_rbac_roles.yaml` | Role `capi-controllers` | `openshift-cluster-api` | CAPI core + infra provider resources, secrets, events, leases |
-| `03_rbac_roles.yaml` | Role `capi-controllers` | `openshift-machine-api` | MAPI machines, machinesets, controlplanemachinesets, secrets, events |
-| `03_rbac_roles.yaml` | Role `capi-controllers-kube-system` | `kube-system` | Secrets (vSphere credentials) |
-| `03_rbac_roles.yaml` | Role `cluster-capi-operator-pull-secret` | `openshift-config` | Pull-secret read |
+| `0000_30_cluster-api_03_rbac_roles.yaml` | ClusterRole `openshift-capi-controllers` | cluster-wide | Cluster-scoped resources only: infrastructures, clusteroperators, featuregates, clusterversions, nodes, CRDs |
+| `0000_30_cluster-api_03_rbac_roles.yaml` | Role `capi-controllers` | `openshift-cluster-api` | CAPI core + infra provider resources, secrets, pod self-read, events, leases |
+| `0000_30_cluster-api_03_rbac_roles.yaml` | Role `capi-controllers` | `openshift-machine-api` | MAPI machines, machinesets, controlplanemachinesets, secrets, events |
+| `0000_30_cluster-api_03_rbac_roles.yaml` | Role `capi-controllers-kube-system` | `kube-system` | Secrets (vSphere credentials) |
+| `0000_30_cluster-api_03_rbac_roles.yaml` | Role `cluster-capi-operator-pull-secret` | `openshift-config` | Pull-secret read |
+
+This SA also binds to ClusterRole `system:openshift:openshift-cluster-api:read-tls-configuration` for APIServer TLS profile reading.
 
 ## Principles
 

--- a/manifests/0000_30_cluster-api_03_rbac_roles.yaml
+++ b/manifests/0000_30_cluster-api_03_rbac_roles.yaml
@@ -10,11 +10,65 @@ metadata:
   name: openshift-capi-controllers
 rules:
 - apiGroups:
-  - '*'
+  - config.openshift.io
   resources:
-  - '*'
+  - infrastructures
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusteroperators
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusteroperators
+  resourceNames:
+  - cluster-api
+  verbs:
+  - get
+  - patch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusteroperators/status
+  resourceNames:
+  - cluster-api
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - featuregates
+  - clusterversions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -28,11 +82,251 @@ metadata:
   namespace: openshift-cluster-api
 rules:
 - apiGroups:
-  - '*'
+  - coordination.k8s.io
   resources:
-  - '*'
+  - leases
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - machines
+  - machinesets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters/status
+  - machines/status
+  - machinesets/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters/finalizers
+  - machines/finalizers
+  - machinesets/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - awsclusters
+  - azureclusters
+  - gcpclusters
+  - vsphereclusters
+  - openstackclusters
+  - metal3clusters
+  - ibmpowervsclusters
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - awsclusters/status
+  - azureclusters/status
+  - gcpclusters/status
+  - vsphereclusters/status
+  - openstackclusters/status
+  - metal3clusters/status
+  - ibmpowervsclusters/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - azureclusteridentities
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - awsmachines
+  - azuremachines
+  - gcpmachines
+  - vspheremachines
+  - openstackmachines
+  - metal3machines
+  - ibmpowervsmachines
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - awsmachines/status
+  - azuremachines/status
+  - gcpmachines/status
+  - vspheremachines/status
+  - openstackmachines/status
+  - metal3machines/status
+  - ibmpowervsmachines/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - awsmachinetemplates
+  - azuremachinetemplates
+  - gcpmachinetemplates
+  - vspheremachinetemplates
+  - openstackmachinetemplates
+  - metal3machinetemplates
+  - ibmpowervsmachinetemplates
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-gate: "ClusterAPIMachineManagement"
+  name: capi-controllers
+  namespace: openshift-machine-api
+rules:
+- apiGroups:
+  - machine.openshift.io
+  resources:
+  - machines
+  - machinesets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - machine.openshift.io
+  resources:
+  - machines/status
+  - machinesets/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - machine.openshift.io
+  resources:
+  - machines/finalizers
+  - machinesets/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - machine.openshift.io
+  resources:
+  - controlplanemachinesets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-gate: "ClusterAPIMachineManagement"
+  name: capi-controllers-kube-system
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  - vsphere-creds
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/manifests/0000_30_cluster-api_04_rbac_bindings.yaml
+++ b/manifests/0000_30_cluster-api_04_rbac_bindings.yaml
@@ -57,6 +57,44 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  name: capi-controllers
+  namespace: openshift-machine-api
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-gate: "ClusterAPIMachineManagement"
+roleRef:
+  kind: Role
+  name: capi-controllers
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  namespace: openshift-cluster-api
+  name: capi-controllers
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: capi-controllers-kube-system
+  namespace: kube-system
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-gate: "ClusterAPIMachineManagement"
+roleRef:
+  kind: Role
+  name: capi-controllers-kube-system
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  namespace: openshift-cluster-api
+  name: capi-controllers
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
   name: cluster-capi-operator-pull-secret
   namespace: openshift-config
   annotations:

--- a/pkg/controllers/infracluster/infracluster_controller.go
+++ b/pkg/controllers/infracluster/infracluster_controller.go
@@ -238,7 +238,7 @@ func (r *InfraClusterController) ensureInfraCluster(ctx context.Context, log log
 
 // setAvailableCondition sets the ClusterOperator status condition to Available.
 func (r *InfraClusterController) setAvailableCondition(ctx context.Context, log logr.Logger) error {
-	co, err := r.GetOrCreateClusterOperator(ctx)
+	co, err := r.GetClusterOperator(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get cluster operator: %w", err)
 	}

--- a/pkg/controllers/secretsync/secret_sync_controller.go
+++ b/pkg/controllers/secretsync/secret_sync_controller.go
@@ -186,7 +186,7 @@ func (r *UserDataSecretController) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *UserDataSecretController) setAvailableCondition(ctx context.Context, log logr.Logger) error {
-	co, err := r.GetOrCreateClusterOperator(ctx)
+	co, err := r.GetClusterOperator(ctx)
 	if err != nil {
 		return fmt.Errorf("unable to get cluster operator: %w", err)
 	}
@@ -208,7 +208,7 @@ func (r *UserDataSecretController) setAvailableCondition(ctx context.Context, lo
 }
 
 func (r *UserDataSecretController) setDegradedCondition(ctx context.Context, log logr.Logger) error {
-	co, err := r.GetOrCreateClusterOperator(ctx)
+	co, err := r.GetClusterOperator(ctx)
 	if err != nil {
 		return fmt.Errorf("unable to get cluster operator: %w", err)
 	}

--- a/pkg/operatorstatus/operator_status.go
+++ b/pkg/operatorstatus/operator_status.go
@@ -21,7 +21,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/clock"
@@ -53,7 +52,7 @@ type ClusterOperatorStatusClient struct {
 func (r *ClusterOperatorStatusClient) SetStatusAvailable(ctx context.Context, availableConditionMsg string, opts ...SyncStatusOption) error {
 	log := ctrl.LoggerFrom(ctx)
 
-	co, err := r.GetOrCreateClusterOperator(ctx)
+	co, err := r.GetClusterOperator(ctx)
 	if err != nil {
 		log.Error(err, "unable to set cluster operator status available")
 		return err
@@ -81,7 +80,7 @@ func (r *ClusterOperatorStatusClient) SetStatusAvailable(ctx context.Context, av
 func (r *ClusterOperatorStatusClient) SetStatusDegraded(ctx context.Context, reconcileErr error, opts ...SyncStatusOption) error {
 	log := ctrl.LoggerFrom(ctx)
 
-	co, err := r.GetOrCreateClusterOperator(ctx)
+	co, err := r.GetClusterOperator(ctx)
 	if err != nil {
 		log.Error(err, "unable to set cluster operator status degraded")
 		return err
@@ -101,30 +100,12 @@ func (r *ClusterOperatorStatusClient) SetStatusDegraded(ctx context.Context, rec
 	return r.SyncStatus(ctx, co, append(opts, WithConditions(conds))...)
 }
 
-// GetOrCreateClusterOperator is responsible for fetching the cluster operator should it exist,
-// or creating a new cluster operator if it does not already exist.
-func (r *ClusterOperatorStatusClient) GetOrCreateClusterOperator(ctx context.Context) (*configv1.ClusterOperator, error) {
-	log := ctrl.LoggerFrom(ctx)
+// GetClusterOperator fetches the ClusterOperator object.
+// The ClusterOperator is created by CVO, not by this operator.
+func (r *ClusterOperatorStatusClient) GetClusterOperator(ctx context.Context) (*configv1.ClusterOperator, error) {
+	co := &configv1.ClusterOperator{}
 
-	co := &configv1.ClusterOperator{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: controllers.ClusterOperatorName,
-		},
-	}
-
-	err := r.Get(ctx, client.ObjectKey{Name: controllers.ClusterOperatorName}, co)
-	if errors.IsNotFound(err) {
-		log.Info("ClusterOperator does not exist, creating a new one.")
-
-		err = r.Create(ctx, co)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create cluster operator: %w", err)
-		}
-
-		return co, nil
-	}
-
-	if err != nil {
+	if err := r.Get(ctx, client.ObjectKey{Name: controllers.ClusterOperatorName}, co); err != nil {
 		return nil, fmt.Errorf("failed to get clusterOperator %q: %w", controllers.ClusterOperatorName, err)
 	}
 


### PR DESCRIPTION
## Summary
- Replace wildcard RBAC rules (`apiGroups: ['*'], resources: ['*'], verbs: ['*']`) in the `openshift-capi-controllers` ClusterRole and `capi-controllers` Role with enumerated, auditable permissions
- Split namespaced resources out of the ClusterRole into namespace-scoped Roles in `openshift-cluster-api`, `openshift-machine-api`, and `kube-system` — secrets access is no longer cluster-wide
- Restrict ClusterOperator access to the `cluster-api` object specifically via `resourceNames`, and remove the `create` verb (CVO creates the ClusterOperator, not this operator)
- Remove the `GetOrCreateClusterOperator` create fallback in `operator_status.go` — renamed to `GetClusterOperator`
- Derived from code analysis of all controllers (capi-controllers + machine-api-migration) and cross-validated with audit2rbac on a live cluster
- Adds `docs/rbac.md` documenting the RBAC structure and `/rbac-review` skill for repeating this process

## Permission justification

Each rule was derived from code analysis and validated against audit2rbac output from an AWS cluster with `MachineAPIMigration` enabled.

### Confirmed by audit2rbac

| Scope | API Group | Resource | Verbs | Code evidence |
|-------|-----------|----------|-------|---------------|
| ClusterRole | `config.openshift.io` | `infrastructures` | get, list, watch | `corecluster_controller.go:122`, `infracluster_controller.go:278`, `kubeconfig.go:85` |
| ClusterRole | `config.openshift.io` | `clusteroperators` | list, watch | `operator_status.go:115` — informer cache (resourceNames not applicable to list/watch) |
| ClusterRole | `config.openshift.io` | `clusteroperators` (resourceNames: cluster-api) | get, patch | `operator_status.go:115,186`, `controller_status.go:295` |
| ClusterRole | `config.openshift.io` | `clusteroperators/status` (resourceNames: cluster-api) | update, patch | `operator_status.go:186`, `controller_status.go:295` |
| ClusterRole | `config.openshift.io` | `featuregates`, `clusterversions` | get, list, watch | `featuregates.go:50-53` |
| ClusterRole | `apiextensions.k8s.io` | `customresourcedefinitions` | get, list, watch | audit2rbac confirmed (userAgent: `machine-api-migration`) |
| ClusterRole | `""` | `nodes` | get, list, watch, patch, update | audit2rbac confirmed (userAgent: `cluster-api-controller-manager`) |
| Role: `openshift-cluster-api` | `cluster.x-k8s.io` | `clusters`, `machines`, `machinesets` | get, list, watch, create, update, patch, delete | `corecluster_controller.go:122,152`, `machine_sync_controller.go:220,656,686,1060`, `machineset_sync_controller.go:200,838,866,1191` |
| Role: `openshift-cluster-api` | `cluster.x-k8s.io` | `clusters/status`, `machines/status`, `machinesets/status` | update, patch | `corecluster_controller.go:216`, `machine_sync_controller.go:1365`, `machineset_sync_controller.go:917` |
| Role: `openshift-cluster-api` | `infrastructure.cluster.x-k8s.io` | `awsclusters` | get, list, watch, create, patch | `aws.go:57,90` |
| Role: `openshift-cluster-api` | `infrastructure.cluster.x-k8s.io` | `awsclusters/status` | update, patch | `infracluster_controller.go:162` |
| Role: `openshift-cluster-api` | `infrastructure.cluster.x-k8s.io` | `awsmachines` | get, list, watch, create, update, patch, delete | `machine_sync_mapi2capi_infrastructure.go:108,136,213` |
| Role: `openshift-cluster-api` | `infrastructure.cluster.x-k8s.io` | `awsmachines/status` | update, patch | `machine_sync_mapi2capi_infrastructure.go:194` |
| Role: `openshift-cluster-api` | `infrastructure.cluster.x-k8s.io` | `awsmachinetemplates` | get, list, watch, patch, deletecollection | `machineset_sync_controller.go:251,453,763,492` |
| Role: `openshift-cluster-api` | `""` | `pods` | get | audit2rbac confirmed — upstream CAPI controller-manager reads its own pod (`cluster_accessor.go:270`) |
| Role: `openshift-cluster-api` | `""` | `secrets` | get, list, watch, update, patch | `secret_sync_controller.go:73,90,161`, `kubeconfig.go:138,171,209` |
| Role: `openshift-cluster-api` | `""` | `events` | create | `machine_sync_controller.go:180`, `machineset_sync_controller.go:151` |
| Role: `openshift-cluster-api` | `coordination.k8s.io` | `leases` | get, update | Standard controller-runtime leader election |
| Role: `openshift-machine-api` | `machine.openshift.io` | `machines`, `machinesets` | get, list, watch, create, update, patch, delete | `machine_sync_controller.go:203,1391,1467,1039`, `machineset_sync_controller.go:190,943,1149` |
| Role: `openshift-machine-api` | `machine.openshift.io` | `machines/status`, `machinesets/status` | update, patch | `machine_sync_controller.go:1441`, `machineset_sync_controller.go:996`, `migratestatus.go:105` |
| Role: `openshift-machine-api` | `machine.openshift.io` | `controlplanemachinesets` | get, list, watch | `infracluster_controller.go:285-288,412` |
| Role: `openshift-machine-api` | `""` | `secrets` | get, list, watch | `secret_sync_controller.go:73` — controller-runtime cache needs list/watch for Get |
| Role: `openshift-machine-api` | `""` | `events` | create, patch | `machine_sync_controller.go:180` |

### Not observed by audit2rbac — justified by code evidence

| Scope | API Group | Resource | Verbs not observed | Justification |
|-------|-----------|----------|-------------------|---------------|
| Role: `openshift-cluster-api` | `cluster.x-k8s.io` | `clusters/finalizers`, `machines/finalizers`, `machinesets/finalizers` | update | Sync controllers set `blockOwnerDeletion: true` on ownerReferences (`machine_sync_controller.go:577,867`, `machineset_sync_controller.go:635`). Kubernetes requires `update` on the owner's `finalizers` subresource. Not captured by audit2rbac (validated by GC admission plugin, not a separate API call). |
| Role: `openshift-machine-api` | `machine.openshift.io` | `machines/finalizers`, `machinesets/finalizers` | update | Same `blockOwnerDeletion` pattern — MAPI machines set ownerReferences to MAPI machinesets (`machine_sync_controller.go:953-958`). |
| Role: `openshift-cluster-api` | `""` | `secrets` | create | `secret_sync_controller.go:152`, `azure.go:131` — creates secrets if not found. |
| Role: `openshift-cluster-api` | `""` | `events` | patch | Event recorder can patch existing events. Only `create` was observed. |
| Role: `openshift-cluster-api` | `coordination.k8s.io` | `leases` | create, list, watch, patch, delete | `create` only on first leader election. `list`/`watch`/`delete` are standard controller-runtime patterns. |
| Role: `openshift-cluster-api` | `infrastructure.cluster.x-k8s.io` | non-AWS resources | all | Platform-specific — identical code patterns to AWS. Can only be verified on respective platforms. |
| Role: `openshift-cluster-api` | `infrastructure.cluster.x-k8s.io` | `azureclusteridentities` | get, list, watch, create | Azure-only. `azure.go:142` Get (controller-runtime cache needs list/watch), `:188` Create. |
| Role: `openshift-cluster-api` | `infrastructure.cluster.x-k8s.io` | `awsmachinetemplates` | create, update, delete | SSA patch and DeleteAllOf were used instead. |
| Role: `openshift-machine-api` | `machine.openshift.io` | `machinesets` | create | `machineset_sync_controller.go` — creates MAPI MachineSets during CAPI→MAPI sync. Only MAPI→CAPI direction was tested. |
| Role: `kube-system` | `""` | `secrets` | list, watch | vSphere — controller-runtime cache (resourceNames not applicable to list/watch) |
| Role: `kube-system` | `""` | `secrets` (resourceNames: vsphere-creds) | get | vSphere credentials. `vsphere.go:157` — only exercised on vSphere clusters. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
