### PR TITLE
NO-JIRA: fix machine sync e2e test flake

### DIFF
--- a/e2e/machine_sync_test.go
+++ b/e2e/machine_sync_test.go
@@ -63,6 +63,10 @@ var _ = Describe("Machine Sync", Ordered, func() {
 		capiMachine := framework.GetMachineWithRetry(machineName, framework.CAPINamespace)
 		Expect(capiMachine).NotTo(BeNil())
 
+		By("Waiting for CAPI Machine to reach Running phase")
+		capiMachineForRunning := &clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{Name: machineName, Namespace: framework.CAPINamespace}}
+		verifyMachineRunning(cl, capiMachineForRunning)
+
 		By("Fetching the infrastructure machine")
 		infraMachine, err := external.GetObjectFromContractVersionedRef(ctx, cl, capiMachine.Spec.InfrastructureRef, capiMachine.Namespace)
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Summary
- Wait for the CAPI Machine to reach Running phase before capturing the infrastructure machine UID and asserting stability
- The test was flaky because it started the stability check before provisioning completed — when the MAPI machine controller set `providerID`, the sync controller saw a spec diff on the infra machine and did a legitimate delete+recreate, changing the UID within the `Consistently` window

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end validation to wait for machine startup before checking sync status and stability, making the test more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->