### PR TITLE
OCPBUGS-98329: Add aggregated cluster role for extended per-provider RBAC

### DIFF
--- a/docs/provider-contract.md
+++ b/docs/provider-contract.md
@@ -1,5 +1,60 @@
 ## Provider Contract
 
+### capi-installer permissions
+
+By default, capi-installer has permissions to create the following resources:
+
+#### Cluster-scoped
+
+* customresourcedefinitions
+* mutatingwebhookconfigurations
+* validatingwebhookconfigurations
+* validatingadmissionpolicies
+* validatingadmissionpolicybindings
+* clusterroles
+* clusterrolebindings
+
+#### Namespaced to openshift-capi-installer
+
+* serviceaccounts
+* services
+* deployments
+* roles
+* rolebindings
+
+#### Extending capi-installer permissions
+
+If a provider must install any other resource or resources outside of the openshift-capi-installer namespace these permissions can be extended using the aggregated ClusterRole `openshift-capi-installer:provider-permissions`, which uses label `capi-operator.openshift.io/aggregate-to-installer: "true"`.
+This ClusterRole must be installed via the provider's CVO manifests.
+e.g.:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-gate: "MyProviderFeatureGate"
+  labels:
+    capi-operator.openshift.io/aggregate-to-installer: "true"
+  name: openshift-capi-installer:myprovider
+rules:
+- apiGroups:
+  - myprovider.example.com
+  resources:
+  - myresource
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+```
+
 ### Invoking manifests-gen
 
 `manifests-gen` is typically invoked in a provider repo from a `ocp-manifests` target in `openshift/Makefile`.

--- a/manifests/0000_30_cluster-api-operator_03_capi-installer-clusterrole.yaml
+++ b/manifests/0000_30_cluster-api-operator_03_capi-installer-clusterrole.yaml
@@ -269,3 +269,21 @@ rules:
   - machinesets
   verbs:
   - list
+---
+# Aggregated ClusterRole that provider repos contribute to via the
+# capi-operator.openshift.io/aggregate-to-installer label. If a provider's
+# manifests require the installer to have permissions beyond the default set
+# they can add them via a sub-role in their own repo.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-gate: "ClusterAPIMachineManagement"
+  name: openshift-capi-installer:provider-permissions
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      capi-operator.openshift.io/aggregate-to-installer: "true"

--- a/manifests/0000_30_cluster-api-operator_04_capi-installer-clusterrolebinding.yaml
+++ b/manifests/0000_30_cluster-api-operator_04_capi-installer-clusterrolebinding.yaml
@@ -91,3 +91,21 @@ subjects:
 - kind: ServiceAccount
   namespace: openshift-cluster-api-operator
   name: capi-installer
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:openshift:capi-installer:provider-permissions
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-gate: "ClusterAPIMachineManagement"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-capi-installer:provider-permissions
+subjects:
+- kind: ServiceAccount
+  name: capi-installer
+  namespace: openshift-cluster-api-operator

--- a/pkg/controllers/installer/installer_controller.go
+++ b/pkg/controllers/installer/installer_controller.go
@@ -148,6 +148,7 @@ func setupTrackingCache(mgr ctrl.Manager) (managedcache.TrackingCache, error) {
 		cache.Options{
 			Scheme:               mgr.GetScheme(),
 			DefaultLabelSelector: labels.NewSelector().Add(*managedByReq),
+			Mapper:               mgr.GetRESTMapper(),
 		},
 	)
 	if err != nil {

--- a/pkg/controllers/installer/revision_reconciler_test.go
+++ b/pkg/controllers/installer/revision_reconciler_test.go
@@ -60,7 +60,7 @@ var _ = Describe("revisionReconciler.resolveCollectedObjects", func() {
 			InstallerController: &InstallerController{
 				restMapper: wrappedMapper,
 			},
-			log: test.NewVerboseGinkgoLogger(0),
+			log: test.NewVerboseGinkgoLogger(4),
 			collectedNonNSObjects: sets.New(collectedObjectRef{
 				gvk:  unknownGK.WithVersion("v1"),
 				name: "test-object",
@@ -91,7 +91,7 @@ var _ = Describe("revisionReconciler.resolveCollectedObjects", func() {
 			InstallerController: &InstallerController{
 				restMapper: wrappedMapper,
 			},
-			log: test.NewVerboseGinkgoLogger(0),
+			log: test.NewVerboseGinkgoLogger(4),
 			collectedNonNSObjects: sets.New(collectedObjectRef{
 				gvk:  failingGK.WithVersion("v1"),
 				name: "test-object",
@@ -120,7 +120,7 @@ var _ = Describe("revisionReconciler.resolveCollectedObjects", func() {
 			InstallerController: &InstallerController{
 				restMapper: wrappedMapper,
 			},
-			log: test.NewVerboseGinkgoLogger(0),
+			log: test.NewVerboseGinkgoLogger(4),
 			collectedNonNSObjects: sets.New(collectedObjectRef{
 				gvk:  crdGK.WithVersion("v1"),
 				name: "test-widget",
@@ -156,7 +156,7 @@ var _ = Describe("revisionReconciler.resolveCollectedObjects", func() {
 			InstallerController: &InstallerController{
 				restMapper: wrappedMapper,
 			},
-			log: test.NewVerboseGinkgoLogger(0),
+			log: test.NewVerboseGinkgoLogger(4),
 			collectedNonNSObjects: sets.New(collectedObjectRef{
 				gvk:  clusterRoleGK.WithVersion("v1"),
 				name: "test-clusterrole",

--- a/pkg/controllers/installer/suite_test.go
+++ b/pkg/controllers/installer/suite_test.go
@@ -65,7 +65,7 @@ func TestInstallerController(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	logger := test.NewVerboseGinkgoLogger(0)
+	logger := test.NewVerboseGinkgoLogger(4)
 	logf.SetLogger(logger)
 
 	By("bootstrapping test environment")

--- a/pkg/controllers/machinemigration/suite_test.go
+++ b/pkg/controllers/machinemigration/suite_test.go
@@ -56,7 +56,7 @@ func TestMachineMigration(t *testing.T) {
 var _ = BeforeSuite(func() {
 	klog.SetOutput(GinkgoWriter)
 
-	testLogger = test.NewVerboseGinkgoLogger(0)
+	testLogger = test.NewVerboseGinkgoLogger(4)
 	logf.SetLogger(testLogger)
 	ctrl.SetLogger(testLogger)
 

--- a/pkg/controllers/machinesetmigration/suite_test.go
+++ b/pkg/controllers/machinesetmigration/suite_test.go
@@ -56,7 +56,7 @@ func TestMachineSetMigration(t *testing.T) {
 var _ = BeforeSuite(func() {
 	klog.SetOutput(GinkgoWriter)
 
-	testLogger = test.NewVerboseGinkgoLogger(0)
+	testLogger = test.NewVerboseGinkgoLogger(4)
 	logf.SetLogger(testLogger)
 	ctrl.SetLogger(testLogger)
 

--- a/pkg/controllers/machinesetsync/suite_test.go
+++ b/pkg/controllers/machinesetsync/suite_test.go
@@ -66,7 +66,7 @@ func TestAPIs(t *testing.T) {
 var _ = BeforeSuite(func() {
 	klog.SetOutput(GinkgoWriter)
 
-	testLogger = test.NewVerboseGinkgoLogger(0)
+	testLogger = test.NewVerboseGinkgoLogger(4)
 	logf.SetLogger(testLogger)
 	ctrl.SetLogger(testLogger)
 

--- a/pkg/controllers/machinesync/machine_sync_controller_test.go
+++ b/pkg/controllers/machinesync/machine_sync_controller_test.go
@@ -1439,44 +1439,45 @@ var _ = Describe("With a running MachineSync Reconciler", func() {
 
 		Context("cluster api vap tests", func() {
 			BeforeEach(func() {
-				By("Waiting for VAP to be ready")
+				By("Waiting for VAP to be ready", func() {
+					machineVap = &admissionregistrationv1.ValidatingAdmissionPolicy{}
+					machineVap.Name = clusterAPIMachineVAPName
+					Eventually(k.Update(machineVap, func() {
+						admissiontestutils.AddSentinelValidation(machineVap)
+					})).Should(Succeed())
 
-				machineVap = &admissionregistrationv1.ValidatingAdmissionPolicy{}
-				Eventually(k8sClient.Get(ctx, client.ObjectKey{Name: clusterAPIMachineVAPName}, machineVap), setupTimeout).Should(Succeed())
-				Eventually(k.Update(machineVap, func() {
-					admissiontestutils.AddSentinelValidation(machineVap)
-				})).Should(Succeed())
+					sentinelGeneration := machineVap.Generation
+					Eventually(k.Object(machineVap), setupTimeout).Should(
+						HaveField("Status.ObservedGeneration", BeNumerically(">=", sentinelGeneration)),
+					)
+				})
 
-				Eventually(k.Object(machineVap), setupTimeout).Should(
-					HaveField("Status.ObservedGeneration", BeNumerically(">=", 2)),
-				)
+				By("Updating the VAP binding", func() {
+					policyBinding = &admissionregistrationv1.ValidatingAdmissionPolicyBinding{}
+					Eventually(k8sClient.Get(ctx, client.ObjectKey{
+						Name: clusterAPIMachineVAPName}, policyBinding), setupTimeout).Should(Succeed())
 
-				By("Updating the VAP binding")
+					Eventually(k.Update(policyBinding, func() {
+						admissiontestutils.UpdateVAPBindingNamespaces(policyBinding, mapiNamespace.GetName(), capiNamespace.GetName())
+					}), timeout).Should(Succeed())
 
-				policyBinding = &admissionregistrationv1.ValidatingAdmissionPolicyBinding{}
-				Eventually(k8sClient.Get(ctx, client.ObjectKey{
-					Name: clusterAPIMachineVAPName}, policyBinding), setupTimeout).Should(Succeed())
+					// Wait until the binding shows the patched values
+					Eventually(k.Object(policyBinding), setupTimeout).Should(
+						SatisfyAll(
+							HaveField("Spec.ParamRef.Namespace",
+								Equal(mapiNamespace.GetName())),
 
-				Eventually(k.Update(policyBinding, func() {
-					admissiontestutils.UpdateVAPBindingNamespaces(policyBinding, mapiNamespace.GetName(), capiNamespace.GetName())
-				}), timeout).Should(Succeed())
+							HaveField("Spec.MatchResources.NamespaceSelector.MatchLabels",
+								HaveKeyWithValue("kubernetes.io/metadata.name",
+									capiNamespace.GetName())),
+						),
+					)
+				})
 
-				// Wait until the binding shows the patched values
-				Eventually(k.Object(policyBinding), setupTimeout).Should(
-					SatisfyAll(
-						HaveField("Spec.ParamRef.Namespace",
-							Equal(mapiNamespace.GetName())),
-
-						HaveField("Spec.MatchResources.NamespaceSelector.MatchLabels",
-							HaveKeyWithValue("kubernetes.io/metadata.name",
-								capiNamespace.GetName())),
-					),
-				)
-
-				By("Creating the sentinel CAPI infra machine")
-
-				capaMachine = capaMachineBuilder.WithName("sentinel-machine").Build()
-				Eventually(k8sClient.Create(ctx, capaMachine)).Should(Succeed(), "capa machine should be able to be created")
+				By("Creating the sentinel CAPI infra machine", func() {
+					capaMachine = capaMachineBuilder.WithName("sentinel-machine").Build()
+					Eventually(k8sClient.Create(ctx, capaMachine)).Should(Succeed(), "capa machine should be able to be created")
+				})
 
 				capaMachineRef := clusterv1.ContractVersionedObjectReference{
 					Kind:     capaMachine.Kind,
@@ -1484,37 +1485,41 @@ var _ = Describe("With a running MachineSync Reconciler", func() {
 					APIGroup: awsv1.GroupVersion.Group,
 				}
 
-				By("Creating a sentinel CAPI machine")
-
 				testMachine := capiMachineBuilder.WithName("sentinel-machine").WithInfrastructureRef(capaMachineRef).Build()
-				Eventually(k8sClient.Create(ctx, testMachine), timeout).Should(Succeed())
 
-				By("setting the owner reference on the sentinel CAPI infra machine")
-				Eventually(k.Update(capaMachine, func() {
-					capaMachine.SetOwnerReferences([]metav1.OwnerReference{
-						{
-							Kind:               machineKind,
-							APIVersion:         clusterv1.GroupVersion.String(),
-							Name:               testMachine.Name,
-							UID:                testMachine.UID,
-							BlockOwnerDeletion: ptr.To(true),
-							Controller:         ptr.To(false),
-						},
-					})
-				})).Should(Succeed())
+				By("Creating a sentinel CAPI machine", func() {
+					Eventually(k8sClient.Create(ctx, testMachine), timeout).Should(Succeed())
+				})
 
-				By("Creating a sentinel MAPI Machine")
+				By("setting the owner reference on the sentinel CAPI infra machine", func() {
+					Eventually(k.Update(capaMachine, func() {
+						capaMachine.SetOwnerReferences([]metav1.OwnerReference{
+							{
+								Kind:               machineKind,
+								APIVersion:         clusterv1.GroupVersion.String(),
+								Name:               testMachine.Name,
+								UID:                testMachine.UID,
+								BlockOwnerDeletion: ptr.To(true),
+								Controller:         ptr.To(false),
+							},
+						})
+					})).Should(Succeed())
+				})
 
 				testMapiMachine := mapiMachineBuilder.WithName(testMachine.Name).Build()
-				Eventually(k8sClient.Create(ctx, testMapiMachine), timeout).Should(Succeed())
 
-				By("Setting the sentinel MAPI machine AuthoritativeAPI to Machine API")
-				Eventually(k.UpdateStatus(testMapiMachine, func() {
-					testMapiMachine.Status.AuthoritativeAPI = mapiv1beta1.MachineAuthorityMachineAPI
-				})).Should(Succeed())
+				By("Creating a sentinel MAPI Machine", func() {
+					Eventually(k8sClient.Create(ctx, testMapiMachine), timeout).Should(Succeed())
+				})
 
-				Eventually(k.Object(testMapiMachine), timeout).Should(
-					HaveField("Status.AuthoritativeAPI", Equal(mapiv1beta1.MachineAuthorityMachineAPI)))
+				By("Setting the sentinel MAPI machine AuthoritativeAPI to Machine API", func() {
+					Eventually(k.UpdateStatus(testMapiMachine, func() {
+						testMapiMachine.Status.AuthoritativeAPI = mapiv1beta1.MachineAuthorityMachineAPI
+					})).Should(Succeed())
+
+					Eventually(k.Object(testMapiMachine), timeout).Should(
+						HaveField("Status.AuthoritativeAPI", Equal(mapiv1beta1.MachineAuthorityMachineAPI)))
+				})
 
 				// The sync controller copies labels MAPI → CAPI. Labels under
 				// machine.openshift.io/* and cluster.x-k8s.io/* are controller-managed and
@@ -1522,9 +1527,11 @@ var _ = Describe("With a running MachineSync Reconciler", func() {
 				// populated, our change can drop them and be rejected. Wait for sync, then add
 				// the test sentinel.
 
-				Eventually(k.Object(testMachine), timeout).Should(
-					HaveField("ObjectMeta.Labels", Not(BeNil())),
-				)
+				By("Waiting for the sentinel CAPI machine to be synced to the sentinel MAPI machine", func() {
+					Eventually(k.Object(testMachine), timeout).Should(
+						HaveField("ObjectMeta.Labels", Not(BeNil())),
+					)
+				})
 
 				Eventually(k.Update(testMachine, func() {
 					testMachine.ObjectMeta.Labels["test-sentinel"] = "fubar"

--- a/pkg/controllers/machinesync/suite_test.go
+++ b/pkg/controllers/machinesync/suite_test.go
@@ -71,7 +71,7 @@ func TestAPIs(t *testing.T) {
 var _ = BeforeSuite(func() {
 	klog.SetOutput(GinkgoWriter)
 
-	testLogger = test.NewVerboseGinkgoLogger(0)
+	testLogger = test.NewVerboseGinkgoLogger(4)
 	logf.SetLogger(testLogger)
 	ctrl.SetLogger(testLogger)
 


### PR DESCRIPTION
Adds `openshift-capi-installer:provider-permissions` ClusterRole and binds it to capi-installer. This is an aggregated cluster rule which uses the label `capi-operator.openshift.io/aggregate-to-installer`. If a provider's manifests include any object which the default CAPIO RBAC does not cover they can specify their additional requirements in their own repo as a separate ClusterRole which aggregates to this one.

Also fixes a bug initialising boxcutter's tracking cache which turns missing RBAC into a panic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added aggregated installer provider RBAC: a new cluster-scoped `ClusterRole` and a corresponding `ClusterRoleBinding` to grant `capi-installer` the default provider-permissions via label-driven aggregation.
- **Bug Fixes**
  - Improved installer managed tracking by wiring the correct REST mapping for cluster-scoped resources.
- **Documentation**
  - Expanded the provider contract with a new “capi-installer permissions” section, including an example of extending permissions through the aggregated `ClusterRole`.
- **Tests**
  - Increased test logging verbosity and refined machine sync readiness/sentinel workflow assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->