### PR TITLE
NO-JIRA: Fix a race in MachineSet e2es

### DIFF
--- a/e2e/machineset_migration_mapi_authoritative_test.go
+++ b/e2e/machineset_migration_mapi_authoritative_test.go
@@ -329,11 +329,15 @@ var _ = Describe("[sig-cluster-lifecycle][OCPFeatureGate:MachineAPIMigration] Ma
 				capiMachineSet = capiframework.GetMachineSetWithRetry(mapiMSAuthMAPIName, capiframework.CAPINamespace)
 				Eventually(k.Object(capiMachineSet), capiframework.WaitMedium, capiframework.RetryMedium).Should(HaveField("Spec.Template.Spec.InfrastructureRef.Name", Not(Equal(originalAWSMachineTemplateName))), "Should have InfraTemplate name changed")
 
-				By("Verifying new InfraTemplate has the updated InstanceType")
-				var err error
-				newAWSMachineTemplate, err = getAWSMachineTemplateByPrefix(mapiMSAuthMAPIName, capiframework.CAPINamespace)
-				Expect(err).ToNot(HaveOccurred(), "Failed to get new awsMachineTemplate  %s", newAWSMachineTemplate)
-				Expect(newAWSMachineTemplate.Spec.Template.Spec.InstanceType).To(Equal(newInstanceType))
+				By("Verifying new InfraTemplate has the updated InstanceType", func() {
+					newAWSMachineTemplate = &awsv1.AWSMachineTemplate{}
+					newAWSMachineTemplate.Name = capiMachineSet.Spec.Template.Spec.InfrastructureRef.Name
+					newAWSMachineTemplate.Namespace = capiMachineSet.Namespace
+
+					Eventually(k.Object(newAWSMachineTemplate), capiframework.WaitShort, capiframework.RetryShort).Should(
+						HaveField("Spec.Template.Spec.InstanceType", Equal(newInstanceType)),
+					)
+				})
 
 				By("Verifying the old InfraTemplate is deleted")
 				verifyResourceRemoved(awsMachineTemplate)


### PR DESCRIPTION
We were using getAWSMachineTemplateByPrefix, which assumes that only 1 template exists with the given prefix. But this relies on the previous template having been garbage collected before we check. Instead we just use the new name directly as we already have it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved the MachineSets update end-to-end test to reliably validate that a newly created InfraTemplate results in the expected AWSMachineTemplate `InstanceType` update, using wait-for-condition polling to prevent flaky timing issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->