### PR TITLE
OCPBUGS-99541: rbac: allow capi-installer to manage and watch ConfigMaps

### DIFF
--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -13,7 +13,7 @@ The `capi-operator` and `capi-installer` ServiceAccounts (in `openshift-cluster-
 | `0000_30_cluster-api-operator_03_clusterrole.yaml` | Role `capi-operator` | `openshift-cluster-api` | `capi-operator` | Deployment read, ConfigMap read |
 | `0000_30_cluster-api-operator_03_capi-installer-clusterrole.yaml` | ClusterRole `openshift-capi-installer` | cluster-wide | `capi-installer` | CRDs, admission resources, cluster RBAC, config.openshift.io, ClusterAPI/ClusterOperator status, tracking cache informers |
 | `0000_30_cluster-api-operator_03_capi-installer-clusterrole.yaml` | Role `capi-installer` | `openshift-cluster-api-operator` | `capi-installer` | Leader election leases, pod self-read, ConfigMap read, events |
-| `0000_30_cluster-api-operator_03_capi-installer-clusterrole.yaml` | Role `capi-installer` | `openshift-cluster-api` | `capi-installer` | boxcutter-managed resources (ServiceAccounts, Services, Deployments, Roles, RoleBindings), VAP paramRef list |
+| `0000_30_cluster-api-operator_03_capi-installer-clusterrole.yaml` | Role `capi-installer` | `openshift-cluster-api` | `capi-installer` | boxcutter-managed resources (ConfigMaps, ServiceAccounts, Services, Deployments, Roles, RoleBindings), VAP paramRef list |
 | `0000_30_cluster-api-operator_03_capi-installer-clusterrole.yaml` | Role `capi-installer` | `openshift-machine-api` | `capi-installer` | VAP paramRef list (machines, machinesets) |
 
 Both SAs also bind to ClusterRole `system:openshift:openshift-cluster-api:read-tls-configuration` for APIServer TLS profile reading.

--- a/manifests/0000_30_cluster-api-operator_03_capi-installer-clusterrole.yaml
+++ b/manifests/0000_30_cluster-api-operator_03_capi-installer-clusterrole.yaml
@@ -129,6 +129,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
   - serviceaccounts
   - services
   verbs:
@@ -204,6 +205,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
   - serviceaccounts
   - services
   verbs:


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/OCPBUGS-99541 (split out of OCPBUGS-98576, component readiness regression 43136).

## Problem

Since the least-privilege RBAC change (e938299d), the `openshift-capi-installer` ClusterRole grants the boxcutter tracking cache cluster-scoped `watch` on ServiceAccounts, Services, Deployments, Roles and RoleBindings — but not ConfigMaps. On metal TechPreview clusters the provider revision includes `/v1, Kind=ConfigMap` in its watched GVKs (see the installer's "Watching GVKs" log line), so every `InstallerController` reconcile fails:

```
E0717 04:31:36 controller.go:495] "Reconciler error" err="watching GVKs: configmaps is forbidden:
User \"system:serviceaccount:openshift-cluster-api-operator:capi-installer\" cannot watch resource
\"configmaps\" in API group \"\" at the cluster scope"
```

Before #624/09fff437 this additionally crash-looped the pod (nil REST mapper panic in boxcutter's `trackingCache.handleCacheWatchError`, 50–67 restarts per CI run). With the panic fixed the installer still never converges: CAPI providers are not installed, the capm3 `Metal3Cluster` conversion webhook has no endpoints, **all namespace deletions cluster-wide block** on Metal3Cluster discovery (~2000 namespaces stuck `Terminating` per run), leaked e2e pods saturate worker `maxPods=250`, and workers go NotReady — failing `verify all nodes should be ready` on the metal techpreview lanes since ~July 8.

Evidence (see OCPBUGS-99541 for full analysis):
- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-main-nightly-5.0-e2e-metal-ipi-ovn-dualstack-rhcos9-10-techpreview/2074836521076133888 (panic + crashloop, 67 restarts)
- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-main-nightly-5.0-e2e-metal-ipi-ovn-dualstack-techpreview/2077964182824685568 (post-panic-fix payload: 164 `configmaps is forbidden` reconcile errors, installer never converges; `gather-extra/artifacts/pods/openshift-cluster-api-operator_capi-installer-76db766b96-x7xfr_capi-installer.log`)

## Fix

- Add `configmaps` (get/list/watch) to the tracking-cache rules of the `openshift-capi-installer` ClusterRole.
- Add `configmaps` (create/get/update/patch/delete) to the boxcutter apply Role in `openshift-cluster-api`, since the same revision object must also be applied there.
- Update `docs/rbac.md`.

---
This PR was generated using AI. Please verify before acting on it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added required ConfigMap permissions for cluster API installation and management workflows.

- **Documentation**
  - Clarified the managed resources covered by the installer’s role-based access control permissions, including ConfigMaps and Role/RoleBinding objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->