### PR TITLE
OCPBUGS-88035: Add e2e test verifying CAPI EC2 instance ownership tag

### DIFF
--- a/e2e/aws_helpers.go
+++ b/e2e/aws_helpers.go
@@ -214,6 +214,26 @@ func compareInstances(awsClient *ec2.EC2, mapiMsName, capiMsName string) {
 	}
 }
 
+// verifyCAPIInstanceOwnershipTag asserts that a CAPI-created EC2 instance has the
+// kubernetes.io/cluster/<infraName>=owned tag that openshift-install destroy cluster
+// relies on to identify and clean up cloud resources.
+func verifyCAPIInstanceOwnershipTag(awsClient *ec2.EC2, capiMsName, infraName string) {
+	GinkgoHelper()
+	By("Verifying CAPI-created EC2 instance has cluster ownership tag")
+
+	Expect(awsClient).ToNot(BeNil())
+	Expect(capiMsName).ToNot(BeEmpty())
+	Expect(infraName).ToNot(BeEmpty())
+
+	instance := getCAPICreatedInstance(awsClient, capiMsName)
+
+	expectedTagKey := fmt.Sprintf("kubernetes.io/cluster/%s", infraName)
+	Expect(instance.Tags).To(ContainElement(SatisfyAll(
+		HaveField("Key", HaveValue(Equal(expectedTagKey))),
+		HaveField("Value", HaveValue(Equal("owned"))),
+	)), "expected EC2 instance to have tag %s=owned for cluster destroy to find it", expectedTagKey)
+}
+
 // deleteAWSMachineTemplates deletes the specified AWSMachineTemplates.
 func deleteAWSMachineTemplates(ctx context.Context, cl client.Client, templates ...*awsv1.AWSMachineTemplate) {
 	GinkgoHelper()

--- a/e2e/aws_test.go
+++ b/e2e/aws_test.go
@@ -79,5 +79,6 @@ var _ = Describe("Cluster API AWS MachineSet", Ordered, func() {
 		framework.WaitForMachineSet(ctx, cl, machineSet.Name, machineSet.Namespace, framework.WaitLong)
 
 		compareInstances(awsClient, mapiDefaultMS.Name, "aws-machineset")
+		verifyCAPIInstanceOwnershipTag(awsClient, "aws-machineset", clusterName)
 	})
 })


### PR DESCRIPTION
Verify that a CAPI-created EC2 instance has the
kubernetes.io/cluster/<infraID>=owned tag that openshift-install destroy cluster relies on to identify and clean up cloud resources.

CAPA may already add this tag automatically via its Build() + WithCloudProvider() tag pipeline. This test confirms whether the tag is present without any explicit AdditionalTags on the AWSCluster object.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced AWS end-to-end testing with additional verification to confirm EC2 instances are properly tagged with cluster ownership information. The test now validates that instances provisioned through the cluster API provider contain the required Kubernetes cluster ownership tag, ensuring proper resource management, accurate tracking of cluster-owned resources, and compliance with tagging standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->