### PR TITLE
OCPBUGS-91667: Bump capi-installer resync to 12 hours

### DIFF
--- a/cmd/capi-installer/main.go
+++ b/cmd/capi-installer/main.go
@@ -85,7 +85,7 @@ func main() {
 			*operatorConfig.CAPINamespace:     {},
 			*operatorConfig.OperatorNamespace: {},
 		},
-		SyncPeriod: ptr.To(10 * time.Minute),
+		SyncPeriod: ptr.To(12 * time.Hour),
 	}
 
 	mgr, err := initManager(ctx, cancel, mgrOpts)


### PR DESCRIPTION
capi-installer shouldn't need a resync at all, so this is really just a safety blanket. We produce an SSA on every resync for every objects which uses server-side defaulting, which makes frequent resyncs noisy.

TODO:
* [x] Observe several passing `periodic-ci-openshift-release-main-ci-5.0-e2e-azure-ovn-upgrade-rhcos9-techpreview` runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted cache synchronization frequency to reduce system overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->