### PR TITLE
no-jira: capi: enable MachineTaintPropagation feature gate on CAPI controllers

### DIFF
--- a/pkg/revisiongenerator/transform.go
+++ b/pkg/revisiongenerator/transform.go
@@ -36,6 +36,8 @@ func envSubstSubstitutions(key string) string {
 	// provider metadata.
 	case "EXP_BOOTSTRAP_FORMAT_IGNITION":
 		return "true"
+	case "EXP_MACHINE_TAINT_PROPAGATION":
+		return "true"
 	default:
 		return ""
 	}

--- a/pkg/revisiongenerator/transform_test.go
+++ b/pkg/revisiongenerator/transform_test.go
@@ -42,6 +42,14 @@ func TestTransformYaml(t *testing.T) {
 			expected: "bootstrap: true",
 		},
 		{
+			name: "machine taint propagation feature gate enabled",
+			yaml: "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},MachineTaintPropagation=${EXP_MACHINE_TAINT_PROPAGATION:=false}",
+			profile: providerimages.ProviderImageManifests{
+				ImageRef: "example.com/img@sha256:abc",
+			},
+			expected: "--feature-gates=MachinePool=true,MachineTaintPropagation=true",
+		},
+		{
 			name: "unknown variable replaced with empty",
 			yaml: "value: ${UNKNOWN_VAR}",
 			profile: providerimages.ProviderImageManifests{


### PR DESCRIPTION
## Description

Set `EXP_MACHINE_TAINT_PROPAGATION=true` in envsubst substitutions so the upstream CAPI controller-manager deploys with `MachineTaintPropagation` enabled.

This allows taint propagation from CAPI machines to nodes, which is a requirement for edge nodes (i.e. AWS local and wavelength zones). See https://github.com/openshift/installer/pull/10625

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed environment-based feature gate substitution so `MachineTaintPropagation` now resolves to `true` as expected.
  * Preserved existing feature-gate values while applying the new default substitution behavior.

* **Tests**
  * Added coverage for the `MachineTaintPropagation` feature gate to verify the generated feature-gates string includes the correct value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->