### PR TITLE
OCPCLOUD-3451: Scope capi-operator and capi-installer RBAC to least-privilege

### DIFF
--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -1,0 +1,41 @@
+# RBAC Management
+
+## Structure
+
+### capi-operator and capi-installer
+
+The `capi-operator` and `capi-installer` ServiceAccounts (in `openshift-cluster-api-operator`) have separate, scoped permissions:
+
+| Manifest | Kind | Scope | SA | Purpose |
+|----------|------|-------|----|---------|
+| `0000_30_cluster-api-operator_03_clusterrole.yaml` | ClusterRole `openshift-capi-operator` | cluster-wide | `capi-operator` | config.openshift.io resources, ClusterOperator management, ClusterAPI/ConfigMap/Deployment read |
+| `0000_30_cluster-api-operator_03_clusterrole.yaml` | Role `capi-operator` | `openshift-cluster-api-operator` | `capi-operator` | Leader election leases, Deployment write (capi-installer), pod self-read, events |
+| `0000_30_cluster-api-operator_03_capi-installer-clusterrole.yaml` | ClusterRole `openshift-capi-installer` | cluster-wide | `capi-installer` | CRDs, admission resources, cluster RBAC, config.openshift.io, ClusterAPI/ClusterOperator status, tracking cache informers |
+| `0000_30_cluster-api-operator_03_capi-installer-clusterrole.yaml` | Role `capi-installer` | `openshift-cluster-api-operator` | `capi-installer` | Leader election leases, pod self-read, ConfigMap read, events |
+| `0000_30_cluster-api-operator_03_capi-installer-clusterrole.yaml` | Role `capi-installer` | `openshift-cluster-api` | `capi-installer` | boxcutter-managed resources (ServiceAccounts, Services, Deployments, Roles, RoleBindings), VAP paramRef list |
+| `0000_30_cluster-api-operator_03_capi-installer-clusterrole.yaml` | Role `capi-installer` | `openshift-machine-api` | `capi-installer` | VAP paramRef list (machines, machinesets) |
+
+Both SAs also bind to ClusterRole `system:openshift:openshift-cluster-api:read-tls-configuration` for APIServer TLS profile reading.
+
+### capi-controllers
+
+The `capi-controllers` ServiceAccount (used by both the `capi-controllers` and `machine-api-migration` containers) has permissions split across scopes:
+
+| Manifest | Kind | Scope | Purpose |
+|----------|------|-------|---------|
+| `03_rbac_roles.yaml` | ClusterRole `openshift-capi-controllers` | cluster-wide | Cluster-scoped resources only: infrastructures, clusteroperators, featuregates, clusterversions, nodes, CRDs |
+| `03_rbac_roles.yaml` | Role `capi-controllers` | `openshift-cluster-api` | CAPI core + infra provider resources, secrets, events, leases |
+| `03_rbac_roles.yaml` | Role `capi-controllers` | `openshift-machine-api` | MAPI machines, machinesets, controlplanemachinesets, secrets, events |
+| `03_rbac_roles.yaml` | Role `capi-controllers-kube-system` | `kube-system` | Secrets (vSphere credentials) |
+| `03_rbac_roles.yaml` | Role `cluster-capi-operator-pull-secret` | `openshift-config` | Pull-secret read |
+
+## Principles
+
+- Each permission lives in the narrowest scope where it's used
+- Cluster-scoped Kubernetes objects (CRDs, ClusterRoles, ClusterOperators) go in ClusterRoles
+- Namespaced resources go into Roles in the specific namespace where they're accessed
+- Read-only informer permissions may use ClusterRoles when the cache watches multiple namespaces
+
+## Updating RBAC
+
+Use the `/rbac-review` skill to audit and regenerate RBAC permissions. It requires a live cluster and uses audit2rbac + static code analysis to derive least-privilege rules.

--- a/manifests/0000_30_cluster-api-operator_00_tombstones.yaml
+++ b/manifests/0000_30_cluster-api-operator_00_tombstones.yaml
@@ -11,3 +11,14 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/feature-gate: "ClusterAPIMachineManagement"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openshift-capi-installer
+  annotations:
+    release.openshift.io/delete: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-gate: "ClusterAPIMachineManagement"

