### PR TITLE
OCPBUGS-85337: fix(manifests-gen): set imagePullPolicy IfNotPresent on provider workloads

### DIFF
--- a/manifests-gen/kustomization.yaml
+++ b/manifests-gen/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Component
 namespace: openshift-cluster-api
 
 resources:
-  - webhook-namespace-selector.yaml
+  - kustomize-values.yaml
 
 # Scope all provider webhooks to the openshift-cluster-api namespace.
 # This prevents webhooks from intercepting requests in other namespaces,
@@ -12,7 +12,7 @@ resources:
 replacements:
   - source:
       kind: ConfigMap
-      name: webhook-namespace-selector
+      name: kustomize-values
       fieldPath: data.namespace
     targets:
       - select:
@@ -25,6 +25,56 @@ replacements:
           kind: MutatingWebhookConfiguration
         fieldPaths:
           - webhooks.*.namespaceSelector.matchLabels.kubernetes\.io/metadata\.name
+        options:
+          create: true
+  # In disconnected clusters using pinned image sets, images are already
+  # present on nodes. IfNotPresent avoids unnecessary pulls that fail
+  # when the registry is unreachable (OCPBUGS-85337).
+  - source:
+      kind: ConfigMap
+      name: kustomize-values
+      fieldPath: data.imagePullPolicy
+    targets:
+      - select:
+          kind: Deployment
+        fieldPaths:
+          - spec.template.spec.containers.*.imagePullPolicy
+        options:
+          create: true
+      - select:
+          kind: StatefulSet
+        fieldPaths:
+          - spec.template.spec.containers.*.imagePullPolicy
+        options:
+          create: true
+      - select:
+          kind: DaemonSet
+        fieldPaths:
+          - spec.template.spec.containers.*.imagePullPolicy
+        options:
+          create: true
+      - select:
+          kind: ReplicaSet
+        fieldPaths:
+          - spec.template.spec.containers.*.imagePullPolicy
+        options:
+          create: true
+      - select:
+          kind: Job
+        fieldPaths:
+          - spec.template.spec.containers.*.imagePullPolicy
+        options:
+          create: true
+      - select:
+          kind: CronJob
+        fieldPaths:
+          - spec.jobTemplate.spec.template.spec.containers.*.imagePullPolicy
+        options:
+          create: true
+      - select:
+          kind: Pod
+        fieldPaths:
+          - spec.containers.*.imagePullPolicy
         options:
           create: true
 

--- a/manifests-gen/kustomize-values.yaml
+++ b/manifests-gen/kustomize-values.yaml
@@ -1,14 +1,15 @@
 # This ConfigMap is a kustomize workaround: replacements need a concrete source resource
-# to read a value from, but there is no real resource that holds the target namespace.
-# This ConfigMap acts as that source, providing the namespace value to inject into webhook
-# namespaceSelector fields via the replacements defined in kustomization.yaml.
+# to read a value from, but there is no real resource that holds the values we need.
+# This ConfigMap acts as that source, providing values to inject into target resources
+# via the replacements defined in kustomization.yaml.
 # It is marked as local-config so kustomize never emits it in the final output.
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: webhook-namespace-selector
+  name: kustomize-values
   annotations:
     # Marks this resource as local-only so kustomize excludes it from the final output.
     config.kubernetes.io/local-config: "true"
 data:
   namespace: openshift-cluster-api
+  imagePullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary

- In disconnected clusters using pinned image sets, provider pods (`capi-controller-manager`, `capa-controller-manager`, etc.) crash with `ImagePullBackOff` because their containers have `imagePullPolicy: Always`. The images are already present on the node via pinning, so pulling is unnecessary and fails without registry access.
- Adds a kustomize replacement in the `manifests-gen` component that sets `imagePullPolicy: IfNotPresent` on all containers in all provider workloads at build time.
- Renames the local-config ConfigMap from `webhook-namespace-selector` to `kustomize-values` since it now holds more than just the webhook namespace value.

## Usage

Example usage in a provider repo: https://github.com/openshift/cluster-api/pull/302

## Test plan

- [ ] Vendor this change into a provider repo (e.g. `openshift/cluster-api`) and rebuild its manifests to verify `imagePullPolicy: IfNotPresent` appears on all workloads containers in the generated output.
- [ ] Verify the generated manifests are otherwise unchanged apart from the new field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring image pull policy through cluster values.
  * Updated workload manifests to apply the configured image pull policy across supported resource types.

* **Bug Fixes**
  * Improved namespace scoping for webhook-related resources by sourcing the namespace from the shared values config.

* **Chores**
  * Consolidated manifest configuration into a single values source for easier maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->