### PR TITLE
OCPCLOUD-3553: change webhook failurePolicy to Fail

### DIFF
--- a/pkg/controllers/crdcompatibility/bindata/assets/compatibility-requirements-compatibility-requirement-webhook.yaml
+++ b/pkg/controllers/crdcompatibility/bindata/assets/compatibility-requirements-compatibility-requirement-webhook.yaml
@@ -17,9 +17,7 @@ webhooks:
       name: compatibility-requirements-controllers-webhook-service
       namespace: openshift-compatibility-requirements-operator
       path: /validate-apiextensions-openshift-io-v1alpha1-compatibilityrequirement
-  # XXX: This is Ignore so that we don't block cluster bootstrap.
-  # Long term we want to make this Fail, but first we need to resolve https://github.com/openshift/enhancements/pull/1941.
-  failurePolicy: Ignore
+  failurePolicy: Fail
   matchPolicy: Equivalent
   name: compatibilityrequirement.operator.openshift.io
   rules:

--- a/pkg/controllers/crdcompatibility/bindata/assets/compatibility-requirements-custom-resource-definition-webhook.yaml
+++ b/pkg/controllers/crdcompatibility/bindata/assets/compatibility-requirements-custom-resource-definition-webhook.yaml
@@ -17,9 +17,7 @@ webhooks:
       name: compatibility-requirements-controllers-webhook-service
       namespace: openshift-compatibility-requirements-operator
       path: /validate-apiextensions-k8s-io-v1-customresourcedefinition
-  # XXX: This is Ignore so that we don't block cluster bootstrap.
-  # Long term we want to make this Fail, but first we need to resolve https://github.com/openshift/enhancements/pull/1941.
-  failurePolicy: Ignore
+  failurePolicy: Fail
   matchPolicy: Equivalent
   name: compatibilityrequirement.operator.openshift.io
   rules:


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPCLOUD-3553

Reverts https://github.com/openshift/cluster-capi-operator/pull/479
Supersedes https://github.com/openshift/cluster-capi-operator/pull/486

Change CRD Compatibility Checker webhook configurations from failurePolicy: Ignore to failurePolicy: Fail now that the prerequisite Konnectivity enhancement (openshift/enhancements#1941) has been resolved.

This ensures validation is properly enforced - operations are blocked if the webhook cannot be reached, providing higher security posture and operational confidence.

Updated webhooks:
- compatibility-requirements-custom-resource-definition-webhook
- compatibility-requirements-compatibility-requirement-webhook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Validation now fails closed when webhook checks can’t be reached or don’t succeed, helping prevent invalid configuration from being admitted.
  * This applies to both compatibility requirement and custom resource definition validation, making admission behavior more consistent and strict.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->