### PR TITLE
OCPBUGS-88036: Set cluster ownership tag on AzureCluster

### DIFF
--- a/pkg/controllers/infracluster/azure.go
+++ b/pkg/controllers/infracluster/azure.go
@@ -242,6 +242,16 @@ func (r *InfraClusterController) ensureAzureInfraCluster(ctx context.Context, ta
 
 // createNewAzureCluster creates a new Azure Infra Cluster.
 func (r *InfraClusterController) newAzureCluster(providerSpec *mapiv1beta1.AzureMachineProviderSpec, apiURL *url.URL, port int32, location string) *azurev1.AzureCluster {
+	tags := azurev1.Tags{}
+
+	if r.Infra.Status.PlatformStatus.Azure != nil {
+		for _, t := range r.Infra.Status.PlatformStatus.Azure.ResourceTags {
+			tags[t.Key] = t.Value
+		}
+	}
+
+	tags[fmt.Sprintf("kubernetes.io_cluster.%s", r.Infra.Status.InfrastructureName)] = "owned"
+
 	return &azurev1.AzureCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      r.Infra.Status.InfrastructureName,
@@ -257,6 +267,7 @@ func (r *InfraClusterController) newAzureCluster(providerSpec *mapiv1beta1.Azure
 			AzureClusterClassSpec: azurev1.AzureClusterClassSpec{
 				Location:         location,
 				AzureEnvironment: "AzurePublicCloud",
+				AdditionalTags:   tags,
 				IdentityRef: &corev1.ObjectReference{
 					Name:      r.Infra.Status.InfrastructureName,
 					Namespace: r.CAPINamespace,


### PR DESCRIPTION
(damdo) Closing in favour of: https://github.com/openshift/cluster-capi-operator/pull/594

--

Set the kubernetes.io_cluster.<infraID>=owned tag on the AzureCluster object via AdditionalTags so that CAPI-created Azure resources are visible to the installer's destroy logic. Azure tag keys do not permit slashes, so underscores and a dot are used instead. Also propagate user-defined resource tags from
Infrastructure.Status.PlatformStatus.Azure.ResourceTags to match MAPI behaviour.

Without this tag, openshift-install destroy cluster cannot identify CAPI-created resources and they are leaked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic tagging support for Azure cluster infrastructure, including an "owned" tag and the ability to merge custom resource tags for better cluster organization and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->