### PR TITLE
OCPBUGS-85063: Fix CredentialsRequest capability annotations

### DIFF
--- a/manifests/0000_30_cluster-api_01_credentials-request.yaml
+++ b/manifests/0000_30_cluster-api_01_credentials-request.yaml
@@ -270,7 +270,7 @@ metadata:
   name: openshift-cluster-api-vsphere
   namespace: openshift-cloud-credential-operator
   annotations:
-    capability.openshift.io/name: ClusterAPI
+    capability.openshift.io/name: CloudCredential+ClusterAPI
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-gate: "ClusterAPIMachineManagement"
@@ -280,22 +280,4 @@ spec:
     kind: VSphereProviderSpec
   secretRef:
     name: capv-manager-bootstrap-credentials
-    namespace: openshift-cluster-api
----
-apiVersion: cloudcredential.openshift.io/v1
-kind: CredentialsRequest
-metadata:
-  name: openshift-cluster-api-baremetal
-  namespace: openshift-cloud-credential-operator
-  annotations:
-    capability.openshift.io/name: ClusterAPI
-    exclude.release.openshift.io/internal-openshift-hosted: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
-    release.openshift.io/feature-gate: "ClusterAPIMachineManagement"
-spec:
-  providerSpec:
-    apiVersion: cloudcredential.openshift.io/v1
-    kind: Metal3ProviderSpec
-  secretRef:
-    name: capm3-manager-bootstrap-credentials
     namespace: openshift-cluster-api


### PR DESCRIPTION
## Summary

- Add `CloudCredential` to vSphere CredentialsRequest capability annotation so the CVO skips it when `CloudCredential` is disabled
- Remove the baremetal CredentialsRequest — the secret it provisions is unused

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the vSphere credentials capability classification to include cloud credentials and Cluster API.
  * Removed the obsolete bare-metal Cluster API credentials request from the manifest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->