### PR TITLE
OCPBUGS-98492: Fix CAPI MachineSet deletion when MAPI MachineSet has already been deleted

### DIFF
--- a/pkg/controllers/machinesetsync/machineset_sync_controller.go
+++ b/pkg/controllers/machinesetsync/machineset_sync_controller.go
@@ -172,6 +172,23 @@ func (r *MachineSetSyncReconciler) Reconcile(ctx context.Context, req reconcile.
 	}
 
 	if mapiMachineSet == nil {
+		if capiMachineSet == nil {
+			logger.Info("Both MAPI and CAPI machine sets not found, nothing to do")
+			return ctrl.Result{}, nil
+		}
+
+		// The MAPI MachineSet has already been deleted.
+		// If the CAPI MachineSet is deleting and still has our sync finalizer,
+		// reconcile its deletion so the finalizer can be removed.
+		if shouldRequeue, err := r.reconcileCAPItoMAPIMachineSetDeletion(ctx, nil, capiMachineSet); err != nil {
+			return ctrl.Result{}, fmt.Errorf(
+				"failed to reconcile Cluster API machine set deletion: %w",
+				err,
+			)
+		} else if shouldRequeue {
+			return ctrl.Result{}, nil
+		}
+
 		logger.Info("Only CAPI machine set found, nothing to do")
 		return ctrl.Result{}, nil
 	}

--- a/pkg/controllers/machinesetsync/machineset_sync_controller.go
+++ b/pkg/controllers/machinesetsync/machineset_sync_controller.go
@@ -172,11 +172,6 @@ func (r *MachineSetSyncReconciler) Reconcile(ctx context.Context, req reconcile.
 	}
 
 	if mapiMachineSet == nil {
-		if capiMachineSet == nil {
-			logger.Info("Both MAPI and CAPI machine sets not found, nothing to do")
-			return ctrl.Result{}, nil
-		}
-
 		// The MAPI MachineSet has already been deleted.
 		// If the CAPI MachineSet is deleting and still has our sync finalizer,
 		// reconcile its deletion so the finalizer can be removed.
@@ -190,6 +185,7 @@ func (r *MachineSetSyncReconciler) Reconcile(ctx context.Context, req reconcile.
 		}
 
 		logger.Info("Only CAPI machine set found, nothing to do")
+
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/controllers/machinesetsync/machineset_sync_controller_test.go
+++ b/pkg/controllers/machinesetsync/machineset_sync_controller_test.go
@@ -1168,6 +1168,31 @@ var _ = Describe("With a running MachineSetSync controller", func() {
 				ContainElement(HaveField("ObjectMeta.Name", Equal(capiMachineSet.GetName()))),
 			))
 		})
+
+		// Regression test for OCPBUGS-98492: ensure the sync finalizer is removed
+		// when the MAPI MachineSet is already absent.
+		Context("when the CAPI machine set has the sync finalizer and is being deleted", func() {
+			BeforeEach(func() {
+				By("Adding the sync finalizer to the CAPI machine set")
+				Eventually(k.Update(capiMachineSet, func() {
+					capiMachineSet.SetFinalizers([]string{machinesync.SyncFinalizer})
+				})).Should(Succeed())
+
+				By("Waiting for the manager's informer cache to observe the finalizer")
+				eventuallyManagerInformerCache(capiMachineSet).Should(
+					HaveField("ObjectMeta.Finalizers", ContainElement(machinesync.SyncFinalizer)),
+				)
+
+				By("Deleting the CAPI machine set")
+				Eventually(kDelete(ctx, capiMachineSet)).Should(Succeed())
+			})
+
+			It("should remove the sync finalizer and allow the CAPI machine set to be deleted", func() {
+				Eventually(k.Get(capiMachineSet), timeout).Should(
+					WithTransform(apierrors.IsNotFound, BeTrue()),
+				)
+			})
+		})
 	})
 
 	Context("when the CAPI infra machine template resource does not exist", func() {


### PR DESCRIPTION
Summary

When a CAPI MachineSet is reconciled after its corresponding MAPI MachineSet has already been removed, the existing deletion reconciliation is not executed, leaving the sync.machine.openshift.io/finalizer on the CAPI MachineSet and preventing it from completing deletion.

This change updates the reconciliation flow to invoke the existing CAPI deletion reconciliation when the MAPI MachineSet is absent, allowing the controller to remove the sync finalizer and complete CAPI MachineSet deletion.

This PR also adds a regression integration test covering the scenario where the MAPI MachineSet is absent and the CAPI MachineSet is deleted while still carrying the sync finalizer. The test failed prior to this change and now passes.

Additionally, this PR removes an unreachable `capiMachineSet == nil` check from Reconcile(), since that case is already handled by the earlier `mapiMachineSet == nil && capiMachineSet == nil` check.

Testing
✅ Added a regression integration test for OCPBUGS-98492
✅ Verified the regression test fails without the fix and passes with the fix
✅ Ran the full MachineSetSync test suite (123/123 passing)

#### Fixes: [OCPBUGS-98492](https://redhat.atlassian.net/browse/OCPBUGS-98492)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization cleanup when the MAPI MachineSet is missing while the CAPI MachineSet is being deleted.
  * Deletion handling now proceeds reliably from the CAPI side, with retry/requeue behavior honored, preventing stale resources from remaining stuck.
* **Tests**
  * Added a regression test covering removal of the sync finalizer and full deletion of the CAPI MachineSet when the MAPI MachineSet does not exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->