### PR TITLE
 OCPCLOUD-3570: e2e skip Cluster API authoritative MachineSets in GetFirstMAPIMachineSet

### DIFF
--- a/e2e/framework/providerspec.go
+++ b/e2e/framework/providerspec.go
@@ -24,18 +24,28 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-// GetFirstMAPIMachineSet lists MAPI MachineSets, sorts by name, and returns the first one.
+// GetFirstMAPIMachineSet lists MAPI MachineSets, sorts by name, and returns the first one
+// whose authoritative API is Machine API. MachineSets synced from Cluster API are excluded
+// because their machines are provisioned by Cluster API and carry no Machine API machine objects.
 func GetFirstMAPIMachineSet(ctx context.Context, cl client.Client) *mapiv1beta1.MachineSet {
 	GinkgoHelper()
 
 	machineSetList := &mapiv1beta1.MachineSetList{}
 	Expect(cl.List(ctx, machineSetList, client.InNamespace(MAPINamespace))).To(Succeed(),
 		"should not fail listing MAPI MachineSets")
-	Expect(machineSetList.Items).ToNot(BeEmpty(), "expected to have at least a MachineSet")
 
 	SortListByName(machineSetList)
 
-	return &machineSetList.Items[0]
+	for i := range machineSetList.Items {
+		ms := &machineSetList.Items[i]
+		if ms.Spec.AuthoritativeAPI != mapiv1beta1.MachineAuthorityClusterAPI {
+			return ms
+		}
+	}
+
+	Fail("expected to find at least one Machine API authoritative MachineSet")
+
+	return nil
 }
 
 // GetMAPIProviderSpec lists MAPI MachineSets, sorts by name, and unmarshals


### PR DESCRIPTION
## Summary

`GetFirstMAPIMachineSet` sorts all `mapiv1beta1.MachineSet` objects in `openshift-machine-api` alphabetically and returns the first. When migration tests run, the machine sync controller creates genuine MAPI MachineSet objects as mirrors of CAPI-authoritative MachineSets (e.g. `capi-ms-auth-capi-*`). These names sort before native worker MachineSets, causing the function to return a synced mirror. `getMAPICreatedInstance` then fails to find MAPI Machine objects for it because the machines are provisioned by CAPI, not MAPI.

Filter to skip MachineSets where `Spec.AuthoritativeAPI == ClusterAPI`. `Spec` is used instead of `Status` because the status is set by the migration controller after reconciliation and may be empty on freshly created objects.

**Observed failure:**
```
Failed to find MAPI machines for MachineSet capi-ms-auth-capi-wqbkl
Expected []v1beta1.Machine | len:0, cap:0 not to be empty
```
This proves that function `GetFirstMAPIMachineSet` returned a MachineSet named `capi-ms-auth-capi-wqbkl`. The name itself (`capi-ms` prefix, `auth-capi` = CAPI authoritative) is self-documenting - it's a CAPI-synced mirror that was picked up from the MAPI namespace

Example run: pull-ci-openshift-cluster-capi-operator-main-e2e-aws-capi-techpreview [#2070173165606146048](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cluster-capi-operator/606/pull-ci-openshift-cluster-capi-operator-main-e2e-aws-capi-techpreview/2070173165606146048)

## Test plan

- [x] `e2e-aws-capi-techpreview` passes without the flake


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved machine selection so the first eligible MachineSet is chosen after sorting, skipping entries authored by Cluster API.
  * Added a clearer failure when no suitable MachineSet is available, reducing unexpected test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->