--- a/manifests/0000_30_cluster-api-operator_03_capi-installer-clusterrole.yaml
+++ b/manifests/0000_30_cluster-api-operator_03_capi-installer-clusterrole.yaml
@@ -1,0 +1,271 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-gate: "ClusterAPIMachineManagement"
+  name: openshift-capi-installer
+rules:
+# VAP binding creation requires get+list on all resources when the referenced
+# policy doesn't exist yet. Also covers boxcutter tracking cache reads.
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - infrastructures
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusteroperators
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusteroperators/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - clusterapis
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - clusterapis/status
+  verbs:
+  - get
+  - update
+  - patch
+# boxcutter: manages CRDs from provider manifests
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+# boxcutter: manages admission resources from provider manifests
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  - validatingadmissionpolicies
+  - validatingadmissionpolicybindings
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+# boxcutter: manages cluster-scoped RBAC from provider manifests.
+# escalate + bind: installer creates Roles granting permissions it doesn't hold.
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+  - escalate
+  - bind
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+# boxcutter: tracking cache watches namespace-scoped types cluster-wide
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-gate: "ClusterAPIMachineManagement"
+  name: capi-installer
+  namespace: openshift-cluster-api-operator
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-gate: "ClusterAPIMachineManagement"
+  name: capi-installer
+  namespace: openshift-cluster-api
+rules:
+# boxcutter: applies namespace-scoped provider resources
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - get
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - get
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  verbs:
+  - create
+  - get
+  - update
+  - patch
+  - delete
+  - escalate
+  - bind
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - get
+  - update
+  - patch
+  - delete
+# VAP paramRef authorization: API server requires list on paramKind types
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machines
+  - machinesets
+  verbs:
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-gate: "ClusterAPIMachineManagement"
+  name: capi-installer
+  namespace: openshift-machine-api
+rules:
+# VAP paramRef authorization: API server requires list on paramKind types
+- apiGroups:
+  - machine.openshift.io
+  resources:
+  - machines
+  - machinesets
+  verbs:
+  - list

--- a/manifests/0000_30_cluster-api-operator_03_clusterrole.yaml
+++ b/manifests/0000_30_cluster-api-operator_03_clusterrole.yaml
@@ -9,10 +9,138 @@ metadata:
     release.openshift.io/feature-gate: "ClusterAPIMachineManagement"
   name: openshift-capi-operator
 rules:
-# Being an installer, the required RBAC is necessarily a lot
 - apiGroups:
-  - '*'
+  - config.openshift.io
   resources:
-  - '*'
+  - infrastructures
   verbs:
-  - '*'
+  - get
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusteroperators
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusteroperators
+  resourceNames:
+  - cluster-api
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusteroperators/status
+  resourceNames:
+  - cluster-api
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusterversions
+  - featuregates
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - clusterapis
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-gate: "ClusterAPIMachineManagement"
+  name: capi-operator
+  namespace: openshift-cluster-api-operator
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-gate: "ClusterAPIMachineManagement"
+  name: capi-operator
+  namespace: openshift-cluster-api
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch

--- a/manifests/0000_30_cluster-api-operator_04_capi-installer-clusterrolebinding.yaml
+++ b/manifests/0000_30_cluster-api-operator_04_capi-installer-clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: openshift-capi-installer
+  name: system:openshift:capi-installer
   annotations:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
@@ -11,8 +11,83 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: openshift-capi-operator
+  name: openshift-capi-installer
 subjects:
 - kind: ServiceAccount
   name: capi-installer
   namespace: openshift-cluster-api-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: capi-installer
+  namespace: openshift-cluster-api-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-gate: "ClusterAPIMachineManagement"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: capi-installer
+subjects:
+- kind: ServiceAccount
+  name: capi-installer
+  namespace: openshift-cluster-api-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: capi-installer
+  namespace: openshift-cluster-api
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-gate: "ClusterAPIMachineManagement"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: capi-installer
+subjects:
+- kind: ServiceAccount
+  name: capi-installer
+  namespace: openshift-cluster-api-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: capi-installer
+  namespace: openshift-machine-api
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-gate: "ClusterAPIMachineManagement"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: capi-installer
+subjects:
+- kind: ServiceAccount
+  name: capi-installer
+  namespace: openshift-cluster-api-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:openshift:capi-installer-read-tls-configuration
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-gate: "ClusterAPIMachineManagement"
+roleRef:
+  kind: ClusterRole
+  name: system:openshift:openshift-cluster-api:read-tls-configuration
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  namespace: openshift-cluster-api-operator
+  name: capi-installer

