### PR TITLE
OCPCLOUD-3647: Consolidate install-time object processing in toBoxcutterRevision

### DIFF
--- a/pkg/controllers/installer/boxcutter.go
+++ b/pkg/controllers/installer/boxcutter.go
@@ -17,6 +17,8 @@ limitations under the License.
 package installer
 
 import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"pkg.package-operator.run/boxcutter"
 	"pkg.package-operator.run/boxcutter/probing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -26,6 +28,16 @@ import (
 )
 
 // toBoxcutterRevision converts an InstallerRevision to a boxcutter.Revision.
+// Each component in an InstallerRevision contains a parsed collection of
+// objects with no further ordering. toBoxcutterRevision creates a Revision
+// containing the following phases for each of these components:
+// - a phase for the component's CRDs, if any
+// - a phase for the component's remaining objects, if any
+//
+// Although this is not yet the case, toBoxcutterRevision is intended to capture
+// all processing required only at installation time. Ideally InstallerRevision
+// will contain only parsed versions of exactly what was in provider manifests
+// without any further processing. That processing should be done here.
 func toBoxcutterRevision(installerRevision revisiongenerator.InstallerRevision) boxcutter.Revision {
 	probeOpts := util.SliceMap(allProbes(), func(p *probing.GroupKindSelector) boxcutter.PhaseReconcileOption {
 		return boxcutter.WithProbe(boxcutter.ProgressProbeType, p)
@@ -33,18 +45,32 @@ func toBoxcutterRevision(installerRevision revisiongenerator.InstallerRevision) 
 
 	var phases []boxcutter.Phase
 
-	for _, component := range installerRevision.Components() {
-		if crds := component.CRDs(); len(crds) > 0 {
-			objects, adoptOpts := processAdoptExistingAnnotations(crds)
-			phases = append(phases, boxcutter.NewPhase(component.Name()+"-crds", objects).
-				WithReconcileOptions(append(probeOpts, adoptOpts...)...))
+	addPhase := func(name string, objects []*unstructured.Unstructured) {
+		if len(objects) == 0 {
+			return
 		}
 
-		if objects := component.Objects(); len(objects) > 0 {
-			objects, adoptOpts := processAdoptExistingAnnotations(objects)
-			phases = append(phases, boxcutter.NewPhase(component.Name(), objects).
-				WithReconcileOptions(append(probeOpts, adoptOpts...)...))
+		objects, adoptOpts := processAdoptExistingAnnotations(objects)
+		bcPhase := boxcutter.NewPhase(name, util.SliceMap(objects, toClientObject)).
+			WithReconcileOptions(append(probeOpts, adoptOpts...)...)
+
+		phases = append(phases, bcPhase)
+	}
+
+	for _, component := range installerRevision.Components() {
+		var crds, objects []*unstructured.Unstructured
+
+		for _, obj := range component.Objects() {
+			gvk := obj.GetObjectKind().GroupVersionKind()
+			if gvk.GroupKind() == (schema.GroupKind{Group: "apiextensions.k8s.io", Kind: "CustomResourceDefinition"}) {
+				crds = append(crds, obj)
+			} else {
+				objects = append(objects, obj)
+			}
 		}
+
+		addPhase(component.Name()+"-crds", crds)
+		addPhase(component.Name(), objects)
 	}
 
 	return boxcutter.NewRevision(
@@ -62,10 +88,10 @@ func toBoxcutterRevision(installerRevision revisiongenerator.InstallerRevision) 
 //
 // This function assumes that annotation values have already been validated
 // during revision creation.
-func processAdoptExistingAnnotations(objects []client.Object) ([]client.Object, []boxcutter.PhaseReconcileOption) {
+func processAdoptExistingAnnotations(objects []*unstructured.Unstructured) ([]*unstructured.Unstructured, []boxcutter.PhaseReconcileOption) {
 	var reconcileOpts []boxcutter.PhaseReconcileOption
 
-	return util.SliceMap(objects, func(obj client.Object) client.Object {
+	return util.SliceMap(objects, func(obj *unstructured.Unstructured) *unstructured.Unstructured {
 		annotations := obj.GetAnnotations()
 		value, hasAnnotation := annotations[revisiongenerator.AdoptExistingAnnotation]
 
@@ -80,7 +106,7 @@ func processAdoptExistingAnnotations(objects []client.Object) ([]client.Object, 
 			}
 
 			// Strip the annotation from the object before returning it
-			obj = obj.DeepCopyObject().(client.Object) //nolint:forcetypeassert // This is guaranteed to be client.Object because obj is client.Object
+			obj = obj.DeepCopy()
 			annotationsCopy := obj.GetAnnotations()
 			delete(annotationsCopy, revisiongenerator.AdoptExistingAnnotation)
 			obj.SetAnnotations(annotationsCopy)
@@ -88,4 +114,8 @@ func processAdoptExistingAnnotations(objects []client.Object) ([]client.Object, 
 
 		return obj
 	}), reconcileOpts
+}
+
+func toClientObject(obj *unstructured.Unstructured) client.Object {
+	return obj
 }

--- a/pkg/controllers/installer/boxcutter.go
+++ b/pkg/controllers/installer/boxcutter.go
@@ -25,56 +25,33 @@ import (
 	"github.com/openshift/cluster-capi-operator/pkg/util"
 )
 
+// toBoxcutterRevision converts an InstallerRevision to a boxcutter.Revision.
 func toBoxcutterRevision(installerRevision revisiongenerator.InstallerRevision) boxcutter.Revision {
-	return boxcutterRevision{revision: installerRevision}
-}
-
-// boxcutterRevision wraps an InstallerRevision and provides a boxcutter.Revision implementation.
-type boxcutterRevision struct {
-	revision revisiongenerator.InstallerRevision
-}
-
-var _ boxcutter.Revision = boxcutterRevision{}
-
-// GetName returns the name of the revision.
-func (r boxcutterRevision) GetName() string {
-	return string(r.revision.RevisionName())
-}
-
-// GetRevisionNumber returns the revision number of the revision.
-func (r boxcutterRevision) GetRevisionNumber() int64 {
-	return r.revision.RevisionIndex()
-}
-
-// GetPhases returns the phases of the revision.
-func (r boxcutterRevision) GetPhases() []boxcutter.Phase {
 	probeOpts := util.SliceMap(allProbes(), func(p *probing.GroupKindSelector) boxcutter.PhaseReconcileOption {
 		return boxcutter.WithProbe(boxcutter.ProgressProbeType, p)
 	})
 
 	var phases []boxcutter.Phase
 
-	for _, component := range r.revision.Components() {
+	for _, component := range installerRevision.Components() {
 		if crds := component.CRDs(); len(crds) > 0 {
 			objects, adoptOpts := processAdoptExistingAnnotations(crds)
-			phases = append(phases, boxcutterPhase{
-				name:             component.Name() + "-crds",
-				objects:          objects,
-				reconcileOptions: append(probeOpts, adoptOpts...),
-			})
+			phases = append(phases, boxcutter.NewPhase(component.Name()+"-crds", objects).
+				WithReconcileOptions(append(probeOpts, adoptOpts...)...))
 		}
 
 		if objects := component.Objects(); len(objects) > 0 {
 			objects, adoptOpts := processAdoptExistingAnnotations(objects)
-			phases = append(phases, boxcutterPhase{
-				name:             component.Name(),
-				objects:          objects,
-				reconcileOptions: append(probeOpts, adoptOpts...),
-			})
+			phases = append(phases, boxcutter.NewPhase(component.Name(), objects).
+				WithReconcileOptions(append(probeOpts, adoptOpts...)...))
 		}
 	}
 
-	return phases
+	return boxcutter.NewRevision(
+		string(installerRevision.RevisionName()),
+		installerRevision.RevisionIndex(),
+		phases,
+	)
 }
 
 // processAdoptExistingAnnotations processes the adopt-existing annotation on
@@ -111,42 +88,4 @@ func processAdoptExistingAnnotations(objects []client.Object) ([]client.Object, 
 
 		return obj
 	}), reconcileOpts
-}
-
-// GetReconcileOptions returns the reconcile options of the revision.
-func (r boxcutterRevision) GetReconcileOptions() []boxcutter.RevisionReconcileOption {
-	return nil
-}
-
-// GetTeardownOptions returns the teardown options of the revision.
-func (r boxcutterRevision) GetTeardownOptions() []boxcutter.RevisionTeardownOption {
-	return nil
-}
-
-type boxcutterPhase struct {
-	name             string
-	objects          []client.Object
-	reconcileOptions []boxcutter.PhaseReconcileOption
-}
-
-var _ boxcutter.Phase = boxcutterPhase{}
-
-// GetName returns the name of the phase.
-func (p boxcutterPhase) GetName() string {
-	return p.name
-}
-
-// GetObjects returns the objects of the phase.
-func (p boxcutterPhase) GetObjects() []client.Object {
-	return p.objects
-}
-
-// GetReconcileOptions returns the reconcile options of the phase.
-func (p boxcutterPhase) GetReconcileOptions() []boxcutter.PhaseReconcileOption {
-	return p.reconcileOptions
-}
-
-// GetTeardownOptions returns the teardown options of the phase.
-func (p boxcutterPhase) GetTeardownOptions() []boxcutter.PhaseTeardownOption {
-	return nil
 }

--- a/pkg/controllers/installer/boxcutter.go
+++ b/pkg/controllers/installer/boxcutter.go
@@ -38,7 +38,7 @@ import (
 // all processing required only at installation time. Ideally InstallerRevision
 // will contain only parsed versions of exactly what was in provider manifests
 // without any further processing. That processing should be done here.
-func toBoxcutterRevision(installerRevision revisiongenerator.InstallerRevision) boxcutter.Revision {
+func toBoxcutterRevision(installerRevision revisiongenerator.InstallerRevision, collectObjects func(obj *unstructured.Unstructured)) boxcutter.Revision {
 	probeOpts := util.SliceMap(allProbes(), func(p *probing.GroupKindSelector) boxcutter.PhaseReconcileOption {
 		return boxcutter.WithProbe(boxcutter.ProgressProbeType, p)
 	})
@@ -61,6 +61,8 @@ func toBoxcutterRevision(installerRevision revisiongenerator.InstallerRevision) 
 		var crds, objects []*unstructured.Unstructured
 
 		for _, obj := range component.Objects() {
+			collectObjects(obj)
+
 			gvk := obj.GetObjectKind().GroupVersionKind()
 			if gvk.GroupKind() == (schema.GroupKind{Group: "apiextensions.k8s.io", Kind: "CustomResourceDefinition"}) {
 				crds = append(crds, obj)

--- a/pkg/controllers/installer/boxcutter_test.go
+++ b/pkg/controllers/installer/boxcutter_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package installer
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/cluster-capi-operator/pkg/revisiongenerator"
+)
+
+// installerRevisionFromProfiles builds an InstallerRevision from named provider profiles
+// already registered in providersByName. Delegates to the package-level lookupProfiles helper
+// so the heavy profile setup stays in BeforeSuite.
+func installerRevisionFromProfiles(names ...string) revisiongenerator.InstallerRevision {
+	GinkgoHelper()
+
+	profiles := lookupProfiles(names...)
+
+	rendered, err := revisiongenerator.NewRenderedRevision(profiles)
+	Expect(err).NotTo(HaveOccurred(), "NewRenderedRevision should not fail for valid profiles")
+
+	rev, err := rendered.ForInstall("4.18.0-test", 1)
+	Expect(err).NotTo(HaveOccurred(), "ForInstall should not fail for a valid rendered revision")
+
+	return rev
+}
+
+var _ = Describe("toBoxcutterRevision", func() {
+	Describe("construction", func() {
+		It("should return a Revision with the name of the InstallerRevision", func() {
+			rev := installerRevisionFromProfiles(providerCore)
+
+			bcRev := toBoxcutterRevision(rev)
+
+			Expect(bcRev.GetName()).To(Equal(string(rev.RevisionName())),
+				"returned Revision should carry the same name as the InstallerRevision")
+		})
+	})
+
+	Describe("GetPhases idempotency", func() {
+		DescribeTable("should return stable phases on every call",
+			func(providerName string, wantPhaseCount int) {
+				rev := installerRevisionFromProfiles(providerName)
+
+				bcRev := toBoxcutterRevision(rev)
+
+				first := bcRev.GetPhases()
+				second := bcRev.GetPhases()
+
+				Expect(second).To(HaveLen(wantPhaseCount),
+					"expected %d phase(s) for provider %q", wantPhaseCount, providerName)
+
+				for i := range first {
+					Expect(second[i].GetName()).To(Equal(first[i].GetName()),
+						"phase[%d] name must be stable across GetPhases calls", i)
+					Expect(second[i].GetObjects()).To(HaveLen(len(first[i].GetObjects())),
+						"phase[%d] object count must be stable across GetPhases calls", i)
+				}
+			},
+			Entry("objects only — one objects phase", providerCore, 1),
+			Entry("CRDs only — one CRD phase", providerCRD, 1),
+			Entry("CRDs and objects — two phases", providerMixed, 2),
+			Entry("adopt-existing annotation is stable across calls", providerAdoptExisting, 1),
+		)
+	})
+})

--- a/pkg/controllers/installer/boxcutter_test.go
+++ b/pkg/controllers/installer/boxcutter_test.go
@@ -17,11 +17,39 @@ limitations under the License.
 package installer
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"pkg.package-operator.run/boxcutter"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/cluster-capi-operator/pkg/revisiongenerator"
+	"github.com/openshift/cluster-capi-operator/pkg/util"
 )
+
+// findPhase returns the phase with the given name, failing the test if none is found.
+func findPhase(phases []boxcutter.Phase, name string) boxcutter.Phase {
+	GinkgoHelper()
+
+	for _, phase := range phases {
+		if phase.GetName() == name {
+			return phase
+		}
+	}
+
+	Fail(fmt.Sprintf("phase %q not found", name))
+
+	return nil
+}
+
+// objectKinds returns the Kind of each object, for asserting phase contents
+// without depending on object ordering.
+func objectKinds(objs []client.Object) []string {
+	return util.SliceMap(objs, func(obj client.Object) string {
+		return obj.GetObjectKind().GroupVersionKind().Kind
+	})
+}
 
 // installerRevisionFromProfiles builds an InstallerRevision from named provider profiles
 // already registered in providersByName. Delegates to the package-level lookupProfiles helper
@@ -77,5 +105,40 @@ var _ = Describe("toBoxcutterRevision", func() {
 			Entry("CRDs and objects — two phases", providerMixed, 2),
 			Entry("adopt-existing annotation is stable across calls", providerAdoptExisting, 1),
 		)
+	})
+
+	Describe("CRD splitting", func() {
+		It("splits a component with CRDs and objects into a '-crds' phase and an objects phase", func() {
+			rev := installerRevisionFromProfiles(providerMixed)
+
+			phases := toBoxcutterRevision(rev).GetPhases()
+			Expect(phases).To(HaveLen(2))
+
+			crdPhase := findPhase(phases, providerMixed+"-crds")
+			Expect(objectKinds(crdPhase.GetObjects())).To(ConsistOf("CustomResourceDefinition"),
+				"the '-crds' phase should contain only CRDs")
+
+			objectsPhase := findPhase(phases, providerMixed)
+			Expect(objectKinds(objectsPhase.GetObjects())).To(ConsistOf("ConfigMap"),
+				"the base phase should contain only non-CRD objects")
+		})
+
+		It("does not create a '-crds' phase for a component with no CRDs", func() {
+			rev := installerRevisionFromProfiles(providerCore)
+
+			phases := toBoxcutterRevision(rev).GetPhases()
+			Expect(phases).To(HaveLen(1))
+			Expect(phases[0].GetName()).To(Equal(providerCore))
+			Expect(objectKinds(phases[0].GetObjects())).To(ConsistOf("ConfigMap"))
+		})
+
+		It("does not create a plain objects phase for a component with only CRDs", func() {
+			rev := installerRevisionFromProfiles(providerCRD)
+
+			phases := toBoxcutterRevision(rev).GetPhases()
+			Expect(phases).To(HaveLen(1))
+			Expect(phases[0].GetName()).To(Equal(providerCRD + "-crds"))
+			Expect(objectKinds(phases[0].GetObjects())).To(ConsistOf("CustomResourceDefinition"))
+		})
 	})
 })

--- a/pkg/controllers/installer/boxcutter_test.go
+++ b/pkg/controllers/installer/boxcutter_test.go
@@ -21,12 +21,23 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"pkg.package-operator.run/boxcutter"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/cluster-capi-operator/pkg/revisiongenerator"
 	"github.com/openshift/cluster-capi-operator/pkg/util"
 )
+
+// noopCollector is a collectObjects callback that does nothing, for tests that
+// don't care about collected objects.
+func noopCollector(*unstructured.Unstructured) {}
+
+// objectRef returns a stable identifier for an object, for asserting object
+// identity without depending on object ordering.
+func objectRef(kind, name string) string {
+	return kind + "/" + name
+}
 
 // findPhase returns the phase with the given name, failing the test if none is found.
 func findPhase(phases []boxcutter.Phase, name string) boxcutter.Phase {
@@ -73,7 +84,7 @@ var _ = Describe("toBoxcutterRevision", func() {
 		It("should return a Revision with the name of the InstallerRevision", func() {
 			rev := installerRevisionFromProfiles(providerCore)
 
-			bcRev := toBoxcutterRevision(rev)
+			bcRev := toBoxcutterRevision(rev, noopCollector)
 
 			Expect(bcRev.GetName()).To(Equal(string(rev.RevisionName())),
 				"returned Revision should carry the same name as the InstallerRevision")
@@ -85,7 +96,7 @@ var _ = Describe("toBoxcutterRevision", func() {
 			func(providerName string, wantPhaseCount int) {
 				rev := installerRevisionFromProfiles(providerName)
 
-				bcRev := toBoxcutterRevision(rev)
+				bcRev := toBoxcutterRevision(rev, noopCollector)
 
 				first := bcRev.GetPhases()
 				second := bcRev.GetPhases()
@@ -111,7 +122,7 @@ var _ = Describe("toBoxcutterRevision", func() {
 		It("splits a component with CRDs and objects into a '-crds' phase and an objects phase", func() {
 			rev := installerRevisionFromProfiles(providerMixed)
 
-			phases := toBoxcutterRevision(rev).GetPhases()
+			phases := toBoxcutterRevision(rev, noopCollector).GetPhases()
 			Expect(phases).To(HaveLen(2))
 
 			crdPhase := findPhase(phases, providerMixed+"-crds")
@@ -126,7 +137,7 @@ var _ = Describe("toBoxcutterRevision", func() {
 		It("does not create a '-crds' phase for a component with no CRDs", func() {
 			rev := installerRevisionFromProfiles(providerCore)
 
-			phases := toBoxcutterRevision(rev).GetPhases()
+			phases := toBoxcutterRevision(rev, noopCollector).GetPhases()
 			Expect(phases).To(HaveLen(1))
 			Expect(phases[0].GetName()).To(Equal(providerCore))
 			Expect(objectKinds(phases[0].GetObjects())).To(ConsistOf("ConfigMap"))
@@ -135,10 +146,50 @@ var _ = Describe("toBoxcutterRevision", func() {
 		It("does not create a plain objects phase for a component with only CRDs", func() {
 			rev := installerRevisionFromProfiles(providerCRD)
 
-			phases := toBoxcutterRevision(rev).GetPhases()
+			phases := toBoxcutterRevision(rev, noopCollector).GetPhases()
 			Expect(phases).To(HaveLen(1))
 			Expect(phases[0].GetName()).To(Equal(providerCRD + "-crds"))
 			Expect(objectKinds(phases[0].GetObjects())).To(ConsistOf("CustomResourceDefinition"))
 		})
+	})
+
+	Describe("collectObjects callback", func() {
+		testWidgetCRDName := fmt.Sprintf("testwidgets.%s", testCRDGVK.Group)
+		testGadgetCRDName := fmt.Sprintf("testgadgets.%s", mixedCRDGVK.Group)
+
+		DescribeTable("is called once for every object in every component",
+			func(wantRefs []string, providerNames ...string) {
+				rev := installerRevisionFromProfiles(providerNames...)
+
+				var collectedRefs []string
+
+				toBoxcutterRevision(rev, func(obj *unstructured.Unstructured) {
+					collectedRefs = append(collectedRefs, objectRef(obj.GetKind(), obj.GetName()))
+				})
+
+				Expect(collectedRefs).To(ConsistOf(wantRefs),
+					"collectObjects should be called exactly once for every object that ends up in a phase")
+			},
+			Entry("objects only",
+				[]string{objectRef("ConfigMap", coreCMName)},
+				providerCore),
+			Entry("CRDs only",
+				[]string{objectRef("CustomResourceDefinition", testWidgetCRDName)},
+				providerCRD),
+			Entry("CRDs and objects in the same component",
+				[]string{
+					objectRef("CustomResourceDefinition", testGadgetCRDName),
+					objectRef("ConfigMap", mixedCMName),
+				},
+				providerMixed),
+			Entry("multiple components",
+				[]string{
+					objectRef("ConfigMap", coreCMName),
+					objectRef("CustomResourceDefinition", testGadgetCRDName),
+					objectRef("ConfigMap", mixedCMName),
+					objectRef("CustomResourceDefinition", testWidgetCRDName),
+				},
+				providerCore, providerMixed, providerCRD),
+		)
 	})
 })

--- a/pkg/controllers/installer/revision_reconciler.go
+++ b/pkg/controllers/installer/revision_reconciler.go
@@ -214,21 +214,19 @@ func (r *revisionReconciler) reconcileRevision(ctx context.Context, apiRevision 
 		return true, fmt.Sprintf("Revision %s: complete", revision.RevisionName()), nil
 	}
 
-	var message string
+	return false, waitingRevisionMessage(revision.RevisionName(), result), nil
+}
 
+// waitingRevisionMessage returns the message to use when a revision is still in progress.
+func waitingRevisionMessage(revisionName operatorv1alpha1.RevisionName, result machinery.RevisionResult) string {
 	for _, phase := range result.GetPhases() {
 		if !phase.IsComplete() {
-			message = fmt.Sprintf("Revision %s: waiting on phase %s", revision.RevisionName(), phase.GetName())
-			break
+			return fmt.Sprintf("Revision %s: waiting on phase %s", revisionName, phase.GetName())
 		}
 	}
 
-	if message == "" {
-		// Probably shouldn't happen?
-		message = fmt.Sprintf("Revision %s: waiting for reconciliation", revision.RevisionName())
-	}
-
-	return false, message, nil
+	// Probably shouldn't happen?
+	return fmt.Sprintf("Revision %s: waiting for reconciliation", revisionName)
 }
 
 func (r *revisionReconciler) handlePhaseResults(revisionName operatorv1alpha1.RevisionName, result machinery.RevisionResult) error {

--- a/pkg/controllers/installer/revision_reconciler.go
+++ b/pkg/controllers/installer/revision_reconciler.go
@@ -85,16 +85,6 @@ import (
 // a collision with an existing object on the cluster.
 var errCollision = errors.New("collision with existing objects")
 
-// convertedRevision holds a pre-converted InstallerRevision.
-// If conversion fails, revision is nil and conversionErr is set.
-// We need this because conversion errors are handled differently depending on
-// whether the revision is being reconciled or torn down, and we don't know
-// which in advance.
-type convertedRevision struct {
-	revision      revisiongenerator.InstallerRevision
-	conversionErr error
-}
-
 // collectedObjectRef holds intermediate object reference data collected during
 // revision rendering. The resource name is resolved later.
 type collectedObjectRef struct {
@@ -122,53 +112,45 @@ func newRevisionReconciler(installerController *InstallerController, log logr.Lo
 	}
 }
 
-func (r *revisionReconciler) reconcile(ctx context.Context, revisions []operatorv1alpha1.ClusterAPIInstallerRevision) (*operatorv1alpha1.RevisionName, []string, []error) {
+func (r *revisionReconciler) reconcile(ctx context.Context, apiRevisions []operatorv1alpha1.ClusterAPIInstallerRevision) (*operatorv1alpha1.RevisionName, []string, []error) {
 	// Sort revisions descending by revision number (newest first)
-	revisions = slices.Clone(revisions)
-	slices.SortFunc(revisions, func(a, b operatorv1alpha1.ClusterAPIInstallerRevision) int {
+	apiRevisions = slices.Clone(apiRevisions)
+	cmpRevisions := func(a, b operatorv1alpha1.ClusterAPIInstallerRevision) int {
 		return cmp.Compare(b.Revision, a.Revision)
-	})
+	}
+	slices.SortFunc(apiRevisions, cmpRevisions)
 
-	revisionNames := util.SliceMap(revisions, func(rev operatorv1alpha1.ClusterAPIInstallerRevision) string {
+	getRevisionName := func(rev operatorv1alpha1.ClusterAPIInstallerRevision) string {
 		return string(rev.Name)
-	})
+	}
+	revisionNames := util.SliceMap(apiRevisions, getRevisionName)
+
 	r.log.Info("Reconciling revisions", "revisions", strings.Join(revisionNames, ", "))
 
-	// Convert all API revisions upfront so that collectObjects (and thus
-	// relatedObjects) is fully populated before reconciliation begins.
-	converted := util.SliceMap(revisions, func(apiRev operatorv1alpha1.ClusterAPIInstallerRevision) convertedRevision {
-		rev, err := revisiongenerator.NewInstallerRevisionFromAPI(apiRev, r.providerProfiles, revisiongenerator.WithObjectCollectors(r.collectObjects))
-		if err != nil {
-			err = fmt.Errorf("error creating installer revision from API revision %s: %w", apiRev.Name, reconcile.TerminalError(err))
-		}
-
-		return convertedRevision{
-			revision:      rev,
-			conversionErr: err,
-		}
-	})
+	isComplete, messages, errs := r.reconcileRevisions(ctx, apiRevisions)
 
 	// Resolve collected objects to final ObjectReferences with correct plurals
+	// Object collection is independent of revision reconciliation. We don't
+	// return early here to ensure we still check for reconciliation completion.
 	if err := r.resolveCollectedObjects(); err != nil {
-		return nil, nil, []error{err}
+		errs = append(errs, err)
 	}
 
-	isComplete, messages, errs := r.reconcileRevisions(ctx, converted)
 	if isComplete {
-		name := converted[0].revision.RevisionName()
+		name := apiRevisions[0].Name
 		return &name, messages, errs
 	}
 
 	return nil, messages, errs
 }
 
-func (r *revisionReconciler) reconcileRevisions(ctx context.Context, revisions []convertedRevision) (bool, []string, []error) {
-	if len(revisions) == 0 {
+func (r *revisionReconciler) reconcileRevisions(ctx context.Context, apiRevisions []operatorv1alpha1.ClusterAPIInstallerRevision) (bool, []string, []error) {
+	if len(apiRevisions) == 0 {
 		return true, nil, nil
 	}
 
-	head := revisions[0]
-	tail := revisions[1:]
+	head := apiRevisions[0]
+	tail := apiRevisions[1:]
 
 	isComplete, messages, err := r.reconcileRevision(ctx, head)
 
@@ -187,12 +169,11 @@ func (r *revisionReconciler) reconcileRevisions(ctx context.Context, revisions [
 // * a summary message
 // * a boolean indicating if the revision was reconciled completely
 // * an error if any occurred.
-func (r *revisionReconciler) reconcileRevision(ctx context.Context, conv convertedRevision) (bool, string, error) {
-	if conv.conversionErr != nil {
-		return false, "", conv.conversionErr
+func (r *revisionReconciler) reconcileRevision(ctx context.Context, apiRevision operatorv1alpha1.ClusterAPIInstallerRevision) (bool, string, error) {
+	revision, err := revisiongenerator.NewInstallerRevisionFromAPI(apiRevision, r.providerProfiles, revisiongenerator.WithObjectCollectors(r.collectObjects))
+	if err != nil {
+		return false, "", fmt.Errorf("error creating installer revision from API revision %s: %w", apiRevision.Name, reconcile.TerminalError(err))
 	}
-
-	revision := conv.revision
 
 	bcRevision := toBoxcutterRevision(revision)
 	phases := bcRevision.GetPhases()
@@ -337,13 +318,13 @@ func handlePhaseObject(log logr.Logger, obj machinery.ObjectResult, actionCounts
 	return result
 }
 
-func (r *revisionReconciler) teardownRevisions(ctx context.Context, revisions []convertedRevision) (bool, []string, []error) {
-	if len(revisions) == 0 {
+func (r *revisionReconciler) teardownRevisions(ctx context.Context, apiRevisions []operatorv1alpha1.ClusterAPIInstallerRevision) (bool, []string, []error) {
+	if len(apiRevisions) == 0 {
 		return true, nil, nil
 	}
 
-	head := revisions[0]
-	tail := revisions[1:]
+	head := apiRevisions[0]
+	tail := apiRevisions[1:]
 
 	return mergeWithTail(ctx, r.teardownRevisions, tail)(r.teardownRevision(ctx, head))
 }
@@ -352,13 +333,13 @@ func (r *revisionReconciler) teardownRevisions(ctx context.Context, revisions []
 // * a summary message
 // * a boolean indicating if the revision was torn down completely
 // * an error if any occurred.
-func (r *revisionReconciler) teardownRevision(ctx context.Context, conv convertedRevision) (bool, string, error) {
-	if conv.conversionErr != nil {
+func (r *revisionReconciler) teardownRevision(ctx context.Context, apiRevision operatorv1alpha1.ClusterAPIInstallerRevision) (bool, string, error) {
+	revision, err := revisiongenerator.NewInstallerRevisionFromAPI(apiRevision, r.providerProfiles, revisiongenerator.WithObjectCollectors(r.collectObjects))
+	if err != nil {
 		// We can't teardown this revision if we can't create it, so we consider it complete.
-		return true, "", conv.conversionErr
+		return true, "", fmt.Errorf("error creating installer revision from API revision %s: %w", apiRevision.Name, reconcile.TerminalError(err))
 	}
 
-	revision := conv.revision
 	revisionName := revision.RevisionName()
 
 	bcRevision := toBoxcutterRevision(revision)
@@ -432,10 +413,10 @@ func (r *revisionReconciler) logTeardownPhaseResults(revisionName operatorv1alph
 	}
 }
 
-type revisionHandler func(context.Context, []convertedRevision) (bool, []string, []error)
+type revisionHandler func(context.Context, []operatorv1alpha1.ClusterAPIInstallerRevision) (bool, []string, []error)
 
 // mergeWithTail merges the results of the head revision with the results of calling the tail handler on the tail revisions.
-func mergeWithTail(ctx context.Context, tailHandler revisionHandler, tailRevisions []convertedRevision) func(bool, string, error) (bool, []string, []error) {
+func mergeWithTail(ctx context.Context, tailHandler revisionHandler, tailRevisions []operatorv1alpha1.ClusterAPIInstallerRevision) func(bool, string, error) (bool, []string, []error) {
 	return func(headComplete bool, headMessage string, headErr error) (bool, []string, []error) {
 		tailComplete, tailMessages, tailErrs := tailHandler(ctx, tailRevisions)
 

--- a/pkg/controllers/installer/revision_reconciler.go
+++ b/pkg/controllers/installer/revision_reconciler.go
@@ -170,12 +170,12 @@ func (r *revisionReconciler) reconcileRevisions(ctx context.Context, apiRevision
 // * a boolean indicating if the revision was reconciled completely
 // * an error if any occurred.
 func (r *revisionReconciler) reconcileRevision(ctx context.Context, apiRevision operatorv1alpha1.ClusterAPIInstallerRevision) (bool, string, error) {
-	revision, err := revisiongenerator.NewInstallerRevisionFromAPI(apiRevision, r.providerProfiles, revisiongenerator.WithObjectCollectors(r.collectObjects))
+	revision, err := revisiongenerator.NewInstallerRevisionFromAPI(apiRevision, r.providerProfiles)
 	if err != nil {
 		return false, "", fmt.Errorf("error creating installer revision from API revision %s: %w", apiRevision.Name, reconcile.TerminalError(err))
 	}
 
-	bcRevision := toBoxcutterRevision(revision)
+	bcRevision := toBoxcutterRevision(revision, r.collectObjects)
 	phases := bcRevision.GetPhases()
 
 	totalObjects := 0
@@ -332,7 +332,7 @@ func (r *revisionReconciler) teardownRevisions(ctx context.Context, apiRevisions
 // * a boolean indicating if the revision was torn down completely
 // * an error if any occurred.
 func (r *revisionReconciler) teardownRevision(ctx context.Context, apiRevision operatorv1alpha1.ClusterAPIInstallerRevision) (bool, string, error) {
-	revision, err := revisiongenerator.NewInstallerRevisionFromAPI(apiRevision, r.providerProfiles, revisiongenerator.WithObjectCollectors(r.collectObjects))
+	revision, err := revisiongenerator.NewInstallerRevisionFromAPI(apiRevision, r.providerProfiles)
 	if err != nil {
 		// We can't teardown this revision if we can't create it, so we consider it complete.
 		return true, "", fmt.Errorf("error creating installer revision from API revision %s: %w", apiRevision.Name, reconcile.TerminalError(err))
@@ -340,7 +340,7 @@ func (r *revisionReconciler) teardownRevision(ctx context.Context, apiRevision o
 
 	revisionName := revision.RevisionName()
 
-	bcRevision := toBoxcutterRevision(revision)
+	bcRevision := toBoxcutterRevision(revision, r.collectObjects)
 	phases := bcRevision.GetPhases()
 
 	totalObjects := 0
@@ -430,7 +430,7 @@ func mergeWithTail(ctx context.Context, tailHandler revisionHandler, tailRevisio
 	}
 }
 
-func (r *revisionReconciler) collectObjects(obj unstructured.Unstructured) {
+func (r *revisionReconciler) collectObjects(obj *unstructured.Unstructured) {
 	gvk := obj.GroupVersionKind()
 	r.gvks.Insert(gvk)
 

--- a/pkg/revisiongenerator/revision.go
+++ b/pkg/revisiongenerator/revision.go
@@ -283,22 +283,10 @@ func buildRevisionName(releaseVersion, contentID string, index int64) operatorv1
 }
 
 type revisionRenderConfig struct {
-	objectCollectors []RevisionObjectCollector
-	substitutions    map[string]string
+	substitutions map[string]string
 }
 
 type revisionRenderOption func(*revisionRenderConfig)
-
-// RevisionObjectCollector is a function that will be called for each object in
-// the rendered revision.
-type RevisionObjectCollector func(obj unstructured.Unstructured)
-
-// WithObjectCollectors adds object collectors to the revision render config.
-func WithObjectCollectors(collectors ...RevisionObjectCollector) revisionRenderOption {
-	return func(opts *revisionRenderConfig) {
-		opts.objectCollectors = append(opts.objectCollectors, collectors...)
-	}
-}
 
 // WithManifestSubstitutions adds envsubst-style substitutions that will be
 // applied to manifests during rendering and recorded on the revision. When
@@ -409,10 +397,6 @@ func newRenderedComponent(providerProfile *providerimages.ProviderImageManifests
 		}
 
 		unstructured = transformObject(unstructured, component.name)
-
-		for _, collector := range cfg.objectCollectors {
-			collector(unstructured)
-		}
 
 		component.objects = append(component.objects, &unstructured)
 	}

--- a/pkg/revisiongenerator/revision.go
+++ b/pkg/revisiongenerator/revision.go
@@ -29,8 +29,6 @@ import (
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	operatorv1alpha1ac "github.com/openshift/client-go/operator/applyconfigurations/operator/v1alpha1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	k8syaml "sigs.k8s.io/yaml"
 
 	"github.com/openshift/cluster-capi-operator/pkg/providerimages"
@@ -78,15 +76,13 @@ type InstallerRevision interface {
 	ToAPIRevision() (operatorv1alpha1.ClusterAPIInstallerRevision, error)
 }
 
-// RenderedComponent represents a single provider component with manifests
-// separated into CRDs and other objects.
+// RenderedComponent represents a single provider component with its manifests
+// parsed.
 type RenderedComponent interface {
 	// Name returns the component name.
 	Name() string
-	// CRDs returns the CRD objects for this component.
-	CRDs() []client.Object
-	// Objects returns the non-CRD objects for this component.
-	Objects() []client.Object
+	// Objects returns all objects for this component.
+	Objects() []*unstructured.Unstructured
 }
 
 type renderedRevision struct {
@@ -387,8 +383,7 @@ type renderedComponent struct {
 	imageRef string
 	profile  string
 
-	crds    []unstructured.Unstructured
-	objects []unstructured.Unstructured
+	objects []*unstructured.Unstructured
 }
 
 func newRenderedComponent(providerProfile *providerimages.ProviderImageManifests, cfg *revisionRenderConfig) (*renderedComponent, error) {
@@ -419,14 +414,7 @@ func newRenderedComponent(providerProfile *providerimages.ProviderImageManifests
 			collector(unstructured)
 		}
 
-		gvk := unstructured.GroupVersionKind()
-
-		switch gvk.GroupKind() {
-		case schema.GroupKind{Group: "apiextensions.k8s.io", Kind: "CustomResourceDefinition"}:
-			component.crds = append(component.crds, unstructured)
-		default:
-			component.objects = append(component.objects, unstructured)
-		}
+		component.objects = append(component.objects, &unstructured)
 	}
 
 	return component, nil
@@ -439,24 +427,15 @@ func (c *renderedComponent) Name() string {
 	return c.name
 }
 
-// CRDs returns the CRD objects for this component.
-func (c *renderedComponent) CRDs() []client.Object {
-	return util.SliceMap(c.crds, func(crd unstructured.Unstructured) client.Object {
-		return &crd
-	})
-}
-
-// Objects returns the non-CRD objects for this component.
-func (c *renderedComponent) Objects() []client.Object {
-	return util.SliceMap(c.objects, func(obj unstructured.Unstructured) client.Object {
-		return &obj
-	})
+// Objects returns all objects for this component, including CRDs.
+func (c *renderedComponent) Objects() []*unstructured.Unstructured {
+	return c.objects
 }
 
 func (c *renderedComponent) contentID() (string, error) {
 	h := sha256.New()
 
-	for _, obj := range slices.Concat(c.crds, c.objects) {
+	for _, obj := range c.objects {
 		data, err := json.Marshal(obj.Object)
 		if err != nil {
 			return "", fmt.Errorf("error marshalling object: %w", err)

--- a/pkg/revisiongenerator/revision_test.go
+++ b/pkg/revisiongenerator/revision_test.go
@@ -310,8 +310,7 @@ func TestForInstall(t *testing.T) {
 
 		components := installer.Components()
 		g.Expect(components).To(HaveLen(1))
-		g.Expect(components[0].CRDs()).To(HaveLen(1))
-		g.Expect(components[0].Objects()).To(HaveLen(1))
+		g.Expect(components[0].Objects()).To(HaveLen(2))
 	})
 
 	t.Run("name truncation with long version", func(t *testing.T) {
@@ -548,26 +547,17 @@ func TestComponents(t *testing.T) {
 	for _, tc := range []struct {
 		name        string
 		manifests   string
-		wantCRDs    int
 		wantObjects int
 	}{
 		{
-			name:        "separates CRDs from other objects",
+			name:        "returns all objects",
 			manifests:   multiDoc(crdA, configMapA, crdB, configMapB),
-			wantCRDs:    2,
-			wantObjects: 2,
+			wantObjects: 4,
 		},
 		{
-			name:        "component with only CRDs has empty Objects",
-			manifests:   crdA,
-			wantCRDs:    1,
+			name:        "returns no objects",
+			manifests:   "",
 			wantObjects: 0,
-		},
-		{
-			name:        "component with only objects has empty CRDs",
-			manifests:   configMapA,
-			wantCRDs:    0,
-			wantObjects: 1,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -578,26 +568,11 @@ func TestComponents(t *testing.T) {
 			}))(g)
 
 			c := rev.Components()[0]
-			g.Expect(c.CRDs()).To(HaveLen(tc.wantCRDs))
 			g.Expect(c.Objects()).To(HaveLen(tc.wantObjects))
 		})
 	}
 
-	t.Run("CRDs returns client.Object slices matching underlying objects", func(t *testing.T) {
-		g := NewWithT(t)
-
-		rev := must(NewRenderedRevision([]providerimages.ProviderImageManifests{
-			profile(t, "core", "img1", "default", crdA),
-		}))(g)
-
-		crds := rev.Components()[0].CRDs()
-		g.Expect(crds).To(HaveLen(1))
-		g.Expect(crds[0].GetName()).To(Equal("widgets.example.com"))
-		g.Expect(crds[0].GetObjectKind().GroupVersionKind().Kind).To(Equal("CustomResourceDefinition"))
-		g.Expect(crds[0].GetLabels()).To(HaveKeyWithValue(ManagedLabelKey, "core"))
-	})
-
-	t.Run("Objects returns client.Object slices matching underlying objects", func(t *testing.T) {
+	t.Run("Objects returns unstructured.Unstructured slices matching underlying objects", func(t *testing.T) {
 		g := NewWithT(t)
 
 		rev := must(NewRenderedRevision([]providerimages.ProviderImageManifests{
@@ -710,7 +685,7 @@ func TestNewInstallerRevisionFromAPI(t *testing.T) {
 		g.Expect(components[1].Name()).To(Equal("core"))
 	})
 
-	t.Run("renders CRDs and objects from matched profiles", func(t *testing.T) {
+	t.Run("renders objects from matched profiles", func(t *testing.T) {
 		g := NewWithT(t)
 
 		profiles := makeProfiles(t)
@@ -728,8 +703,7 @@ func TestNewInstallerRevisionFromAPI(t *testing.T) {
 		rev := must(NewInstallerRevisionFromAPI(apiRev, profiles))(g)
 
 		c := rev.Components()[0]
-		g.Expect(c.CRDs()).To(HaveLen(1))
-		g.Expect(c.Objects()).To(HaveLen(1))
+		g.Expect(c.Objects()).To(HaveLen(2))
 	})
 
 	t.Run("returns error for missing component", func(t *testing.T) {

--- a/pkg/revisiongenerator/validate.go
+++ b/pkg/revisiongenerator/validate.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/openshift/cluster-capi-operator/pkg/operatorstatus"
@@ -53,7 +53,7 @@ var ErrInvalidAdoptExistingAnnotation = errors.New("invalid " + AdoptExistingAnn
 
 // ValidateAdoptExistingAnnotation returns an error if the object has an
 // adopt-existing annotation with an unrecognised value.
-func ValidateAdoptExistingAnnotation(obj client.Object) error {
+func ValidateAdoptExistingAnnotation(obj *unstructured.Unstructured) error {
 	annotations := obj.GetAnnotations()
 	if annotations == nil {
 		return nil
@@ -82,12 +82,6 @@ func ValidateAdoptExistingAnnotation(obj client.Object) error {
 // validateRenderedRevision validates all objects in a rendered revision.
 func validateRenderedRevision(rev *renderedRevision) error {
 	for _, component := range rev.components {
-		for _, obj := range component.CRDs() {
-			if err := ValidateAdoptExistingAnnotation(obj); err != nil {
-				return err
-			}
-		}
-
 		for _, obj := range component.Objects() {
 			if err := ValidateAdoptExistingAnnotation(obj); err != nil {
 				return err

--- a/pkg/revisiongenerator/validate_test.go
+++ b/pkg/revisiongenerator/validate_test.go
@@ -87,7 +87,7 @@ func TestValidateRenderedRevision(t *testing.T) {
 		rev := &renderedRevision{
 			components: []*renderedComponent{
 				{
-					objects: []unstructured.Unstructured{
+					objects: []*unstructured.Unstructured{
 						makeUnstructuredWithAnnotations(nil),
 						makeUnstructuredWithAnnotations(map[string]string{AdoptExistingAnnotation: AdoptExistingAlways}),
 					},
@@ -104,28 +104,7 @@ func TestValidateRenderedRevision(t *testing.T) {
 		rev := &renderedRevision{
 			components: []*renderedComponent{
 				{
-					objects: []unstructured.Unstructured{
-						makeUnstructuredWithAnnotations(map[string]string{AdoptExistingAnnotation: "bad"}),
-					},
-				},
-			},
-		}
-
-		err := validateRenderedRevision(rev)
-		if err == nil {
-			t.Fatal("expected error, got nil")
-		}
-
-		if !errors.Is(err, ErrInvalidAdoptExistingAnnotation) {
-			t.Errorf("expected error to wrap ErrInvalidAdoptExistingAnnotation, got %v", err)
-		}
-	})
-
-	t.Run("invalid annotation in CRDs", func(t *testing.T) {
-		rev := &renderedRevision{
-			components: []*renderedComponent{
-				{
-					crds: []unstructured.Unstructured{
+					objects: []*unstructured.Unstructured{
 						makeUnstructuredWithAnnotations(map[string]string{AdoptExistingAnnotation: "bad"}),
 					},
 				},
@@ -143,8 +122,8 @@ func TestValidateRenderedRevision(t *testing.T) {
 	})
 }
 
-func makeUnstructuredWithAnnotations(annotations map[string]string) unstructured.Unstructured {
-	obj := unstructured.Unstructured{}
+func makeUnstructuredWithAnnotations(annotations map[string]string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
 	obj.SetAnnotations(annotations)
 
 	return obj


### PR DESCRIPTION
This refactor forms the basis of a simplification to enable several other
features:
* Integration of CRD CompatibilityRequirement generation into capi-installer
* Consolidation of install-time transformations (e.g. TLS/Proxy Env vars) in
  one place
* Simplification of RenderedRevision


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Installer revisions now reconcile more reliably and report resource-resolution issues clearly.
  * Rendered components present resources consistently, with CRDs grouped into dedicated installation phases when applicable.
  * Existing-resource adoption annotations are validated and honored correctly, including collision protection for “always” adoption.
* **Refactor**
  * Simplified resource handling across rendered components and installation workflows.
* **Tests**
  * Expanded coverage for phase creation, resource grouping, repeatability, and adoption behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->