### PR TITLE
OCPCLOUD-3538,OCPCLOUD-3556: manifests-gen: enable KRM plugins and add exclude/rename-resources transformers

### DIFF
--- a/manifests-gen/generate.go
+++ b/manifests-gen/generate.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/kustomize/api/krusty"
+	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/yaml"
 )
@@ -66,7 +67,16 @@ func generateKustomizeResources(kustomizeDir string) ([]client.Object, error) {
 	// Compile assets using kustomize.
 	fmt.Printf("> Generating OpenShift manifests based on kustomize.yaml from %q\n", kustomizeDir)
 
-	k := krusty.MakeKustomizer(krusty.MakeDefaultOptions())
+	opts := krusty.MakeDefaultOptions()
+	// EnabledPluginConfig lifts plugin restrictions (PluginRestrictionsNone) so
+	// non-builtin plugins such as container-based KRM functions (e.g. starlark
+	// transformers) are allowed. BploUseStaticallyLinked tells kustomize to
+	// resolve builtin plugins from compiled-in code rather than the filesystem.
+	opts.PluginConfig = types.EnabledPluginConfig(types.BploUseStaticallyLinked)
+	// Run KRM containers as the current user instead of "nobody" to avoid
+	// "crun: setgroups: Invalid argument" in nested rootless podman (OpenShift CI).
+	opts.PluginConfig.FnpLoadingOptions.AsCurrentUser = true
+	k := krusty.MakeKustomizer(opts)
 	fSys := filesys.MakeFsOnDisk()
 
 	res, err := k.Run(fSys, kustomizeDir)

--- a/manifests-gen/transformers/exclude-resources.yaml
+++ b/manifests-gen/transformers/exclude-resources.yaml
@@ -1,0 +1,180 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: exclude-resources
+  annotations:
+    config.kubernetes.io/function: |
+      container:
+        image: ghcr.io/kptdev/krm-functions-catalog/starlark@sha256:902f801cd887ec88cc89275672e98811dc3456dcbede2027325ac45d60c84867
+data:
+  source: |
+    # exclude-resources: removes CRDs and their associated resources from the
+    # kustomize output.
+    #
+    # Config: a ConfigMap named "exclude-resources-config" with an "excludeCRDs"
+    # key in data. Each line of its value is of the form: plural.group (e.g. machinepools.cluster.x-k8s.io)
+    #
+    # For each excluded CRD, the transformer cascades removal to:
+    #   - MutatingWebhookConfiguration/ValidatingWebhookConfiguration entries
+    #     whose rules reference the excluded resource
+    #   - ClusterRole RBAC rules that grant access to the excluded resource
+    #     (including sub-resources like /status, /finalizers)
+    #
+    # If all webhook entries in a configuration are excluded, the entire
+    # webhook configuration resource is removed.
+
+    def find_config(items):
+      """Find the exclude-resources-config ConfigMap from the resource list."""
+      for item in items:
+        if item.get("kind") == "ConfigMap" and item.get("metadata", {}).get("name") == "exclude-resources-config":
+          return item.get("data", {})
+      return None
+
+    def parse_exclude_crds(config):
+      """Parse CRD names into {group: set(plurals)} and a set of full CRD names."""
+      by_group = {}
+      crd_names = []
+      raw = config.get("excludeCRDs", "").strip()
+      if not raw:
+        return by_group, crd_names
+      for line in raw.split("\n"):
+        crd_name = line.strip()
+        if not crd_name:
+          continue
+        parts = crd_name.split(".", 1)
+        if len(parts) != 2:
+          fail("invalid CRD name (expected plural.group): " + crd_name)
+        plural = parts[0]
+        group = parts[1]
+        if group not in by_group:
+          by_group[group] = []
+        by_group[group].append(plural)
+        crd_names.append(crd_name)
+      return by_group, crd_names
+
+    def groups_for_rule(rule, by_group):
+      """Return the set of excluded groups that a rule applies to.
+
+      A wildcard ("*") in apiGroups matches all excluded groups.
+      """
+      matched = []
+      for group in rule.get("apiGroups", []):
+        if group == "*":
+          for g in by_group:
+            matched.append(g)
+        elif group in by_group:
+          matched.append(group)
+      return matched
+
+    def is_excluded_resource(resource_name, group, by_group):
+      """Check if a resource name (possibly with sub-resource) is excluded.
+
+      A wildcard ("*") in resources matches all excluded plurals in the group.
+      """
+      if group not in by_group:
+        return False
+      if resource_name == "*":
+        return True
+      base = resource_name.split("/")[0]
+      for plural in by_group[group]:
+        if base == plural:
+          return True
+      return False
+
+    def filter_webhook_rules(webhook, by_group):
+      """Filter a webhook's rules, removing entries that only target excluded resources.
+
+      Returns the filtered rules list. If a rule's apiGroups match excluded groups,
+      its resources are filtered. Rules with no remaining resources are dropped.
+      Rules with no matching groups are kept as-is.
+      """
+      filtered = []
+      for rule in webhook.get("rules", []):
+        matched_groups = groups_for_rule(rule, by_group)
+        if not matched_groups:
+          filtered.append(rule)
+          continue
+        remaining = []
+        for resource in rule.get("resources", []):
+          excluded = False
+          for group in matched_groups:
+            if is_excluded_resource(resource, group, by_group):
+              excluded = True
+              break
+          if not excluded:
+            remaining.append(resource)
+        if remaining:
+          rule["resources"] = remaining
+          filtered.append(rule)
+      return filtered
+
+    def filter_rule_resources(rule, by_group):
+      """Remove excluded resources from a ClusterRole rule."""
+      matched_groups = groups_for_rule(rule, by_group)
+      remaining = []
+      for resource in rule.get("resources", []):
+        excluded = False
+        for group in matched_groups:
+          if is_excluded_resource(resource, group, by_group):
+            excluded = True
+            break
+        if not excluded:
+          remaining.append(resource)
+      return remaining
+
+    def rule_has_excluded_group(rule, by_group):
+      """Check if any of the rule's apiGroups match an excluded group."""
+      for group in rule.get("apiGroups", []):
+        if group == "*" or group in by_group:
+          return True
+      return False
+
+    # Main logic
+    config = find_config(ctx.resource_list["items"])
+    if config == None:
+      # No config found, nothing to do
+      pass
+    else:
+      by_group, crd_names = parse_exclude_crds(config)
+
+      if by_group:
+        result = []
+        for resource in ctx.resource_list["items"]:
+          kind = resource.get("kind", "")
+          name = resource.get("metadata", {}).get("name", "")
+
+          # 1. Remove excluded CRDs
+          if kind == "CustomResourceDefinition":
+            if name in crd_names:
+              continue
+
+          # 2. Filter webhook entries (per-rule, not per-webhook)
+          if kind in ("MutatingWebhookConfiguration", "ValidatingWebhookConfiguration"):
+            webhooks = resource.get("webhooks", [])
+            filtered = []
+            for w in webhooks:
+              remaining_rules = filter_webhook_rules(w, by_group)
+              if remaining_rules:
+                w["rules"] = remaining_rules
+                filtered.append(w)
+            if not filtered:
+              continue
+            resource["webhooks"] = filtered
+
+          # 3. Filter RBAC rules for excluded resources
+          if kind == "ClusterRole":
+            rules = resource.get("rules", [])
+            filtered_rules = []
+            for rule in rules:
+              if not rule_has_excluded_group(rule, by_group):
+                filtered_rules.append(rule)
+                continue
+              remaining = filter_rule_resources(rule, by_group)
+              if remaining:
+                rule["resources"] = remaining
+                filtered_rules.append(rule)
+            resource["rules"] = filtered_rules
+
+          result.append(resource)
+
+        ctx.resource_list["items"] = result

--- a/manifests-gen/transformers/rename-resources.yaml
+++ b/manifests-gen/transformers/rename-resources.yaml
@@ -1,0 +1,120 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rename-resources
+  annotations:
+    config.kubernetes.io/function: |
+      container:
+        image: ghcr.io/kptdev/krm-functions-catalog/starlark@sha256:902f801cd887ec88cc89275672e98811dc3456dcbede2027325ac45d60c84867
+data:
+  source: |
+    # rename-resources: renames Kubernetes resources by apiGroup/Kind/name.
+    #
+    # Config: a ConfigMap named "rename-resources-config" with a "renameResources"
+    # key in data. Each line of its value is of the form: apiGroup/Kind/oldName=newName
+    #
+    # Example:
+    #   rbac.authorization.k8s.io/ClusterRole/manager-role=openshift-manager-role
+    #
+    # When a resource is renamed, references to it are automatically updated:
+    #   - ClusterRole/Role    -> ClusterRoleBinding/RoleBinding roleRef.name
+    #   - ServiceAccount      -> ClusterRoleBinding/RoleBinding subjects[].name
+    #   - Service             -> MutatingWebhookConfiguration/ValidatingWebhookConfiguration
+    #                            webhooks[].clientConfig.service.name
+
+    def find_config(items):
+      """Find the rename-resources-config ConfigMap from the resource list."""
+      for item in items:
+        if item.get("kind") == "ConfigMap" and item.get("metadata", {}).get("name") == "rename-resources-config":
+          return item.get("data", {})
+      return None
+
+    def parse_renames(config):
+      """Parse rename entries from 'apiGroup/Kind/oldName=newName' lines.
+
+      Returns a dict keyed by (apiGroup, kind, oldName) -> newName.
+      """
+      renames = {}
+      raw = config.get("renameResources", "").strip()
+      if not raw:
+        return renames
+      for line in raw.split("\n"):
+        line = line.strip()
+        if not line:
+          continue
+        parts = line.split("=", 1)
+        if len(parts) != 2:
+          fail("invalid rename (expected apiGroup/Kind/oldName=newName): " + line)
+        key = parts[0].strip()
+        new_name = parts[1].strip()
+        if not key or not new_name:
+          fail("invalid rename (both key and newName must be non-empty): " + line)
+        key_parts = key.split("/")
+        if len(key_parts) != 3:
+          fail("invalid rename key (expected apiGroup/Kind/oldName): " + key)
+        api_group = key_parts[0]
+        kind = key_parts[1]
+        old_name = key_parts[2]
+        renames[(api_group, kind, old_name)] = new_name
+      return renames
+
+    def get_api_group(resource):
+      """Extract the apiGroup from a resource's apiVersion."""
+      api_version = resource.get("apiVersion", "")
+      if "/" in api_version:
+        return api_version.split("/")[0]
+      return ""
+
+    def build_ref_maps(renames):
+      """Build lookups for updating references to renamed resources.
+
+      Role refs are keyed by (apiGroup, kind, oldName) to avoid collisions
+      between a Role and ClusterRole with the same name.
+      """
+      role_refs = {}
+      sa_refs = {}
+      svc_refs = {}
+      for (api_group, kind, old_name), new_name in renames.items():
+        if kind in ("ClusterRole", "Role"):
+          role_refs[(api_group, kind, old_name)] = new_name
+        if kind == "ServiceAccount":
+          sa_refs[old_name] = new_name
+        if kind == "Service":
+          svc_refs[old_name] = new_name
+      return role_refs, sa_refs, svc_refs
+
+    # Main logic
+    config = find_config(ctx.resource_list["items"])
+    if config == None:
+      pass
+    else:
+      renames = parse_renames(config)
+      if renames:
+        role_refs, sa_refs, svc_refs = build_ref_maps(renames)
+
+        for resource in ctx.resource_list["items"]:
+          kind = resource.get("kind", "")
+          name = resource.get("metadata", {}).get("name", "")
+          api_group = get_api_group(resource)
+
+          # Rename matching resources
+          if (api_group, kind, name) in renames:
+            resource["metadata"]["name"] = renames[(api_group, kind, name)]
+
+          # Update ClusterRoleBinding/RoleBinding roleRef to renamed ClusterRole/Role
+          if kind in ("ClusterRoleBinding", "RoleBinding"):
+            role_ref = resource.get("roleRef", {})
+            ref_key = (role_ref.get("apiGroup", ""), role_ref.get("kind", ""), role_ref.get("name", ""))
+            if ref_key in role_refs:
+              resource["roleRef"]["name"] = role_refs[ref_key]
+            # Update subjects referencing renamed ServiceAccounts
+            for subject in resource.get("subjects", []):
+              if subject.get("kind") == "ServiceAccount" and subject.get("name", "") in sa_refs:
+                subject["name"] = sa_refs[subject["name"]]
+
+          # Update webhook configs referencing renamed Services
+          if kind in ("MutatingWebhookConfiguration", "ValidatingWebhookConfiguration"):
+            for webhook in resource.get("webhooks", []):
+              svc = webhook.get("clientConfig", {}).get("service", {})
+              if svc.get("name", "") in svc_refs:
+                svc["name"] = svc_refs[svc["name"]]


### PR DESCRIPTION
## Summary

- Enable kustomize KRM function plugins in manifests-gen so that providers can reference container-based transformers (e.g. starlark) in their kustomization.yaml.
- Set `AsCurrentUser` to run KRM containers as the current user instead of `nobody`, avoiding `crun: setgroups: Invalid argument` in nested rootless podman (OpenShift CI). Kustomize hardcodes `--user nobody` by default, which triggers a `setgroups()` call that fails in nested user namespaces.
- Add two generic KRM starlark transformers that providers can use:
  - `exclude-resources`: excludes CRDs and filters associated webhook and RBAC entries. Providers supply config via an `exclude-resources-config` ConfigMap.
  - `rename-resources`: renames resources by apiGroup/Kind/name and automatically updates known references (ClusterRoleBinding/RoleBinding roleRef, binding subjects for ServiceAccounts, webhook clientConfig for Services). Providers supply config via a `rename-resources-config` ConfigMap.

## Context

See https://github.com/openshift/cluster-api-provider-aws/pull/618 and https://github.com/openshift/cluster-api/pull/304 for demonstrations of this framework in use. Those PRs currently vendor these changes locally. Once this PR merges, they will re-vendor and drop the local overrides.

## Test plan

- [ ] `cd manifests-gen && go build ./...` compiles
- [ ] Existing providers that do not reference the transformers are unaffected (no-op when not referenced in kustomization.yaml)
- [ ] CAPA PR #618 and core CAPI PR #304 validate the full end-to-end flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manifest generation now supports additional provider-defined KRM function plugins during output creation.
  * Added new config-driven resource transformers:
    * Exclude transformer to remove selected resources, including CRDs, and to prune related webhook and RBAC rules.
    * Rename transformer to rename resources and update all dependent references in bindings and webhook service targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->