--- a/manifests/0000_30_cluster-api-operator_04_clusterrolebinding.yaml
+++ b/manifests/0000_30_cluster-api-operator_04_clusterrolebinding.yaml
@@ -18,6 +18,44 @@ subjects:
   name: capi-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: capi-operator
+  namespace: openshift-cluster-api-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-gate: "ClusterAPIMachineManagement"
+roleRef:
+  kind: Role
+  name: capi-operator
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  namespace: openshift-cluster-api-operator
+  name: capi-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: capi-operator
+  namespace: openshift-cluster-api
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-gate: "ClusterAPIMachineManagement"
+roleRef:
+  kind: Role
+  name: capi-operator
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  namespace: openshift-cluster-api-operator
+  name: capi-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: system:openshift:capi-operator-read-tls-configuration


### PR DESCRIPTION
## Summary
- Replace the shared wildcard ClusterRole `openshift-capi-operator` (`apiGroups: ['*'], resources: ['*'], verbs: ['*']`) with separate, enumerated RBAC for each ServiceAccount
- `capi-operator` gets a narrow ClusterRole (config resources, ClusterOperator management restricted to `cluster-api` by name) + namespace Roles in `openshift-cluster-api-operator` (leases, Deployment write, configmaps, pod self-read, events) and `openshift-cluster-api` (read-only cache informers for deployments and configmaps)
- `capi-installer` gets a ClusterRole with `get+list */*` (needed for VAP binding creation when policies don't exist yet — the API server falls back to checking both `get` and `list` on all resources), enumerated write permissions (CRDs, admission resources, cluster RBAC with `escalate`/`bind`), and namespace Roles in `openshift-cluster-api` (boxcutter-managed resources, VAP paramRef), `openshift-cluster-api-operator` (leases, pod/configmap read), and `openshift-machine-api` (VAP paramRef list)
- Tombstone for old `openshift-capi-installer` ClusterRoleBinding (roleRef is immutable — the old binding pointed to `openshift-capi-operator`, the new one points to `openshift-capi-installer`)
- Derived from static code analysis of all controllers and cross-validated with audit2rbac on a live AWS cluster

## Permission justification

Each rule was derived from code analysis and validated against audit2rbac output from an AWS cluster.

### capi-operator

| Scope | API Group | Resource | Verbs | Code evidence |
|-------|-----------|----------|-------|---------------|
| ClusterRole | `config.openshift.io` | `infrastructures` | get | `main.go:104` util.GetInfra() |
| ClusterRole | `config.openshift.io` | `clusteroperators` | get, list, watch, create | `clusteroperator_controller.go:73`, `operator_status.go:119` |
| ClusterRole | `config.openshift.io` | `clusteroperators` | update, patch | `operator_status.go:186` (resourceNames: cluster-api) |
| ClusterRole | `config.openshift.io` | `clusteroperators/status` | update, patch | `operator_status.go:186` (resourceNames: cluster-api) |
| ClusterRole | `config.openshift.io` | `clusterversions`, `featuregates` | get, list, watch | `main.go:114` util.GetFeatureGates() |
| ClusterRole | `operator.openshift.io` | `clusterapis` | get, list, watch | `installerdeployment/controller.go:167` |
| Role: operator ns | `apps` | `deployments` | get, list, watch, create, patch, update, delete | `controller.go:148` SSA, `:163` For(), `:209` delete |
| Role: operator ns | `""` | `configmaps` | get, list, watch | `controller.go:107,166` |
| Role: operator ns | `""` | `pods` | get | `main.go:158` pod self-read |
| Role: operator ns | `""` | `events` | create, patch | `operator_status.go:98` |
| Role: operator ns | `coordination.k8s.io` | `leases` | get, list, watch, create, update, patch, delete | Leader election |
| Role: CAPI ns | `apps` | `deployments` | get, list, watch | DefaultNamespaces cache informer |
| Role: CAPI ns | `""` | `configmaps` | get, list, watch | DefaultNamespaces cache informer |

### capi-installer

| Scope | API Group | Resource | Verbs | Code evidence |
|-------|-----------|----------|-------|---------------|
| ClusterRole | `*` | `*` | get, list | VAP binding paramRef fallback — when the referenced policy doesn't exist yet, the API server requires both `get` and `list` on all resources. Also covers boxcutter tracking cache reads |
| ClusterRole | `config.openshift.io` | `infrastructures` | watch | `revision_controller.go:307` Watches() |
| ClusterRole | `config.openshift.io` | `clusteroperators` | watch | Informer |
| ClusterRole | `config.openshift.io` | `clusteroperators/status` | update, patch | `related_objects.go:113`, `controller_status.go:295` |
| ClusterRole | `operator.openshift.io` | `clusterapis` | watch | `installer_controller.go:100`, `revision_controller.go:303` |
| ClusterRole | `operator.openshift.io` | `clusterapis/status` | update, patch | `revision_controller.go:234`, `installer_controller.go:316` |
| ClusterRole | `apiextensions.k8s.io` | `customresourcedefinitions` | watch, create, update, patch, delete | boxcutter: provider CRDs |
| ClusterRole | `admissionregistration.k8s.io` | `mutating/validatingwebhookconfigurations`, `validatingadmissionpolicies/bindings` | watch, create, update, patch, delete | boxcutter: admission resources |
| ClusterRole | `rbac.authorization.k8s.io` | `clusterroles` | watch, create, update, patch, delete, escalate, bind | boxcutter: cluster RBAC. escalate/bind needed because installer creates Roles granting permissions it doesn't hold |
| ClusterRole | `rbac.authorization.k8s.io` | `clusterrolebindings` | watch, create, update, patch, delete | boxcutter: cluster RBAC bindings |
| ClusterRole | various | `roles`, `rolebindings`, `serviceaccounts`, `services`, `deployments` | watch | boxcutter tracking cache |
| Role: CAPI ns | various | `serviceaccounts`, `services`, `deployments` | create, update, patch, delete | boxcutter: namespace resources |
| Role: CAPI ns | `rbac.authorization.k8s.io` | `roles` | create, update, patch, delete, escalate, bind | boxcutter: namespace RBAC |
| Role: CAPI ns | `rbac.authorization.k8s.io` | `rolebindings` | create, update, patch, delete | boxcutter: namespace RBAC bindings |
| Role: CAPI ns | `cluster.x-k8s.io` | `machines`, `machinesets` | list | VAP paramRef authorization (bindings use `selector: {}`) |
| Role: MAPI ns | `machine.openshift.io` | `machines`, `machinesets` | list | VAP paramRef authorization (bindings use `selector: {}`) |
| Role: operator ns | `coordination.k8s.io` | `leases` | get, list, watch, create, update, patch, delete | Leader election |
| Role: operator ns | `""` | `pods` | get | Pod self-read |
| Role: operator ns | `""` | `configmaps` | get | `capi-installer-images` ConfigMap |

### Not observed by audit2rbac — justified by code or CI evidence

| Scope | API Group | Resource | Verbs | Justification |
|-------|-----------|----------|-------|---------------|
| ClusterRole | `config.openshift.io` | `clusteroperators` | create | `operator_status.go:119` — first install only |
| ClusterRole | `rbac.authorization.k8s.io` | `clusterroles` | escalate, bind | Installer creates ClusterRoles (e.g. `capi-manager-role`) that grant permissions to CAPI provider SAs. Invisible to audit2rbac |
| ClusterRole | `*` | `*` | get, list | VAP binding creation when referenced policy doesn't exist yet. CI confirmed: `does not have "list" permission for all groups, versions and resources` |
| Role: operator ns | `apps` | `deployments` | create, delete | `controller.go:148` SSA create on first install, `:209` unsupported platform cleanup |
| Role: CAPI ns | various boxcutter types | delete | Resource teardown during upgrades — no deletions during e2e |

### Upgrade compatibility

The old `openshift-capi-installer` ClusterRoleBinding pointed to ClusterRole `openshift-capi-operator`. Since `roleRef` is immutable in Kubernetes, the CVO cannot update it in-place. A tombstone deletes the old binding, and the new binding is created as `system:openshift:capi-installer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)