### PR TITLE
OCPCLOUD-3541: Use feature gates consistently

### DIFF
--- a/cmd/capi-controllers/main.go
+++ b/cmd/capi-controllers/main.go
@@ -149,7 +149,7 @@ func main() {
 func setupPlatformReconcilers(log logr.Logger, mgr manager.Manager, operatorConfig commoncmdoptions.OperatorConfig, infra *configv1.Infrastructure, platform configv1.PlatformType) error {
 	// Only setup reconcile controllers and webhooks when the platform is supported.
 	// This avoids unnecessary CAPI providers discovery, installs and reconciles when the platform is not supported.
-	infraTypes, _, err := util.GetCAPITypesForInfrastructure(infra)
+	infraTypes, err := util.GetCAPITypesForInfrastructure(infra)
 	if err != nil {
 		if errors.Is(err, util.ErrUnsupportedPlatform) {
 			log.Info("Detected platform is not supported, skipping capi controllers setup", "platform", platform)

--- a/cmd/capi-installer/main.go
+++ b/cmd/capi-installer/main.go
@@ -35,6 +35,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 
+	"github.com/go-logr/logr"
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 
@@ -94,7 +95,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := setupControllers(ctx, mgr, operatorConfig, *providerImageDir); err != nil {
+	if err := setupControllers(ctx, log, mgr, operatorConfig, *providerImageDir, cancel); err != nil {
 		log.Error(err, "unable to setup controllers")
 		os.Exit(1)
 	}
@@ -107,7 +108,12 @@ func main() {
 	}
 }
 
-func setupControllers(ctx context.Context, mgr ctrl.Manager, operatorConfig commoncmdoptions.OperatorConfig, providerImageDir string) error {
+func setupControllers(ctx context.Context, log logr.Logger, mgr ctrl.Manager, operatorConfig commoncmdoptions.OperatorConfig, providerImageDir string, cancel context.CancelFunc) error {
+	featureGates, err := util.GetFeatureGates(ctx, log, managerName, mgr.GetConfig(), cancel)
+	if err != nil {
+		return fmt.Errorf("unable to get feature gates: %w", err)
+	}
+
 	allProviderProfiles, err := loadProviderImages(ctx, mgr, providerImageDir)
 	if err != nil {
 		return err
@@ -125,7 +131,6 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, operatorConfig comm
 		}
 	}
 
-	log := ctrl.LoggerFrom(ctx)
 	for _, profile := range allProviderProfiles {
 		log.Info("loaded provider profile", "name", profile.Name, "imageRef", profile.ImageRef, "profile", profile.Profile)
 	}
@@ -134,6 +139,7 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, operatorConfig comm
 		Client:           mgr.GetClient(),
 		ProviderProfiles: currentReleaseProfiles,
 		ReleaseVersion:   util.GetReleaseVersion(),
+		FeatureGates:     featureGates,
 	}).SetupWithManager(mgr, operatorConfig.TLSOptions); err != nil {
 		log.Error(err, "unable to create revision controller", "controller", "RevisionController")
 		return fmt.Errorf("unable to create revision controller: %w", err)

--- a/cmd/capi-operator/main.go
+++ b/cmd/capi-operator/main.go
@@ -33,7 +33,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/go-logr/logr"
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 
@@ -87,7 +86,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := setupControllers(ctx, log, mgr, operatorConfig, cancel); err != nil {
+	if err := setupControllers(ctx, mgr, operatorConfig); err != nil {
 		log.Error(err, "unable to setup controllers")
 		os.Exit(1)
 	}
@@ -100,7 +99,7 @@ func main() {
 	}
 }
 
-func setupControllers(ctx context.Context, log logr.Logger, mgr ctrl.Manager, operatorConfig commoncmdoptions.OperatorConfig, cancel context.CancelFunc) error {
+func setupControllers(ctx context.Context, mgr ctrl.Manager, operatorConfig commoncmdoptions.OperatorConfig) error {
 	infra, err := util.GetInfra(ctx, mgr.GetAPIReader())
 	if err != nil {
 		return fmt.Errorf("unable to get infrastructure: %w", err)
@@ -111,17 +110,9 @@ func setupControllers(ctx context.Context, log logr.Logger, mgr ctrl.Manager, op
 		return fmt.Errorf("unable to get platform: %w", err)
 	}
 
-	featureGates, err := util.GetFeatureGates(ctx, log, managerName, mgr.GetConfig(), cancel)
-	if err != nil {
-		return fmt.Errorf("unable to get feature gates: %w", err)
-	}
-
-	supportedPlatform := util.IsCAPIEnabledForPlatform(featureGates, infra.Status.PlatformStatus.Type)
-
 	if err := (&clusteroperator.ClusterOperatorController{
 		ClusterOperatorStatusClient: operatorConfig.GetClusterOperatorStatusClient(mgr, platform, "clusteroperator"),
 		Scheme:                      mgr.GetScheme(),
-		IsUnsupportedPlatform:       !supportedPlatform,
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create clusteroperator controller: %w", err)
 	}
@@ -132,12 +123,10 @@ func setupControllers(ctx context.Context, log logr.Logger, mgr ctrl.Manager, op
 		return fmt.Errorf("unable to get container image: %w", err)
 	}
 
-	// Setup InstallerDeploymentController (runs on all platforms)
 	if err := (&installerdeployment.InstallerDeploymentReconciler{
-		Client:            mgr.GetClient(),
-		Namespace:         *operatorConfig.OperatorNamespace,
-		ContainerImage:    containerImage,
-		SupportedPlatform: supportedPlatform,
+		Client:         mgr.GetClient(),
+		Namespace:      *operatorConfig.OperatorNamespace,
+		ContainerImage: containerImage,
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create installerdeployment controller: %w", err)
 	}

--- a/cmd/machine-api-migration/main.go
+++ b/cmd/machine-api-migration/main.go
@@ -24,17 +24,11 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	mapiv1alpha1 "github.com/openshift/api/machine/v1alpha1"
 	mapiv1beta1 "github.com/openshift/api/machine/v1beta1"
-	configv1client "github.com/openshift/client-go/config/clientset/versioned"
-	configinformers "github.com/openshift/client-go/config/informers/externalversions"
-	"k8s.io/klog"
-	"k8s.io/utils/clock"
 	awsv1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	openstackv1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 
 	"github.com/openshift/api/features"
-	featuregates "github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
-	"github.com/openshift/library-go/pkg/operator/events"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -52,11 +46,6 @@ import (
 
 const (
 	managerName = "machine-api-migration"
-)
-
-var (
-	// errTimedOutWaitingForFeatureGates is returned when the feature gates are not initialized within the timeout.
-	errTimedOutWaitingForFeatureGates = errors.New("timed out waiting for feature gates to be initialized")
 )
 
 func initScheme(scheme *runtime.Scheme) {
@@ -91,31 +80,19 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := checkFeatureGates(ctx, log, mgr); err != nil {
-		log.Error(err, "unable to check feature gates")
-		os.Exit(1)
-	}
-
-	infra, err := util.GetInfra(ctx, mgr.GetAPIReader())
+	// Get controllers to add to the manager.
+	//
+	// This will return an empty map if the platform does not support
+	// MachineAPIMigration. In this case we still run the manager, but without
+	// any controllers. This will shut down cleanly when the pod is killed, but
+	// otherwise do nothing.
+	controllers, err := getControllers(ctx, log, mgr, operatorConfig, cancel)
 	if err != nil {
-		log.Error(err, "unable to get infrastructure")
+		log.Error(err, "unable to get controllers")
 		os.Exit(1)
 	}
 
-	infraTypes, platform, err := util.GetCAPITypesForInfrastructure(infra)
-	if err != nil {
-		if errors.Is(err, util.ErrUnsupportedPlatform) {
-			log.Info("MachineAPIMigration not implemented for platform, nothing to do. Waiting for termination signal.", "platform", platform)
-			exitAfterTerminationSignal(ctx)
-		}
-
-		log.Error(err, "unable to get infrastructure types")
-		os.Exit(1)
-	}
-
-	checkPlatformSupported(ctx, log, platform)
-
-	for name, controller := range getControllers(operatorConfig, platform, infra, infraTypes) {
+	for name, controller := range controllers {
 		if err := controller.SetupWithManager(mgr); err != nil {
 			log.Error(err, "failed to set up reconciler with manager", "reconciler", name)
 			os.Exit(1)
@@ -130,41 +107,50 @@ func main() {
 	}
 }
 
-func checkFeatureGates(ctx context.Context, log logr.Logger, mgr ctrl.Manager) error {
-	featureGateAccessor, err := getFeatureGates(ctx, mgr)
-	if err != nil {
-		return fmt.Errorf("unable to get feature gates: %w", err)
-	}
-
-	currentFeatureGates, err := featureGateAccessor.CurrentFeatureGates()
-	if err != nil {
-		return fmt.Errorf("unable to get current feature gates: %w", err)
-	}
-
-	if !currentFeatureGates.Enabled(features.FeatureGateMachineAPIMigration) {
-		log.Info("MachineAPIMigration feature gate is not enabled, nothing to do. Waiting for termination signal.")
-		exitAfterTerminationSignal(ctx)
-	}
-
-	return nil
-}
-
-func checkPlatformSupported(ctx context.Context, log logr.Logger, platform configv1.PlatformType) {
-	switch platform {
-	case configv1.AWSPlatformType, configv1.OpenStackPlatformType:
-		log.Info("starting controllers", "platform", platform)
-
-	default:
-		log.Info("MachineAPIMigration not implemented for platform, nothing to do. Waiting for termination signal.", "platform", platform)
-		exitAfterTerminationSignal(ctx)
-	}
-}
-
 type controller interface {
 	SetupWithManager(mgr ctrl.Manager) error
 }
 
-func getControllers(opts commoncmdoptions.OperatorConfig, platform configv1.PlatformType, infra *configv1.Infrastructure, infraTypes util.InfraTypes) map[string]controller {
+func getControllers(ctx context.Context, log logr.Logger, mgr ctrl.Manager, opts commoncmdoptions.OperatorConfig, cancel context.CancelFunc) (map[string]controller, error) {
+	featureGates, err := util.GetFeatureGates(ctx, log, managerName, mgr.GetConfig(), cancel)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get feature gates: %w", err)
+	}
+
+	if !featureGates.Enabled(features.FeatureGateMachineAPIMigration) {
+		log.Info("MachineAPIMigration feature gate is not enabled, nothing to do. Waiting for termination signal.")
+		return map[string]controller{}, nil
+	}
+
+	infra, err := util.GetInfra(ctx, mgr.GetAPIReader())
+	if err != nil {
+		return nil, fmt.Errorf("unable to get infrastructure: %w", err)
+	}
+
+	platform, err := util.GetPlatformFromInfra(infra)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get platform from infrastructure: %w", err)
+	}
+
+	if !util.IsMAPIMigrationEnabledForPlatform(featureGates, platform) {
+		log.Info("MachineAPIMigration not implemented for platform, nothing to do. Waiting for termination signal.", "platform", platform)
+		return map[string]controller{}, nil
+	}
+
+	infraTypes, err := util.GetCAPITypesForInfrastructure(infra)
+	if err != nil {
+		if errors.Is(err, util.ErrUnsupportedPlatform) {
+			log.Info("MachineAPIMigration not implemented for platform, nothing to do. Waiting for termination signal.", "platform", platform)
+			return map[string]controller{}, nil
+		}
+
+		return nil, fmt.Errorf("unable to get infrastructure types: %w", err)
+	}
+
+	return allControllers(infra, platform, infraTypes, opts), nil
+}
+
+func allControllers(infra *configv1.Infrastructure, platform configv1.PlatformType, infraTypes util.InfraTypes, opts commoncmdoptions.OperatorConfig) map[string]controller {
 	return map[string]controller{
 		"machine sync": &machinesync.MachineSyncReconciler{
 			Infra:      infra,
@@ -199,50 +185,6 @@ func getControllers(opts commoncmdoptions.OperatorConfig, platform configv1.Plat
 			CAPINamespace: *opts.CAPINamespace,
 		},
 	}
-}
-
-// exitAfterTerminationSignal waits until our process receives a termination
-// signal, then exits without an error.
-// It is used when we are running on a cluster where this manager is not
-// required. We don't want to exit immediately because we would be restarted,
-// which is not required.
-func exitAfterTerminationSignal(ctx context.Context) {
-	<-ctx.Done()
-	os.Exit(0)
-}
-
-// getFeatureGates is used to fetch the current feature gates from the cluster.
-// We use this to check if the machine api migration is actually enabled or not.
-func getFeatureGates(ctx context.Context, mgr ctrl.Manager) (featuregates.FeatureGateAccess, error) {
-	desiredVersion := util.GetReleaseVersion()
-	missingVersion := "0.0.1-snapshot"
-
-	configClient, err := configv1client.NewForConfig(mgr.GetConfig())
-	if err != nil {
-		return nil, fmt.Errorf("failed to create config client: %w", err)
-	}
-
-	configInformers := configinformers.NewSharedInformerFactory(configClient, 10*time.Minute)
-
-	// By default, this will exit(0) if the featuregates change.
-	featureGateAccessor := featuregates.NewFeatureGateAccess(
-		desiredVersion, missingVersion,
-		configInformers.Config().V1().ClusterVersions(),
-		configInformers.Config().V1().FeatureGates(),
-		events.NewLoggingEventRecorder("machineapimigration", clock.RealClock{}),
-	)
-	go featureGateAccessor.Run(ctx)
-	go configInformers.Start(ctx.Done())
-
-	select {
-	case <-featureGateAccessor.InitialFeatureGatesObserved():
-		featureGates, _ := featureGateAccessor.CurrentFeatureGates()
-		klog.Infof("FeatureGates initialized: %v", featureGates.KnownFeatures())
-	case <-time.After(1 * time.Minute):
-		return nil, errTimedOutWaitingForFeatureGates
-	}
-
-	return featureGateAccessor, nil
 }
 
 func getDefaultCacheOptions(capiNamespace, mapiNamespace string, sync time.Duration) cache.Options {

--- a/e2e/webhook_test.go
+++ b/e2e/webhook_test.go
@@ -116,7 +116,7 @@ var _ = Describe("Cluster API Webhook Validation Inside Managed Namespace", Seri
 	BeforeEach(func() {
 		skipUnlessClusterAPIClusterCRD()
 
-		_, _, err := util.GetCAPITypesForInfrastructure(infra)
+		_, err := util.GetCAPITypesForInfrastructure(infra)
 		if errors.Is(err, util.ErrUnsupportedPlatform) {
 			Skip("Platform is not supported for Cluster API. Skip webhook validation checks.")
 		}

--- a/go.mod
+++ b/go.mod
@@ -82,7 +82,6 @@ require (
 	k8s.io/apiserver v0.36.2
 	k8s.io/client-go v0.36.2
 	k8s.io/component-base v0.36.2
-	k8s.io/klog v1.0.0
 	k8s.io/klog/v2 v2.140.0
 	k8s.io/kubernetes v1.36.2
 	k8s.io/utils v0.0.0-20260707023825-cf1189d6abe3

--- a/go.sum
+++ b/go.sum
@@ -207,7 +207,6 @@ github.com/gkampitakis/go-snaps v0.5.15 h1:amyJrvM1D33cPHwVrjo9jQxX8g/7E2wYdZ+01
 github.com/gkampitakis/go-snaps v0.5.15/go.mod h1:HNpx/9GoKisdhw9AFOBT1N7DBs9DiHo/hGheFGBZ+mc=
 github.com/go-critic/go-critic v0.14.3 h1:5R1qH2iFeo4I/RJU8vTezdqs08Egi4u5p6vOESA0pog=
 github.com/go-critic/go-critic v0.14.3/go.mod h1:xwntfW6SYAd7h1OqDzmN6hBX/JxsEKl5up/Y2bsxgVQ=
-github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -928,8 +927,6 @@ k8s.io/component-helpers v0.36.2 h1:YsqocS183ThSUw90OXsxkKxIgdQF4qWInwrn6pZdDH8=
 k8s.io/component-helpers v0.36.2/go.mod h1:YrHgzezjsyXAFq9+gKw6IbgJg7IHEUVwK41eEAiTRR4=
 k8s.io/controller-manager v0.36.2 h1:uQrvXNDPsjDy3q7cECuFufUfmWhjQQccvVoUGLXcQPw=
 k8s.io/controller-manager v0.36.2/go.mod h1:VGcOtE1E71vmt3tDIAdG/rQxzwNb6YE5us+paWyZtOQ=
-k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
-k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.140.0 h1:Tf+J3AH7xnUzZyVVXhTgGhEKnFqye14aadWv7bzXdzc=
 k8s.io/klog/v2 v2.140.0/go.mod h1:o+/RWfJ6PwpnFn7OyAG3QnO47BFsymfEfrz6XyYSSp0=
 k8s.io/kms v0.36.2 h1:o0l8zMRecm38k5NyRnO/3+2YA/MR6TMGcc3KQZA76hI=

--- a/pkg/controllers/clusteroperator/clusteroperator_controller.go
+++ b/pkg/controllers/clusteroperator/clusteroperator_controller.go
@@ -31,15 +31,13 @@ import (
 )
 
 const (
-	capiUnsupportedPlatformMsg = "Cluster API is not yet implemented on this platform"
-	controllerName             = "ClusterOperatorController"
+	controllerName = "ClusterOperatorController"
 )
 
 // ClusterOperatorController watches and keeps the cluster-api ClusterObject up to date.
 type ClusterOperatorController struct {
 	operatorstatus.ClusterOperatorStatusClient
-	Scheme                *runtime.Scheme
-	IsUnsupportedPlatform bool
+	Scheme *runtime.Scheme
 }
 
 // Reconcile reconciles the cluster-api ClusterOperator object.
@@ -47,19 +45,11 @@ func (r *ClusterOperatorController) Reconcile(ctx context.Context, req ctrl.Requ
 	log := ctrl.LoggerFrom(ctx).WithName(controllerName)
 	log.Info(fmt.Sprintf("Reconciling %q ClusterObject", controllers.ClusterOperatorName))
 
-	message := func() string {
-		if r.IsUnsupportedPlatform {
-			return capiUnsupportedPlatformMsg
-		}
-
-		return ""
-	}()
-
 	// TODO: wrap this into status aggregation logic to get these conditions to
 	// represent the meaningful aggregation of all other controller statuses.
 	// We should also only update the version after the aggregator confirms
 	// all controllers have succeeded in the new version.
-	if err := r.SetStatusAvailable(ctx, message, operatorstatus.WithVersions(r.OperandVersions())); err != nil {
+	if err := r.SetStatusAvailable(ctx, "", operatorstatus.WithVersions(r.OperandVersions())); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to set conditions for %q ClusterObject: %w", controllers.ClusterOperatorName, err)
 	}
 

--- a/pkg/controllers/clusteroperator/clusteroperator_controller_test.go
+++ b/pkg/controllers/clusteroperator/clusteroperator_controller_test.go
@@ -77,7 +77,7 @@ var _ = Describe("ClusterOperator controller", func() {
 
 	Context("With a supported platform", func() {
 		JustBeforeEach(func() {
-			mgrCancel, mgrDone = startManager(false)
+			mgrCancel, mgrDone = startManager()
 		})
 
 		JustAfterEach(func() {
@@ -122,53 +122,9 @@ var _ = Describe("ClusterOperator controller", func() {
 			)
 		})
 	})
-
-	Context("With an unsupported platform", func() {
-		JustBeforeEach(func() {
-			mgrCancel, mgrDone = startManager(true)
-		})
-
-		JustAfterEach(func() {
-			stopManager()
-		})
-
-		It("should update the ClusterOperator status with an 'unsupported' message", func() {
-			Eventually(komega.Object(configv1resourcebuilder.ClusterOperator().WithName(controllers.ClusterOperatorName).Build())).
-				Should(HaveField("Status.Conditions", SatisfyAll(
-					ContainElement(And(HaveField("Type", Equal(configv1.OperatorAvailable)), HaveField("Status", Equal(configv1.ConditionTrue)),
-						HaveField("Message", Equal("Cluster API is not yet implemented on this platform")))),
-					ContainElement(And(HaveField("Type", Equal(configv1.OperatorProgressing)), HaveField("Status", Equal(configv1.ConditionFalse)))),
-					ContainElement(And(HaveField("Type", Equal(configv1.OperatorDegraded)), HaveField("Status", Equal(configv1.ConditionFalse)))),
-					ContainElement(And(HaveField("Type", Equal(configv1.OperatorUpgradeable)), HaveField("Status", Equal(configv1.ConditionTrue)))),
-				)), "should match the expected ClusterOperator status conditions")
-		})
-
-		It("should update the ClusterOperator status version to the desired one", func() {
-			Eventually(komega.Object(configv1resourcebuilder.ClusterOperator().WithName(controllers.ClusterOperatorName).Build())).
-				Should(HaveField("Status.Versions", ContainElement(SatisfyAll(
-					HaveField("Name", Equal("operator")),
-					HaveField("Version", Equal(desiredOperatorReleaseVersion)),
-				))), "should match the expected ClusterOperator status versions")
-		})
-
-		It("should update the ClusterOperator status version to the desired one when an incorrect one is present", func() {
-			By("Setting the ClusterOperator status version to an incorrect one")
-
-			patchBase := client.MergeFrom(capiClusterOperator.DeepCopy())
-			capiClusterOperator.Status.Versions = []configv1.OperandVersion{{Name: "operator", Version: "incorrect"}}
-			Expect(cl.Status().Patch(ctx, capiClusterOperator, patchBase)).To(Succeed())
-
-			By("Checking the conditions are as expected")
-			Eventually(komega.Object(configv1resourcebuilder.ClusterOperator().WithName(controllers.ClusterOperatorName).Build())).
-				Should(HaveField("Status.Versions", ContainElement(SatisfyAll(
-					HaveField("Name", Equal("operator")),
-					HaveField("Version", Equal(desiredOperatorReleaseVersion)),
-				))))
-		})
-	})
 })
 
-func startManager(isUnsupportedPlatform bool) (context.CancelFunc, chan struct{}) {
+func startManager() (context.CancelFunc, chan struct{}) {
 	mgrCtx, mgrCancel := context.WithCancel(context.Background())
 	mgrDone := make(chan struct{})
 
@@ -185,7 +141,6 @@ func startManager(isUnsupportedPlatform bool) (context.CancelFunc, chan struct{}
 
 	r := &ClusterOperatorController{
 		ClusterOperatorStatusClient: operatorstatus.ClusterOperatorStatusClient{Client: cl, ReleaseVersion: desiredOperatorReleaseVersion},
-		IsUnsupportedPlatform:       isUnsupportedPlatform,
 	}
 	Expect(r.SetupWithManager(mgr)).To(Succeed(), "Reconciler should be able to setup with manager")
 

--- a/pkg/controllers/installerdeployment/controller.go
+++ b/pkg/controllers/installerdeployment/controller.go
@@ -45,21 +45,14 @@ const (
 // InstallerDeploymentReconciler reconciles the capi-installer Deployment.
 type InstallerDeploymentReconciler struct {
 	client.Client
-	Namespace         string
-	ContainerImage    string
-	SupportedPlatform bool
+	Namespace      string
+	ContainerImage string
 }
 
 // Reconcile reconciles the capi-installer Deployment by reading provider image refs
 // from the ConfigMap and ClusterAPI revisions, then applying the desired deployment.
-// On unsupported platforms, it deletes the deployment if it exists.
 func (r *InstallerDeploymentReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx).WithName("InstallerDeploymentReconciler")
-
-	// If platform is unsupported, delete deployment.
-	if !r.SupportedPlatform {
-		return r.deleteDeploymentIfExists(ctx, log)
-	}
 
 	// Read ConfigMap with current-release provider image refs.
 	configMap, err := r.getConfigMap(ctx, log)
@@ -194,30 +187,4 @@ func (r *InstallerDeploymentReconciler) mapClusterAPIToReconcile(ctx context.Con
 	}
 
 	return nil
-}
-
-// deleteDeploymentIfExists deletes the capi-installer Deployment if it exists.
-// Returns no error if the deployment doesn't exist.
-func (r *InstallerDeploymentReconciler) deleteDeploymentIfExists(ctx context.Context, log logr.Logger) (reconcile.Result, error) {
-	deployment := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      deploymentName,
-			Namespace: r.Namespace,
-		},
-	}
-
-	err := r.Delete(ctx, deployment)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			log.V(1).Info("Deployment does not exist, nothing to delete")
-
-			return reconcile.Result{}, nil
-		}
-
-		return reconcile.Result{}, fmt.Errorf("failed to delete Deployment: %w", err)
-	}
-
-	log.Info("Deleted capi-installer Deployment on unsupported platform")
-
-	return reconcile.Result{}, nil
 }

--- a/pkg/controllers/installerdeployment/controller_test.go
+++ b/pkg/controllers/installerdeployment/controller_test.go
@@ -64,10 +64,9 @@ var _ = Describe("InstallerDeployment Controller", func() {
 
 		// Create the InstallerDeploymentReconciler.
 		reconciler = &InstallerDeploymentReconciler{
-			Client:            cl,
-			Namespace:         namespace,
-			ContainerImage:    "quay.io/openshift/cluster-capi-operator:test",
-			SupportedPlatform: true,
+			Client:         cl,
+			Namespace:      namespace,
+			ContainerImage: "quay.io/openshift/cluster-capi-operator:test",
 		}
 
 		// Create ConfigMap with provider image refs.
@@ -229,41 +228,6 @@ var _ = Describe("InstallerDeployment Controller", func() {
 
 			_, err = reconciler.Reconcile(ctx, reconcile.Request{})
 			Expect(err).NotTo(HaveOccurred())
-		})
-	})
-
-	Context("when platform is unsupported", func() {
-		It("should delete Deployment when it exists", func() {
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{})
-			Expect(err).NotTo(HaveOccurred())
-
-			deployment := &appsv1.Deployment{}
-
-			Eventually(func() error {
-				return cl.Get(ctx, client.ObjectKey{Name: deploymentName, Namespace: namespace}, deployment)
-			}).WithTimeout(testTimeout).WithPolling(testInterval).Should(Succeed())
-
-			reconciler.SupportedPlatform = false
-
-			_, err = reconciler.Reconcile(ctx, reconcile.Request{})
-			Expect(err).NotTo(HaveOccurred())
-
-			Eventually(func() bool {
-				err := cl.Get(ctx, client.ObjectKey{Name: deploymentName, Namespace: namespace}, deployment)
-
-				return err != nil
-			}).WithTimeout(testTimeout).WithPolling(testInterval).Should(BeTrue())
-		})
-
-		It("should not error when Deployment does not exist", func() {
-			reconciler.SupportedPlatform = false
-
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{})
-			Expect(err).NotTo(HaveOccurred())
-
-			deployment := &appsv1.Deployment{}
-			err = cl.Get(ctx, client.ObjectKey{Name: deploymentName, Namespace: namespace}, deployment)
-			Expect(err).To(HaveOccurred())
 		})
 	})
 })

--- a/pkg/controllers/machinesetsync/machineset_sync_controller_test.go
+++ b/pkg/controllers/machinesetsync/machineset_sync_controller_test.go
@@ -251,7 +251,7 @@ var _ = Describe("With a running MachineSetSync controller", func() {
 
 		infra := configv1resourcebuilder.Infrastructure().
 			AsAWS("cluster", "us-east-1").WithInfrastructureName(infrastructureName).Build()
-		infraTypes, _, err := util.GetCAPITypesForInfrastructure(infra)
+		infraTypes, err := util.GetCAPITypesForInfrastructure(infra)
 		Expect(err).ToNot(HaveOccurred(), "InfraTypes should be able to be created")
 
 		reconciler = &MachineSetSyncReconciler{

--- a/pkg/controllers/machinesync/aws_test.go
+++ b/pkg/controllers/machinesync/aws_test.go
@@ -126,7 +126,7 @@ var _ = Describe("AWS load balancer validation during MAPI->CAPI conversion", fu
 		Expect(err).ToNot(HaveOccurred())
 
 		infra := configv1resourcebuilder.Infrastructure().AsAWS("cluster", "us-east-1").WithInfrastructureName(infrastructureName).Build()
-		infraTypes, _, err := util.GetCAPITypesForInfrastructure(infra)
+		infraTypes, err := util.GetCAPITypesForInfrastructure(infra)
 		Expect(err).ToNot(HaveOccurred(), "InfraTypes should be able to be created")
 
 		reconciler = &MachineSyncReconciler{

--- a/pkg/controllers/machinesync/machine_sync_controller_test.go
+++ b/pkg/controllers/machinesync/machine_sync_controller_test.go
@@ -321,7 +321,7 @@ var _ = Describe("With a running MachineSync Reconciler", func() {
 
 		infra := configv1resourcebuilder.Infrastructure().
 			AsAWS("cluster", "us-east-1").WithInfrastructureName(infrastructureName).Build()
-		infraTypes, _, err := util.GetCAPITypesForInfrastructure(infra)
+		infraTypes, err := util.GetCAPITypesForInfrastructure(infra)
 		Expect(err).ToNot(HaveOccurred(), "InfraTypes should be able to be created")
 
 		reconciler = &MachineSyncReconciler{

--- a/pkg/controllers/revision/helpers_test.go
+++ b/pkg/controllers/revision/helpers_test.go
@@ -31,9 +31,11 @@ import (
 	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
 
 	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/api/features"
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	"github.com/openshift/cluster-capi-operator/pkg/providerimages"
 	"github.com/openshift/cluster-capi-operator/pkg/test"
+	featuregates "github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 )
 
 // Helper to start and stop a manager for a test.
@@ -44,7 +46,31 @@ type managerWrapper struct {
 	done   chan struct{}
 }
 
-func newManagerWrapper(providerImgs []providerimages.ProviderImageManifests, tlsOptions ...func(config *tls.Config)) *managerWrapper {
+// newFeatureGate constructs a featuregates.FeatureGate with the 7 CAPI platform
+// gates classified as enabled or disabled based on the provided list.
+func newFeatureGate(enabled ...configv1.FeatureGateName) featuregates.FeatureGate {
+	allCAPIPlatformGates := []configv1.FeatureGateName{
+		features.FeatureGateClusterAPIMachineManagementAWS,
+		features.FeatureGateClusterAPIMachineManagementAzure,
+		features.FeatureGateClusterAPIMachineManagementBareMetal,
+		features.FeatureGateClusterAPIMachineManagementGCP,
+		features.FeatureGateClusterAPIMachineManagementPowerVS,
+		features.FeatureGateClusterAPIMachineManagementOpenStack,
+		features.FeatureGateClusterAPIMachineManagementVSphere,
+	}
+
+	var disabled []configv1.FeatureGateName
+
+	for _, g := range allCAPIPlatformGates {
+		if !slices.Contains(enabled, g) {
+			disabled = append(disabled, g)
+		}
+	}
+
+	return featuregates.NewFeatureGate(enabled, disabled)
+}
+
+func newManagerWrapper(providerImgs []providerimages.ProviderImageManifests, fg featuregates.FeatureGate, tlsOptions ...func(config *tls.Config)) *managerWrapper {
 	// Don't use the BeforeEach context because it will be cancelled before the test starts.
 	ctx := context.Background()
 
@@ -73,6 +99,7 @@ func newManagerWrapper(providerImgs []providerimages.ProviderImageManifests, tls
 		Client:           mgr.GetClient(),
 		ProviderProfiles: imgs,
 		ReleaseVersion:   "4.18.0",
+		FeatureGates:     fg,
 	}).SetupWithManager(mgr, tlsOptions)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/controllers/revision/revision_controller.go
+++ b/pkg/controllers/revision/revision_controller.go
@@ -30,6 +30,7 @@ import (
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	operatorv1alpha1ac "github.com/openshift/client-go/operator/applyconfigurations/operator/v1alpha1"
 	libgocrypto "github.com/openshift/library-go/pkg/crypto"
+	featuregates "github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -65,6 +66,7 @@ type RevisionController struct {
 	client.Client
 	ProviderProfiles []providerimages.ProviderImageManifests
 	ReleaseVersion   string
+	FeatureGates     featuregates.FeatureGate
 
 	// manifestSubstitutions is derived from TLSProfileSpec during SetupWithManager.
 	manifestSubstitutions map[string]string
@@ -241,12 +243,19 @@ func (r *RevisionController) writeRevisions(ctx context.Context, log logr.Logger
 
 // buildComponentList builds an ordered list of provider components for the
 // given platform. Components are ordered by install order, then platform, then
-// name. Providers that don't match the current platform are filtered out.
+// name. Providers that don't match the current platform or whose platform
+// feature gate is not enabled are filtered out.
 func (r *RevisionController) buildComponentList(platform configv1.PlatformType) []providerimages.ProviderImageManifests {
+	platformEnabled := util.IsCAPIEnabledForPlatform(r.FeatureGates, platform)
+
 	// Iterate over only providers that have either no platform restriction, or
-	// match the current platform.
+	// match the current platform and whose feature gate is enabled.
 	componentsByPlatform := util.IterFilter(slices.Values(r.ProviderProfiles), func(provider providerimages.ProviderImageManifests) bool {
-		return provider.OCPPlatform == "" || provider.OCPPlatform == platform
+		if provider.OCPPlatform == "" {
+			return true
+		}
+
+		return platformEnabled && provider.OCPPlatform == platform
 	})
 
 	// Sort components by install order, then platform, then name.

--- a/pkg/controllers/revision/revision_controller_test.go
+++ b/pkg/controllers/revision/revision_controller_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/api/features"
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -58,10 +59,11 @@ const (
 
 func TestBuildComponentList(t *testing.T) {
 	tests := []struct {
-		name          string
-		providers     []providerimages.ProviderImageManifests
-		platform      configv1.PlatformType
-		expectedNames []string
+		name                string
+		providers           []providerimages.ProviderImageManifests
+		platform            configv1.PlatformType
+		enabledFeatureGates []configv1.FeatureGateName
+		expectedNames       []string
 	}{
 		{
 			name: "orders components by type and platform scope",
@@ -71,7 +73,8 @@ func TestBuildComponentList(t *testing.T) {
 				{ProviderMetadata: providerimages.ProviderMetadata{Name: "infra-global", InstallOrder: 20}},
 				{ProviderMetadata: providerimages.ProviderMetadata{Name: "core-aws", InstallOrder: 10, OCPPlatform: configv1.AWSPlatformType}},
 			},
-			platform: configv1.AWSPlatformType,
+			platform:            configv1.AWSPlatformType,
+			enabledFeatureGates: []configv1.FeatureGateName{features.FeatureGateClusterAPIMachineManagementAWS},
 			// Expected order: core+global, core+platform, infra+global, infra+platform
 			expectedNames: []string{"core", "core-aws", "infra-global", "infra-aws"},
 		},
@@ -83,14 +86,16 @@ func TestBuildComponentList(t *testing.T) {
 				{ProviderMetadata: providerimages.ProviderMetadata{Name: "infra-gcp", InstallOrder: 20, OCPPlatform: configv1.GCPPlatformType}},
 				{ProviderMetadata: providerimages.ProviderMetadata{Name: "infra-azure", InstallOrder: 20, OCPPlatform: configv1.AzurePlatformType}},
 			},
-			platform:      configv1.AWSPlatformType,
-			expectedNames: []string{"core", "infra-aws"},
+			platform:            configv1.AWSPlatformType,
+			enabledFeatureGates: []configv1.FeatureGateName{features.FeatureGateClusterAPIMachineManagementAWS},
+			expectedNames:       []string{"core", "infra-aws"},
 		},
 		{
-			name:          "returns empty list when no providers",
-			providers:     []providerimages.ProviderImageManifests{},
-			platform:      configv1.AWSPlatformType,
-			expectedNames: []string{},
+			name:                "returns empty list when no providers",
+			providers:           []providerimages.ProviderImageManifests{},
+			platform:            configv1.AWSPlatformType,
+			enabledFeatureGates: []configv1.FeatureGateName{features.FeatureGateClusterAPIMachineManagementAWS},
+			expectedNames:       []string{},
 		},
 		{
 			name: "includes all global providers regardless of platform",
@@ -101,6 +106,17 @@ func TestBuildComponentList(t *testing.T) {
 			platform:      configv1.GCPPlatformType,
 			expectedNames: []string{"core", "addon"},
 		},
+		{
+			name: "excludes platform profiles when feature gate is disabled",
+			providers: []providerimages.ProviderImageManifests{
+				{ProviderMetadata: providerimages.ProviderMetadata{Name: "infra-aws", InstallOrder: 20, OCPPlatform: configv1.AWSPlatformType}},
+				{ProviderMetadata: providerimages.ProviderMetadata{Name: "core", InstallOrder: 10}},
+				{ProviderMetadata: providerimages.ProviderMetadata{Name: "infra-global", InstallOrder: 20}},
+				{ProviderMetadata: providerimages.ProviderMetadata{Name: "core-aws", InstallOrder: 10, OCPPlatform: configv1.AWSPlatformType}},
+			},
+			platform:      configv1.AWSPlatformType,
+			expectedNames: []string{"core", "infra-global"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -109,6 +125,7 @@ func TestBuildComponentList(t *testing.T) {
 
 			r := &RevisionController{
 				ProviderProfiles: tt.providers,
+				FeatureGates:     newFeatureGate(tt.enabledFeatureGates...),
 			}
 
 			components := r.buildComponentList(tt.platform)
@@ -131,7 +148,7 @@ var _ = Describe("RevisionController", Serial, func() {
 		createFixtures(ctx)
 
 		// Create manager and controller
-		mgr = newManagerWrapper(defaultProviderImgs)
+		mgr = newManagerWrapper(defaultProviderImgs, newFeatureGate(features.FeatureGateClusterAPIMachineManagementAWS))
 
 		DeferCleanup(func(ctx context.Context) {
 			mgr.stop()
@@ -218,7 +235,7 @@ var _ = Describe("RevisionController", Serial, func() {
 		originalRev1 := initialClusterAPI.Status.Revisions[0]
 
 		// Restart the manager with different provider images
-		mgr = newManagerWrapper(updatedProviderImgs)
+		mgr = newManagerWrapper(updatedProviderImgs, newFeatureGate(features.FeatureGateClusterAPIMachineManagementAWS))
 
 		// Wait for the controller to create the second revision
 		Eventually(kWithCtx(ctx).Object(clusterAPI)).
@@ -257,7 +274,7 @@ var _ = Describe("RevisionController", Serial, func() {
 		mgr.stop()
 
 		// Restart with only GCP providers on an AWS cluster — no providers match
-		mgr = newManagerWrapper(nonMatchingProviderImgs)
+		mgr = newManagerWrapper(nonMatchingProviderImgs, newFeatureGate(features.FeatureGateClusterAPIMachineManagementAWS))
 
 		// Wait for the controller to create the second revision
 		Eventually(kWithCtx(ctx).Object(clusterAPI)).
@@ -273,12 +290,34 @@ var _ = Describe("RevisionController", Serial, func() {
 		Expect(clusterAPI.Status.ObservedRevisionGeneration).To(Equal(clusterAPI.Generation))
 	}, defaultNodeTimeout)
 
+	It("excludes platform-specific components when feature gate is disabled", func(ctx context.Context) {
+		// Stop manager with default (matching) providers and enabled feature gate
+		mgr.stop()
+
+		// Restart with default providers (core + infra-aws) but no feature gates enabled
+		mgr = newManagerWrapper(defaultProviderImgs, newFeatureGate())
+
+		// Wait for the controller to create the second revision
+		Eventually(kWithCtx(ctx).Object(clusterAPI)).
+			WithContext(ctx).
+			Should(HaveField("Status.Revisions", HaveLen(2)))
+
+		// The new revision should have only the core (global) component
+		newRev := latestRevision(clusterAPI.Status.Revisions)
+		Expect(newRev.Components).To(HaveLen(1))
+		Expect(newRev.Components[0].Image.Ref).To(Equal(operatorv1alpha1.ImageDigestFormat(defaultProviderImgs[0].ImageRef)))
+
+		// DesiredRevision should point to the new revision
+		Expect(clusterAPI.Status.DesiredRevision).To(Equal(newRev.Name))
+		Expect(clusterAPI.Status.ObservedRevisionGeneration).To(Equal(clusterAPI.Generation))
+	}, defaultNodeTimeout)
+
 	It("trims old revisions when current matches latest", func(ctx context.Context) {
 		// BeforeEach created rev1 from defaultProviderImgs.
 		mgr.stop()
 
 		// Create rev2 with different content.
-		mgr = newManagerWrapper(updatedProviderImgs)
+		mgr = newManagerWrapper(updatedProviderImgs, newFeatureGate(features.FeatureGateClusterAPIMachineManagementAWS))
 
 		// Wait for the controller to create the second revision
 		Eventually(kWithCtx(ctx).Object(clusterAPI)).
@@ -316,7 +355,7 @@ var _ = Describe("RevisionController", Serial, func() {
 		Expect(cl.Status().Patch(ctx, clusterAPI, patch)).To(Succeed())
 
 		// Start with different content, producing a new revision.
-		mgr = newManagerWrapper(updatedProviderImgs)
+		mgr = newManagerWrapper(updatedProviderImgs, newFeatureGate(features.FeatureGateClusterAPIMachineManagementAWS))
 
 		Eventually(kWithCtx(ctx).Object(clusterAPI)).
 			WithContext(ctx).
@@ -384,7 +423,7 @@ var _ = Describe("RevisionController", Serial, func() {
 		mgr.stop()
 
 		// Restart with providers that have an invalid adopt-existing annotation value
-		mgr = newManagerWrapper(invalidAnnotationProviderImgs)
+		mgr = newManagerWrapper(invalidAnnotationProviderImgs, newFeatureGate(features.FeatureGateClusterAPIMachineManagementAWS))
 
 		waitForConditions(ctx,
 			test.HaveCondition(conditionTypeProgressing).
@@ -408,7 +447,7 @@ var _ = Describe("RevisionController waiting states", Serial, func() {
 		BeforeEach(func(ctx context.Context) {
 			createFixtures(ctx, withoutInfraStatus)
 
-			mgr := newManagerWrapper(defaultProviderImgs)
+			mgr := newManagerWrapper(defaultProviderImgs, newFeatureGate(features.FeatureGateClusterAPIMachineManagementAWS))
 
 			DeferCleanup(func(ctx context.Context) {
 				mgr.stop()
@@ -459,7 +498,7 @@ var _ = Describe("RevisionController waiting states", Serial, func() {
 		BeforeEach(func(ctx context.Context) {
 			createFixtures(ctx, withoutClusterAPI)
 
-			mgr := newManagerWrapper(defaultProviderImgs)
+			mgr := newManagerWrapper(defaultProviderImgs, newFeatureGate(features.FeatureGateClusterAPIMachineManagementAWS))
 
 			DeferCleanup(func(ctx context.Context) {
 				mgr.stop()
@@ -504,7 +543,7 @@ var _ = Describe("RevisionController manifest substitutions", Serial, func() {
 	}, defaultNodeTimeout)
 
 	It("includes substitutions in created revision", func(ctx context.Context) {
-		mgr := newManagerWrapper(defaultProviderImgs, func(config *tls.Config) {
+		mgr := newManagerWrapper(defaultProviderImgs, newFeatureGate(features.FeatureGateClusterAPIMachineManagementAWS), func(config *tls.Config) {
 			config.CipherSuites = []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256}
 			config.MinVersion = tls.VersionTLS12
 		})
@@ -557,6 +596,7 @@ var _ = Describe("RevisionController error handling", Serial, func() {
 			Client:           interceptorCl,
 			ProviderProfiles: providerImgs,
 			ReleaseVersion:   "4.18.0",
+			FeatureGates:     newFeatureGate(features.FeatureGateClusterAPIMachineManagementAWS),
 		}
 	}, defaultNodeTimeout)
 

--- a/pkg/conversion/test/fuzz/fuzz.go
+++ b/pkg/conversion/test/fuzz/fuzz.go
@@ -810,6 +810,7 @@ func MAPIMachineSetFuzzerFuncs() fuzzer.FuzzerFuncs {
 			func(m *mapiv1beta1.MachineSetStatus, c randfill.Continue) {
 				c.FillNoCustom(m)
 
+				m.LabelSelector = ""         // Ignore this field. Both MAPI and CAPI (field is called 'selector') set this from spec.selector.
 				m.ObservedGeneration = 0     // Ignore, this field as it shouldn't match between CAPI and MAPI.
 				m.AuthoritativeAPI = ""      // Ignore, this field as it is not present in CAPI.
 				m.SynchronizedGeneration = 0 // Ignore, this field as it is not present in CAPI.

--- a/pkg/util/featuregates.go
+++ b/pkg/util/featuregates.go
@@ -110,3 +110,26 @@ func IsCAPIEnabledForPlatform(currentFeatureGates featuregates.FeatureGate, plat
 		return false
 	}
 }
+
+// IsMAPIMigrationEnabledForPlatform returns true if MAPI migration is enabled for the given
+// platform in the given feature gates.
+func IsMAPIMigrationEnabledForPlatform(featureGates featuregates.FeatureGate, platform configv1.PlatformType) bool {
+	switch platform {
+	case configv1.AWSPlatformType:
+		return featureGates.Enabled(features.FeatureGateMachineAPIMigrationAWS)
+	case configv1.GCPPlatformType:
+		return featureGates.Enabled(features.FeatureGateMachineAPIMigrationGCP)
+	case configv1.AzurePlatformType:
+		return featureGates.Enabled(features.FeatureGateMachineAPIMigrationAzure)
+	case configv1.PowerVSPlatformType:
+		return featureGates.Enabled(features.FeatureGateMachineAPIMigrationPowerVS)
+	case configv1.VSpherePlatformType:
+		return featureGates.Enabled(features.FeatureGateMachineAPIMigrationVSphere)
+	case configv1.OpenStackPlatformType:
+		return featureGates.Enabled(features.FeatureGateMachineAPIMigrationOpenStack)
+	case configv1.BareMetalPlatformType:
+		return featureGates.Enabled(features.FeatureGateMachineAPIMigrationBareMetal)
+	}
+
+	return false
+}

--- a/pkg/util/platform.go
+++ b/pkg/util/platform.go
@@ -99,10 +99,10 @@ type InfraTypes interface {
 
 // GetCAPITypesForInfrastructure returns the infrastructure objects for a given platform.
 // Returns ErrUnsupportedPlatform for unsupported platforms.
-func GetCAPITypesForInfrastructure(infra *configv1.Infrastructure) (InfraTypes, configv1.PlatformType, error) {
+func GetCAPITypesForInfrastructure(infra *configv1.Infrastructure) (InfraTypes, error) {
 	platform, err := GetPlatformFromInfra(infra)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
 	switch platform {
@@ -110,45 +110,45 @@ func GetCAPITypesForInfrastructure(infra *configv1.Infrastructure) (InfraTypes, 
 		return newInfraTypes[
 			*awsv1.AWSMachine, *awsv1.AWSCluster,
 			*awsv1.AWSMachineTemplate, *awsv1.AWSClusterTemplate,
-		](), platform, nil
+		](), nil
 	case configv1.GCPPlatformType:
 		return newInfraTypes[
 			*gcpv1.GCPMachine, *gcpv1.GCPCluster,
 			*gcpv1.GCPMachineTemplate, *gcpv1.GCPClusterTemplate,
-		](), platform, nil
+		](), nil
 	case configv1.AzurePlatformType:
 		azureCloudEnvironment := getAzureCloudEnvironment(infra.Status.PlatformStatus)
 		if azureCloudEnvironment == configv1.AzureStackCloud {
 			klog.Infof("Detected Azure Cloud Environment %q on platform %q is not supported", azureCloudEnvironment, platform)
-			return nil, platform, fmt.Errorf("%w: %s", ErrUnsupportedPlatform, platform)
+			return nil, fmt.Errorf("%w: %s", ErrUnsupportedPlatform, platform)
 		}
 
 		return newInfraTypes[
 			*azurev1.AzureMachine, *azurev1.AzureCluster,
 			*azurev1.AzureMachineTemplate, *azurev1.AzureClusterTemplate,
-		](), platform, nil
+		](), nil
 	case configv1.PowerVSPlatformType:
 		return newInfraTypes[
 			*ibmpowervsv1.IBMPowerVSMachine, *ibmpowervsv1.IBMPowerVSCluster,
 			*ibmpowervsv1.IBMPowerVSMachineTemplate, *ibmpowervsv1.IBMPowerVSClusterTemplate,
-		](), platform, nil
+		](), nil
 	case configv1.VSpherePlatformType:
 		return newInfraTypes[
 			*vspherev1.VSphereMachine, *vspherev1.VSphereCluster,
 			*vspherev1.VSphereMachineTemplate, *vspherev1.VSphereClusterTemplate,
-		](), platform, nil
+		](), nil
 	case configv1.OpenStackPlatformType:
 		return newInfraTypes[
 			*openstackv1.OpenStackMachine, *openstackv1.OpenStackCluster,
 			*openstackv1.OpenStackMachineTemplate, *openstackv1.OpenStackClusterTemplate,
-		](), platform, nil
+		](), nil
 	case configv1.BareMetalPlatformType:
 		return newInfraTypes[
 			*metal3v1.Metal3Machine, *metal3v1.Metal3Cluster,
 			*metal3v1.Metal3MachineTemplate, *metal3v1.Metal3ClusterTemplate,
-		](), platform, nil
+		](), nil
 	default:
-		return nil, platform, fmt.Errorf("%w: %s", ErrUnsupportedPlatform, platform)
+		return nil, fmt.Errorf("%w: %s", ErrUnsupportedPlatform, platform)
 	}
 }
 


### PR DESCRIPTION
This change removes various hard-coded assumptions in the code about which
platforms are supported and uses feature gates exclusively for feature
enablement. Specifically:

* When ClusterAPIMachineMigration is enabled we now always run the operator,
  regardless of whether the platform has support.
* Consequently we always install core CAPI, even if platform support is not yet
  enabled.
* The revision controller now checks the per-platform feature gate before
  enabling any platform-specific profiles.
* The machine-api-migration entrypoint now uses the MachineAPIMigration
  featuregate and the per-platform MachineAPIMigration instead of hard-coding
  AWS and OpenStack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Platform-specific components are now included only when their corresponding feature gates are enabled.
  - Machine API migration components now start only when migration is enabled for the detected platform.

- **Bug Fixes**
  - Unsupported platforms no longer trigger unnecessary deployment removal or misleading availability status.
  - Controller startup now handles disabled features and unsupported platforms cleanly without waiting indefinitely.

- **Refactor**
  - Platform detection and feature-gate handling have been streamlined for more consistent controller behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->