### PR TITLE
OCPBUGS-92817: delete MAPI MachineSets before CAPI in e2e cleanup

### DIFF
--- a/e2e/machineset_migration_helpers.go
+++ b/e2e/machineset_migration_helpers.go
@@ -443,22 +443,12 @@ func updateCAPIMachineSetInfraTemplate(capiMachineSet *clusterv1.MachineSet, new
 	)
 }
 
-// cleanupMachineSetTestResources deletes CAPI MachineSets, MAPI MachineSets, and AWSMachineTemplates created during tests.
+// cleanupMachineSetTestResources deletes MAPI MachineSets, CAPI MachineSets, and AWSMachineTemplates created during tests.
 func cleanupMachineSetTestResources(ctx context.Context, cl client.Client, capiMachineSets []*clusterv1.MachineSet, awsMachineTemplates []*awsv1.AWSMachineTemplate, mapiMachineSets []*mapiv1beta1.MachineSet) {
 	GinkgoHelper()
 
 	cleanupCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()
-
-	for _, ms := range capiMachineSets {
-		if ms == nil {
-			continue
-		}
-
-		By(fmt.Sprintf("Deleting CAPI MachineSet %s", ms.Name))
-		capiframework.DeleteMachineSets(cleanupCtx, cl, ms)
-		capiframework.WaitForMachineSetsDeleted(ms)
-	}
 
 	for _, ms := range mapiMachineSets {
 		if ms == nil {
@@ -483,6 +473,16 @@ func cleanupMachineSetTestResources(ctx context.Context, cl client.Client, capiM
 		if !notFound {
 			mapiframework.WaitForMachineSetsDeleted(cleanupCtx, cl, ms)
 		}
+	}
+
+	for _, ms := range capiMachineSets {
+		if ms == nil {
+			continue
+		}
+
+		By(fmt.Sprintf("Deleting CAPI MachineSet %s", ms.Name))
+		capiframework.DeleteMachineSets(cleanupCtx, cl, ms)
+		capiframework.WaitForMachineSetsDeleted(ms)
 	}
 
 	for _, template := range awsMachineTemplates {


### PR DESCRIPTION
## Summary

Fixes a deadlock in `cleanupMachineSetTestResources` that causes `e2e-aws-capi-techpreview` to fail with a 15-minute timeout.

When a test creates both a CAPI MachineSet and a MAPI MachineSet with the same name and `authoritativeAPI: ClusterAPI`, deleting CAPI first causes the sync controller to loop in `reconcileCAPItoMAPIMachineSetDeletionNormal` - it waits for the CAPI-specific finalizer (`cluster.x-k8s.io/machineset`) to be removed, but its own constant requeues conflict with the CAPI controller's finalizer removal patch, deadlocking cleanup.

Deleting MAPI first instead triggers `reconcileCAPItoMAPIMachineSetDeletionCAPINotDeleting`, which removes the sync finalizer from CAPI immediately. The CAPI MachineSet can then be deleted cleanly with no sync interference.

## Test plan

- [x] `e2e-aws-capi-techpreview` passes without the `Should have deleted MachineSet openshift-cluster-api/capi-ms-auth-capi-*` timeout

Fixes: https://issues.redhat.com/browse/OCPBUGS-92817


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted test cleanup order for machine set migrations so managed resources are removed in the correct sequence.
  * Improved cleanup reliability by deleting MAPI machine sets before CAPI machine sets, helping avoid leftover resources during end-to-end runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->