### PR TITLE
OCPCLOUD-3571: Add OTE e2e tests for ClusterAPIMachineManagementAWS feature gate

### DIFF
--- a/e2e/cluster_api_machine_management_aws.go
+++ b/e2e/cluster_api_machine_management_aws.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	awsv1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/api/features"
+	"github.com/openshift/cluster-capi-operator/e2e/framework"
+	"github.com/openshift/cluster-capi-operator/pkg/test"
+)
+
+var _ = Describe("[sig-cluster-lifecycle][OCPFeatureGate:ClusterAPIMachineManagementAWS] Cluster API Machine Management AWS",
+	Label("platform:aws"),
+	func() {
+		BeforeEach(func() {
+			if platform != configv1.AWSPlatformType {
+				Skip("Skipping AWS-specific tests on non-AWS platform.")
+			}
+			if !framework.IsFeatureGateEnabled(ctx, cl, features.FeatureGateClusterAPIMachineManagementAWS) {
+				Skip("Feature gate ClusterAPIMachineManagementAWS is not enabled.")
+			}
+		})
+
+		Context("AWS provider deployment", func() {
+			It("should have the capa-controller-manager deployment available", func() {
+				framework.AssertDeploymentAvailable("capa-controller-manager", framework.CAPINamespace)
+			})
+		})
+
+		Context("AWS infrastructure CRDs", func() {
+			DescribeTable("should have core AWS Cluster API CRDs installed and established",
+				func(name string) {
+					crd := &apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: name}}
+					Eventually(komega.Object(crd)).WithTimeout(framework.WaitMedium).WithPolling(framework.RetryMedium).Should(
+						HaveField("Status.Conditions", test.HaveCondition(apiextensionsv1.Established).WithStatus(apiextensionsv1.ConditionTrue)),
+					)
+				},
+				Entry("awsclusters CRD", "awsclusters.infrastructure.cluster.x-k8s.io"),
+				Entry("awsmachines CRD", "awsmachines.infrastructure.cluster.x-k8s.io"),
+				Entry("awsmachinetemplates CRD", "awsmachinetemplates.infrastructure.cluster.x-k8s.io"),
+				Entry("awsclustercontrolleridentities CRD", "awsclustercontrolleridentities.infrastructure.cluster.x-k8s.io"),
+			)
+
+		})
+
+		Context("Management cluster AWS resources", func() {
+			It("should have the AWSCluster object ready", func() {
+				awsCluster := &awsv1.AWSCluster{ObjectMeta: metav1.ObjectMeta{
+					Name:      clusterName,
+					Namespace: framework.CAPINamespace,
+				}}
+				Eventually(komega.Object(awsCluster)).WithTimeout(framework.WaitLong).WithPolling(framework.RetryMedium).Should(
+					HaveField("Status.Ready", BeTrue()),
+				)
+			})
+		})
+	})

--- a/openshift-tests-extension/cmd/main.go
+++ b/openshift-tests-extension/cmd/main.go
@@ -19,10 +19,12 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/openshift-eng/openshift-tests-extension/pkg/cmd"
 	e "github.com/openshift-eng/openshift-tests-extension/pkg/extension"
+	et "github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests"
 	g "github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo"
 	"github.com/spf13/cobra"
 
@@ -68,6 +70,15 @@ func main() {
 
 	specs.AddBeforeAll(func() {
 		e2e.InitCommonVariables()
+	})
+
+	// Auto-apply platform environment selectors from Ginkgo Label("platform:<name>") annotations.
+	specs.Walk(func(spec *et.ExtensionTestSpec) {
+		for label := range spec.Labels {
+			if platform, ok := strings.CutPrefix(label, "platform:"); ok {
+				spec.Include(et.PlatformEquals(platform))
+			}
+		}
 	})
 
 	ext.AddSpecs(specs)


### PR DESCRIPTION
## Summary

Implements 6 OTE e2e tests for the `ClusterAPIMachineManagementAWS` feature gate, plus a generic platform Walk in the OTE extension registration.

## Tests

| # | Test | What it proves | Gated by |
|---|---|---|---|
| 1 | `capa-controller-manager` deployment available in `openshift-cluster-api` | AWS provider controller deployed by capi-installer | `ClusterAPIMachineManagementAWS` only |
| 2 | `awsclusters.infrastructure.cluster.x-k8s.io` CRD established | CAPA CRD bundle installed by capi-installer | `ClusterAPIMachineManagementAWS` only |
| 3 | `awsmachines.infrastructure.cluster.x-k8s.io` CRD established | CAPA CRD bundle installed by capi-installer | `ClusterAPIMachineManagementAWS` only |
| 4 | `awsmachinetemplates.infrastructure.cluster.x-k8s.io` CRD established | CAPA CRD bundle installed by capi-installer | `ClusterAPIMachineManagementAWS` only |
| 5 | `awsclustercontrolleridentities.infrastructure.cluster.x-k8s.io` CRD established | CAPA CRD bundle installed by capi-installer | `ClusterAPIMachineManagementAWS` only |
| 6 | `AWSCluster.Status.Ready=True` | AWSCluster was created and is fully ready (VPC, subnets, security groups, load balancer all reconciled) | `ClusterAPIMachineManagementAWS` only |

Tests 1-5 check that capi-installer deployed the CAPA CRD bundle. Test 6 directly checks the `AWSCluster` object - the AWS-specific infra resource this feature gate controls. `Status.Ready=True` is set by CAPA only after all sub-conditions (VPC, subnets, security groups, load balancer, etc.) succeed, making it the canonical readiness signal for the AWSCluster.

## Platform restriction (two-layer)

**Layer 1 - OTE environmentSelector (periodic jobs):**
A generic Walk reads `Label("platform:<name>")` from each spec and adds `spec.Include(PlatformEquals(platform))`. No per-platform clauses in `main.go` - adding GCP/Azure tests only requires a `Label` on the Describe block.

**Layer 2 - `BeforeEach` guard (`make e2e` presubmits):**
Platform check runs first, before any `config.openshift.io\ API calls, so the test skips cleanly on non-AWS clusters (including MicroShift). Feature gate check follows.

## Test plan

- [x] `e2e-aws-capi-techpreview` passes with all 6 tests green
- [x] `e2e-aws-ovn-techpreview` passes with all 6 OTE tests green
- [x] tests are excluded from e.g. `e2e-gcp-ovn-techpreview`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an AWS-specific end-to-end test suite for Cluster API machine management, validating controller availability, AWS infrastructure CRD readiness, and management cluster readiness.
  * Enhanced extension test execution by automatically updating spec inclusion criteria based on matching platform labels, reducing manual platform scoping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->