### PR TITLE
OCPCLOUD-3647: Add ManifestTransformers interface

### DIFF
--- a/cmd/capi-installer/main.go
+++ b/cmd/capi-installer/main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/openshift/cluster-capi-operator/pkg/controllers"
 	"github.com/openshift/cluster-capi-operator/pkg/controllers/installer"
 	"github.com/openshift/cluster-capi-operator/pkg/controllers/revision"
+	"github.com/openshift/cluster-capi-operator/pkg/manifesttransformer"
 	"github.com/openshift/cluster-capi-operator/pkg/providerimages"
 	"github.com/openshift/cluster-capi-operator/pkg/util"
 )
@@ -130,16 +131,21 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, operatorConfig comm
 		log.Info("loaded provider profile", "name", profile.Name, "imageRef", profile.ImageRef, "profile", profile.Profile)
 	}
 
+	// transformers is the shared list of ManifestTransformers applied during revision
+	// validation and object transformation. Initially empty; populated in future phases.
+	var transformers []manifesttransformer.ManifestTransformer
+
 	if err := (&revision.RevisionController{
 		Client:           mgr.GetClient(),
 		ProviderProfiles: currentReleaseProfiles,
 		ReleaseVersion:   util.GetReleaseVersion(),
+		Transformers:     transformers,
 	}).SetupWithManager(mgr, operatorConfig.TLSOptions); err != nil {
 		log.Error(err, "unable to create revision controller", "controller", "RevisionController")
 		return fmt.Errorf("unable to create revision controller: %w", err)
 	}
 
-	if err := installer.SetupWithManager(mgr, allProviderProfiles); err != nil {
+	if err := installer.SetupWithManager(mgr, allProviderProfiles, transformers); err != nil {
 		return fmt.Errorf("unable to create installer controller: %w", err)
 	}
 

--- a/pkg/controllers/installer/boxcutter.go
+++ b/pkg/controllers/installer/boxcutter.go
@@ -32,7 +32,7 @@ func toClientObject(obj *unstructured.Unstructured) client.Object {
 }
 
 // toBoxcutterRevision converts an InstallerRevision to a boxcutter.Revision.
-func toBoxcutterRevision(installerRevision revisiongenerator.InstallerRevision) boxcutter.Revision {
+func toBoxcutterRevision(installerRevision revisiongenerator.InstallerRevision, collectObjects func(obj *unstructured.Unstructured)) boxcutter.Revision {
 	probeOpts := util.SliceMap(allProbes(), func(p *probing.GroupKindSelector) boxcutter.PhaseReconcileOption {
 		return boxcutter.WithProbe(boxcutter.ProgressProbeType, p)
 	})
@@ -55,6 +55,8 @@ func toBoxcutterRevision(installerRevision revisiongenerator.InstallerRevision) 
 		var crds, objects []*unstructured.Unstructured
 
 		for _, obj := range component.Objects() {
+			collectObjects(obj)
+
 			gvk := obj.GetObjectKind().GroupVersionKind()
 			if gvk.GroupKind() == (schema.GroupKind{Group: "apiextensions.k8s.io", Kind: "CustomResourceDefinition"}) {
 				crds = append(crds, obj)

--- a/pkg/controllers/installer/boxcutter.go
+++ b/pkg/controllers/installer/boxcutter.go
@@ -17,12 +17,17 @@ limitations under the License.
 package installer
 
 import (
+	"context"
+	"errors"
+	"fmt"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"pkg.package-operator.run/boxcutter"
 	"pkg.package-operator.run/boxcutter/probing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/openshift/cluster-capi-operator/pkg/manifesttransformer"
 	"github.com/openshift/cluster-capi-operator/pkg/revisiongenerator"
 	"github.com/openshift/cluster-capi-operator/pkg/util"
 )
@@ -32,30 +37,33 @@ func toClientObject(obj *unstructured.Unstructured) client.Object {
 }
 
 // toBoxcutterRevision converts an InstallerRevision to a boxcutter.Revision.
-func toBoxcutterRevision(installerRevision revisiongenerator.InstallerRevision, collectObjects func(obj *unstructured.Unstructured)) boxcutter.Revision {
+// Each ManifestTransformer is called for every object before phase construction.
+func toBoxcutterRevision(ctx context.Context, installerRevision revisiongenerator.InstallerRevision, transformers []manifesttransformer.ManifestTransformer, collectObjects func(obj *unstructured.Unstructured)) (boxcutter.Revision, error) {
 	probeOpts := util.SliceMap(allProbes(), func(p *probing.GroupKindSelector) boxcutter.PhaseReconcileOption {
 		return boxcutter.WithProbe(boxcutter.ProgressProbeType, p)
 	})
 
 	var phases []boxcutter.Phase
 
-	addPhase := func(name string, objects []*unstructured.Unstructured) {
-		if len(objects) == 0 {
-			return
-		}
-
-		objects, adoptOpts := processAdoptExistingAnnotations(objects)
-		bcPhase := boxcutter.NewPhase(name, util.SliceMap(objects, toClientObject)).
-			WithReconcileOptions(append(probeOpts, adoptOpts...)...)
-
-		phases = append(phases, bcPhase)
+	withRevision := func(t manifesttransformer.ManifestTransformer) manifesttransformer.ManifestTransformer {
+		return t.WithRevision(ctx, installerRevision)
 	}
+	revisionTransformers := util.SliceMap(transformers, withRevision)
+
+	var allErrs []error
 
 	for _, component := range installerRevision.Components() {
+		withComponent := func(t manifesttransformer.ManifestTransformer) manifesttransformer.ManifestTransformer {
+			return t.WithComponent(ctx, component)
+		}
+		componentTransformers := util.SliceMap(revisionTransformers, withComponent)
+
 		var crds, objects []*unstructured.Unstructured
 
 		for _, obj := range component.Objects() {
-			collectObjects(obj)
+			if collectObjects != nil {
+				collectObjects(obj)
+			}
 
 			gvk := obj.GetObjectKind().GroupVersionKind()
 			if gvk.GroupKind() == (schema.GroupKind{Group: "apiextensions.k8s.io", Kind: "CustomResourceDefinition"}) {
@@ -65,15 +73,92 @@ func toBoxcutterRevision(installerRevision revisiongenerator.InstallerRevision, 
 			}
 		}
 
-		addPhase(component.Name()+"-crds", crds)
-		addPhase(component.Name(), objects)
+		var err error
+
+		if phases, err = addPhase(ctx, phases, probeOpts, component.Name()+"-crds", crds, componentTransformers); err != nil {
+			allErrs = append(allErrs, err)
+		}
+
+		if phases, err = addPhase(ctx, phases, probeOpts, component.Name(), objects, componentTransformers); err != nil {
+			allErrs = append(allErrs, err)
+		}
+	}
+
+	if len(allErrs) > 0 {
+		return nil, errors.Join(allErrs...)
 	}
 
 	return boxcutter.NewRevision(
 		string(installerRevision.RevisionName()),
 		installerRevision.RevisionIndex(),
 		phases,
+	), nil
+}
+
+func addPhase(ctx context.Context, phases []boxcutter.Phase, probeOpts []boxcutter.PhaseReconcileOption, name string, objects []*unstructured.Unstructured, ctxTransformers []manifesttransformer.ManifestTransformer) ([]boxcutter.Phase, error) {
+	if len(objects) == 0 {
+		return phases, nil
+	}
+
+	var (
+		xfmrOpts []boxcutter.PhaseReconcileOption
+		allErrs  []error
 	)
+
+	transformedObjects := make([]*unstructured.Unstructured, 0, len(objects))
+
+	for _, obj := range objects {
+		transformedObj, objOpts, objErrs := applyTransformers(ctx, ctxTransformers, obj)
+		if len(objErrs) > 0 {
+			allErrs = append(allErrs, fmt.Errorf("transforming %s %s: %w", obj.GroupVersionKind(), client.ObjectKeyFromObject(obj), errors.Join(objErrs...)))
+			continue
+		}
+
+		// A nil object means a transformer chose to skip it; it must not appear in any phase.
+		if transformedObj == nil {
+			continue
+		}
+
+		if len(objOpts) > 0 {
+			xfmrOpts = append(xfmrOpts, boxcutter.WithObjectReconcileOptions(transformedObj, objOpts...))
+		}
+
+		transformedObjects = append(transformedObjects, transformedObj)
+	}
+
+	transformedObjects, adoptOpts := processAdoptExistingAnnotations(transformedObjects)
+	allOpts := append(append(probeOpts, adoptOpts...), xfmrOpts...)
+	bcPhase := boxcutter.NewPhase(name, util.SliceMap(transformedObjects, toClientObject)).WithReconcileOptions(allOpts...)
+
+	return append(phases, bcPhase), errors.Join(allErrs...)
+}
+
+// applyTransformers applies all transformers to an object in order, accumulating
+// all boxcutter reconcile options and errors they return.
+func applyTransformers(ctx context.Context, transformers []manifesttransformer.ManifestTransformer, obj *unstructured.Unstructured) (*unstructured.Unstructured, []boxcutter.ObjectReconcileOption, []error) {
+	var (
+		errs    []error
+		allOpts []boxcutter.ObjectReconcileOption
+	)
+
+	for _, t := range transformers {
+		transformedObj, opts, err := t.TransformObject(ctx, obj)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		// If the transformer returns a nil object, it means the object should be skipped.
+		if transformedObj == nil {
+			return nil, opts, errs
+		}
+
+		allOpts = append(allOpts, opts...)
+
+		obj = transformedObj
+	}
+
+	return obj, allOpts, errs
 }
 
 // processAdoptExistingAnnotations processes the adopt-existing annotation on

--- a/pkg/controllers/installer/boxcutter.go
+++ b/pkg/controllers/installer/boxcutter.go
@@ -25,56 +25,33 @@ import (
 	"github.com/openshift/cluster-capi-operator/pkg/util"
 )
 
+// toBoxcutterRevision converts an InstallerRevision to a boxcutter.Revision.
 func toBoxcutterRevision(installerRevision revisiongenerator.InstallerRevision) boxcutter.Revision {
-	return boxcutterRevision{revision: installerRevision}
-}
-
-// boxcutterRevision wraps an InstallerRevision and provides a boxcutter.Revision implementation.
-type boxcutterRevision struct {
-	revision revisiongenerator.InstallerRevision
-}
-
-var _ boxcutter.Revision = boxcutterRevision{}
-
-// GetName returns the name of the revision.
-func (r boxcutterRevision) GetName() string {
-	return string(r.revision.RevisionName())
-}
-
-// GetRevisionNumber returns the revision number of the revision.
-func (r boxcutterRevision) GetRevisionNumber() int64 {
-	return r.revision.RevisionIndex()
-}
-
-// GetPhases returns the phases of the revision.
-func (r boxcutterRevision) GetPhases() []boxcutter.Phase {
 	probeOpts := util.SliceMap(allProbes(), func(p *probing.GroupKindSelector) boxcutter.PhaseReconcileOption {
 		return boxcutter.WithProbe(boxcutter.ProgressProbeType, p)
 	})
 
 	var phases []boxcutter.Phase
 
-	for _, component := range r.revision.Components() {
+	for _, component := range installerRevision.Components() {
 		if crds := component.CRDs(); len(crds) > 0 {
 			objects, adoptOpts := processAdoptExistingAnnotations(crds)
-			phases = append(phases, boxcutterPhase{
-				name:             component.Name() + "-crds",
-				objects:          objects,
-				reconcileOptions: append(probeOpts, adoptOpts...),
-			})
+			phases = append(phases, boxcutter.NewPhase(component.Name()+"-crds", objects).
+				WithReconcileOptions(append(probeOpts, adoptOpts...)...))
 		}
 
 		if objects := component.Objects(); len(objects) > 0 {
 			objects, adoptOpts := processAdoptExistingAnnotations(objects)
-			phases = append(phases, boxcutterPhase{
-				name:             component.Name(),
-				objects:          objects,
-				reconcileOptions: append(probeOpts, adoptOpts...),
-			})
+			phases = append(phases, boxcutter.NewPhase(component.Name(), objects).
+				WithReconcileOptions(append(probeOpts, adoptOpts...)...))
 		}
 	}
 
-	return phases
+	return boxcutter.NewRevision(
+		string(installerRevision.RevisionName()),
+		installerRevision.RevisionIndex(),
+		phases,
+	)
 }
 
 // processAdoptExistingAnnotations processes the adopt-existing annotation on
@@ -111,42 +88,4 @@ func processAdoptExistingAnnotations(objects []client.Object) ([]client.Object, 
 
 		return obj
 	}), reconcileOpts
-}
-
-// GetReconcileOptions returns the reconcile options of the revision.
-func (r boxcutterRevision) GetReconcileOptions() []boxcutter.RevisionReconcileOption {
-	return nil
-}
-
-// GetTeardownOptions returns the teardown options of the revision.
-func (r boxcutterRevision) GetTeardownOptions() []boxcutter.RevisionTeardownOption {
-	return nil
-}
-
-type boxcutterPhase struct {
-	name             string
-	objects          []client.Object
-	reconcileOptions []boxcutter.PhaseReconcileOption
-}
-
-var _ boxcutter.Phase = boxcutterPhase{}
-
-// GetName returns the name of the phase.
-func (p boxcutterPhase) GetName() string {
-	return p.name
-}
-
-// GetObjects returns the objects of the phase.
-func (p boxcutterPhase) GetObjects() []client.Object {
-	return p.objects
-}
-
-// GetReconcileOptions returns the reconcile options of the phase.
-func (p boxcutterPhase) GetReconcileOptions() []boxcutter.PhaseReconcileOption {
-	return p.reconcileOptions
-}
-
-// GetTeardownOptions returns the teardown options of the phase.
-func (p boxcutterPhase) GetTeardownOptions() []boxcutter.PhaseTeardownOption {
-	return nil
 }

--- a/pkg/controllers/installer/boxcutter.go
+++ b/pkg/controllers/installer/boxcutter.go
@@ -17,6 +17,8 @@ limitations under the License.
 package installer
 
 import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"pkg.package-operator.run/boxcutter"
 	"pkg.package-operator.run/boxcutter/probing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -24,6 +26,10 @@ import (
 	"github.com/openshift/cluster-capi-operator/pkg/revisiongenerator"
 	"github.com/openshift/cluster-capi-operator/pkg/util"
 )
+
+func toClientObject(obj *unstructured.Unstructured) client.Object {
+	return obj
+}
 
 // toBoxcutterRevision converts an InstallerRevision to a boxcutter.Revision.
 func toBoxcutterRevision(installerRevision revisiongenerator.InstallerRevision) boxcutter.Revision {
@@ -33,18 +39,32 @@ func toBoxcutterRevision(installerRevision revisiongenerator.InstallerRevision) 
 
 	var phases []boxcutter.Phase
 
-	for _, component := range installerRevision.Components() {
-		if crds := component.CRDs(); len(crds) > 0 {
-			objects, adoptOpts := processAdoptExistingAnnotations(crds)
-			phases = append(phases, boxcutter.NewPhase(component.Name()+"-crds", objects).
-				WithReconcileOptions(append(probeOpts, adoptOpts...)...))
+	addPhase := func(name string, objects []*unstructured.Unstructured) {
+		if len(objects) == 0 {
+			return
 		}
 
-		if objects := component.Objects(); len(objects) > 0 {
-			objects, adoptOpts := processAdoptExistingAnnotations(objects)
-			phases = append(phases, boxcutter.NewPhase(component.Name(), objects).
-				WithReconcileOptions(append(probeOpts, adoptOpts...)...))
+		objects, adoptOpts := processAdoptExistingAnnotations(objects)
+		bcPhase := boxcutter.NewPhase(name, util.SliceMap(objects, toClientObject)).
+			WithReconcileOptions(append(probeOpts, adoptOpts...)...)
+
+		phases = append(phases, bcPhase)
+	}
+
+	for _, component := range installerRevision.Components() {
+		var crds, objects []*unstructured.Unstructured
+
+		for _, obj := range component.Objects() {
+			gvk := obj.GetObjectKind().GroupVersionKind()
+			if gvk.GroupKind() == (schema.GroupKind{Group: "apiextensions.k8s.io", Kind: "CustomResourceDefinition"}) {
+				crds = append(crds, obj)
+			} else {
+				objects = append(objects, obj)
+			}
 		}
+
+		addPhase(component.Name()+"-crds", crds)
+		addPhase(component.Name(), objects)
 	}
 
 	return boxcutter.NewRevision(
@@ -62,10 +82,10 @@ func toBoxcutterRevision(installerRevision revisiongenerator.InstallerRevision) 
 //
 // This function assumes that annotation values have already been validated
 // during revision creation.
-func processAdoptExistingAnnotations(objects []client.Object) ([]client.Object, []boxcutter.PhaseReconcileOption) {
+func processAdoptExistingAnnotations(objects []*unstructured.Unstructured) ([]*unstructured.Unstructured, []boxcutter.PhaseReconcileOption) {
 	var reconcileOpts []boxcutter.PhaseReconcileOption
 
-	return util.SliceMap(objects, func(obj client.Object) client.Object {
+	return util.SliceMap(objects, func(obj *unstructured.Unstructured) *unstructured.Unstructured {
 		annotations := obj.GetAnnotations()
 		value, hasAnnotation := annotations[revisiongenerator.AdoptExistingAnnotation]
 
@@ -80,7 +100,7 @@ func processAdoptExistingAnnotations(objects []client.Object) ([]client.Object, 
 			}
 
 			// Strip the annotation from the object before returning it
-			obj = obj.DeepCopyObject().(client.Object) //nolint:forcetypeassert // This is guaranteed to be client.Object because obj is client.Object
+			obj = obj.DeepCopy()
 			annotationsCopy := obj.GetAnnotations()
 			delete(annotationsCopy, revisiongenerator.AdoptExistingAnnotation)
 			obj.SetAnnotations(annotationsCopy)

--- a/pkg/controllers/installer/boxcutter_test.go
+++ b/pkg/controllers/installer/boxcutter_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package installer
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/cluster-capi-operator/pkg/revisiongenerator"
+)
+
+// installerRevisionFromProfiles builds an InstallerRevision from named provider profiles
+// already registered in providersByName. Delegates to the package-level lookupProfiles helper
+// so the heavy profile setup stays in BeforeSuite.
+func installerRevisionFromProfiles(names ...string) revisiongenerator.InstallerRevision {
+	GinkgoHelper()
+
+	profiles := lookupProfiles(names...)
+
+	rendered, err := revisiongenerator.NewRenderedRevision(profiles)
+	Expect(err).NotTo(HaveOccurred(), "NewRenderedRevision should not fail for valid profiles")
+
+	rev, err := rendered.ForInstall("4.18.0-test", 1)
+	Expect(err).NotTo(HaveOccurred(), "ForInstall should not fail for a valid rendered revision")
+
+	return rev
+}
+
+var _ = Describe("toBoxcutterRevision", func() {
+	Describe("construction", func() {
+		It("should return a Revision with the name of the InstallerRevision", func() {
+			rev := installerRevisionFromProfiles(providerCore)
+
+			bcRev := toBoxcutterRevision(rev)
+
+			Expect(bcRev.GetName()).To(Equal(string(rev.RevisionName())),
+				"returned Revision should carry the same name as the InstallerRevision")
+		})
+	})
+
+	Describe("GetPhases idempotency", func() {
+		DescribeTable("should return stable phases on every call",
+			func(providerName string, wantPhaseCount int) {
+				rev := installerRevisionFromProfiles(providerName)
+
+				bcRev := toBoxcutterRevision(rev)
+
+				first := bcRev.GetPhases()
+				second := bcRev.GetPhases()
+
+				Expect(second).To(HaveLen(wantPhaseCount),
+					"expected %d phase(s) for provider %q", wantPhaseCount, providerName)
+
+				for i := range first {
+					Expect(second[i].GetName()).To(Equal(first[i].GetName()),
+						"phase[%d] name must be stable across GetPhases calls", i)
+					Expect(second[i].GetObjects()).To(HaveLen(len(first[i].GetObjects())),
+						"phase[%d] object count must be stable across GetPhases calls", i)
+				}
+			},
+			Entry("objects only — one objects phase", providerCore, 1),
+			Entry("CRDs only — one CRD phase", providerCRD, 1),
+			Entry("CRDs and objects — two phases", providerMixed, 2),
+			Entry("adopt-existing annotation is stable across calls", providerAdoptExisting, 1),
+		)
+	})
+})

--- a/pkg/controllers/installer/boxcutter_test.go
+++ b/pkg/controllers/installer/boxcutter_test.go
@@ -17,11 +17,39 @@ limitations under the License.
 package installer
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"pkg.package-operator.run/boxcutter"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/cluster-capi-operator/pkg/revisiongenerator"
+	"github.com/openshift/cluster-capi-operator/pkg/util"
 )
+
+// findPhase returns the phase with the given name, failing the test if none is found.
+func findPhase(phases []boxcutter.Phase, name string) boxcutter.Phase {
+	GinkgoHelper()
+
+	for _, phase := range phases {
+		if phase.GetName() == name {
+			return phase
+		}
+	}
+
+	Fail(fmt.Sprintf("phase %q not found", name))
+
+	return nil
+}
+
+// objectKinds returns the Kind of each object, for asserting phase contents
+// without depending on object ordering.
+func objectKinds(objs []client.Object) []string {
+	return util.SliceMap(objs, func(obj client.Object) string {
+		return obj.GetObjectKind().GroupVersionKind().Kind
+	})
+}
 
 // installerRevisionFromProfiles builds an InstallerRevision from named provider profiles
 // already registered in providersByName. Delegates to the package-level lookupProfiles helper
@@ -77,5 +105,40 @@ var _ = Describe("toBoxcutterRevision", func() {
 			Entry("CRDs and objects — two phases", providerMixed, 2),
 			Entry("adopt-existing annotation is stable across calls", providerAdoptExisting, 1),
 		)
+	})
+
+	Describe("CRD splitting", func() {
+		It("splits a component with CRDs and objects into a '-crds' phase and an objects phase", func() {
+			rev := installerRevisionFromProfiles(providerMixed)
+
+			phases := toBoxcutterRevision(rev).GetPhases()
+			Expect(phases).To(HaveLen(2))
+
+			crdPhase := findPhase(phases, providerMixed+"-crds")
+			Expect(objectKinds(crdPhase.GetObjects())).To(ConsistOf("CustomResourceDefinition"),
+				"the '-crds' phase should contain only CRDs")
+
+			objectsPhase := findPhase(phases, providerMixed)
+			Expect(objectKinds(objectsPhase.GetObjects())).To(ConsistOf("ConfigMap"),
+				"the base phase should contain only non-CRD objects")
+		})
+
+		It("does not create a '-crds' phase for a component with no CRDs", func() {
+			rev := installerRevisionFromProfiles(providerCore)
+
+			phases := toBoxcutterRevision(rev).GetPhases()
+			Expect(phases).To(HaveLen(1))
+			Expect(phases[0].GetName()).To(Equal(providerCore))
+			Expect(objectKinds(phases[0].GetObjects())).To(ConsistOf("ConfigMap"))
+		})
+
+		It("does not create a plain objects phase for a component with only CRDs", func() {
+			rev := installerRevisionFromProfiles(providerCRD)
+
+			phases := toBoxcutterRevision(rev).GetPhases()
+			Expect(phases).To(HaveLen(1))
+			Expect(phases[0].GetName()).To(Equal(providerCRD + "-crds"))
+			Expect(objectKinds(phases[0].GetObjects())).To(ConsistOf("CustomResourceDefinition"))
+		})
 	})
 })

--- a/pkg/controllers/installer/boxcutter_test.go
+++ b/pkg/controllers/installer/boxcutter_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package installer
 
 import (
+	"context"
+	"errors"
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -25,6 +27,7 @@ import (
 	"pkg.package-operator.run/boxcutter"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/openshift/cluster-capi-operator/pkg/manifesttransformer"
 	"github.com/openshift/cluster-capi-operator/pkg/revisiongenerator"
 	"github.com/openshift/cluster-capi-operator/pkg/util"
 )
@@ -62,14 +65,61 @@ func objectKinds(objs []client.Object) []string {
 	})
 }
 
-// installerRevisionFromProfiles builds an InstallerRevision from named provider profiles
-// already registered in providersByName. Delegates to the package-level lookupProfiles helper
-// so the heavy profile setup stays in BeforeSuite.
+// stubTransformer is a test double for manifesttransformer.ManifestTransformer.
+type stubTransformer struct {
+	opts        []boxcutter.ObjectReconcileOption
+	err         error
+	validateErr error
+}
+
+func (s *stubTransformer) TransformObject(_ context.Context, obj *unstructured.Unstructured) (*unstructured.Unstructured, []boxcutter.ObjectReconcileOption, error) {
+	return obj, s.opts, s.err
+}
+
+func (s *stubTransformer) Validate(_ *unstructured.Unstructured) error {
+	return s.validateErr
+}
+
+func (s *stubTransformer) WithRevision(_ context.Context, _ revisiongenerator.RenderedRevision) manifesttransformer.ManifestTransformer {
+	return s
+}
+
+func (s *stubTransformer) WithComponent(_ context.Context, _ revisiongenerator.RenderedComponent) manifesttransformer.ManifestTransformer {
+	return s
+}
+
+var _ manifesttransformer.ManifestTransformer = &stubTransformer{}
+
+// fnTransformer adapts a plain function to the manifesttransformer.ManifestTransformer
+// interface, letting tests express skip/mutate/observe behaviour inline.
+type fnTransformer struct {
+	fn func(obj *unstructured.Unstructured) (*unstructured.Unstructured, []boxcutter.ObjectReconcileOption, error)
+}
+
+func (f *fnTransformer) TransformObject(_ context.Context, obj *unstructured.Unstructured) (*unstructured.Unstructured, []boxcutter.ObjectReconcileOption, error) {
+	return f.fn(obj)
+}
+
+func (f *fnTransformer) Validate(_ *unstructured.Unstructured) error {
+	return nil
+}
+
+func (f *fnTransformer) WithRevision(_ context.Context, _ revisiongenerator.RenderedRevision) manifesttransformer.ManifestTransformer {
+	return f
+}
+
+func (f *fnTransformer) WithComponent(_ context.Context, _ revisiongenerator.RenderedComponent) manifesttransformer.ManifestTransformer {
+	return f
+}
+
+var _ manifesttransformer.ManifestTransformer = &fnTransformer{}
+
+// installerRevisionFromProfiles builds a bare InstallerRevision from the named
+// provider profiles without writing anything to the cluster.
 func installerRevisionFromProfiles(names ...string) revisiongenerator.InstallerRevision {
 	GinkgoHelper()
 
 	profiles := lookupProfiles(names...)
-
 	rendered, err := revisiongenerator.NewRenderedRevision(profiles)
 	Expect(err).NotTo(HaveOccurred(), "NewRenderedRevision should not fail for valid profiles")
 
@@ -84,7 +134,8 @@ var _ = Describe("toBoxcutterRevision", func() {
 		It("should return a Revision with the name of the InstallerRevision", func() {
 			rev := installerRevisionFromProfiles(providerCore)
 
-			bcRev := toBoxcutterRevision(rev, noopCollector)
+			bcRev, err := toBoxcutterRevision(context.Background(), rev, nil, noopCollector)
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(bcRev.GetName()).To(Equal(string(rev.RevisionName())),
 				"returned Revision should carry the same name as the InstallerRevision")
@@ -96,7 +147,8 @@ var _ = Describe("toBoxcutterRevision", func() {
 			func(providerName string, wantPhaseCount int) {
 				rev := installerRevisionFromProfiles(providerName)
 
-				bcRev := toBoxcutterRevision(rev, noopCollector)
+				bcRev, err := toBoxcutterRevision(context.Background(), rev, nil, noopCollector)
+				Expect(err).NotTo(HaveOccurred())
 
 				first := bcRev.GetPhases()
 				second := bcRev.GetPhases()
@@ -122,7 +174,10 @@ var _ = Describe("toBoxcutterRevision", func() {
 		It("splits a component with CRDs and objects into a '-crds' phase and an objects phase", func() {
 			rev := installerRevisionFromProfiles(providerMixed)
 
-			phases := toBoxcutterRevision(rev, noopCollector).GetPhases()
+			bcRev, err := toBoxcutterRevision(context.Background(), rev, nil, noopCollector)
+			Expect(err).NotTo(HaveOccurred())
+
+			phases := bcRev.GetPhases()
 			Expect(phases).To(HaveLen(2))
 
 			crdPhase := findPhase(phases, providerMixed+"-crds")
@@ -137,7 +192,10 @@ var _ = Describe("toBoxcutterRevision", func() {
 		It("does not create a '-crds' phase for a component with no CRDs", func() {
 			rev := installerRevisionFromProfiles(providerCore)
 
-			phases := toBoxcutterRevision(rev, noopCollector).GetPhases()
+			bcRev, err := toBoxcutterRevision(context.Background(), rev, nil, noopCollector)
+			Expect(err).NotTo(HaveOccurred())
+
+			phases := bcRev.GetPhases()
 			Expect(phases).To(HaveLen(1))
 			Expect(phases[0].GetName()).To(Equal(providerCore))
 			Expect(objectKinds(phases[0].GetObjects())).To(ConsistOf("ConfigMap"))
@@ -146,7 +204,10 @@ var _ = Describe("toBoxcutterRevision", func() {
 		It("does not create a plain objects phase for a component with only CRDs", func() {
 			rev := installerRevisionFromProfiles(providerCRD)
 
-			phases := toBoxcutterRevision(rev, noopCollector).GetPhases()
+			bcRev, err := toBoxcutterRevision(context.Background(), rev, nil, noopCollector)
+			Expect(err).NotTo(HaveOccurred())
+
+			phases := bcRev.GetPhases()
 			Expect(phases).To(HaveLen(1))
 			Expect(phases[0].GetName()).To(Equal(providerCRD + "-crds"))
 			Expect(objectKinds(phases[0].GetObjects())).To(ConsistOf("CustomResourceDefinition"))
@@ -163,9 +224,11 @@ var _ = Describe("toBoxcutterRevision", func() {
 
 				var collectedRefs []string
 
-				toBoxcutterRevision(rev, func(obj *unstructured.Unstructured) {
+				collectObjects := func(obj *unstructured.Unstructured) {
 					collectedRefs = append(collectedRefs, objectRef(obj.GetKind(), obj.GetName()))
-				})
+				}
+				_, err := toBoxcutterRevision(context.Background(), rev, nil, collectObjects)
+				Expect(err).NotTo(HaveOccurred())
 
 				Expect(collectedRefs).To(ConsistOf(wantRefs),
 					"collectObjects should be called exactly once for every object that ends up in a phase")
@@ -191,5 +254,222 @@ var _ = Describe("toBoxcutterRevision", func() {
 				},
 				providerCore, providerMixed, providerCRD),
 		)
+	})
+
+	Describe("transformer integration", func() {
+		It("should return an error when a transformer fails", func() {
+			stub := &stubTransformer{err: errors.New("transform failed")}
+			rev := installerRevisionFromProfiles(providerCore)
+
+			_, err := toBoxcutterRevision(context.Background(), rev, []manifesttransformer.ManifestTransformer{stub}, nil)
+
+			Expect(err).To(MatchError(ContainSubstring("transform failed")))
+		})
+
+		It("should include options returned by transformers in phase reconcile options", func() {
+			rev := installerRevisionFromProfiles(providerCore)
+
+			base, err := toBoxcutterRevision(context.Background(), rev, nil, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			baseOptCount := len(base.GetPhases()[0].GetReconcileOptions())
+
+			stub := &stubTransformer{opts: []boxcutter.ObjectReconcileOption{
+				boxcutter.WithCollisionProtection(boxcutter.CollisionProtectionNone),
+			}}
+			withTfm, err := toBoxcutterRevision(context.Background(), rev, []manifesttransformer.ManifestTransformer{stub}, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(len(withTfm.GetPhases()[0].GetReconcileOptions())).To(
+				BeNumerically(">", baseOptCount),
+				"transformer options should augment the phase reconcile options",
+			)
+		})
+
+		It("should omit an object from its phase when a transformer returns a nil object", func() {
+			rev := installerRevisionFromProfiles(providerMixed)
+
+			skipConfigMaps := &fnTransformer{fn: func(obj *unstructured.Unstructured) (*unstructured.Unstructured, []boxcutter.ObjectReconcileOption, error) {
+				if obj.GetKind() == "ConfigMap" {
+					return nil, nil, nil
+				}
+
+				return obj, nil, nil
+			}}
+
+			bcRev, err := toBoxcutterRevision(context.Background(), rev, []manifesttransformer.ManifestTransformer{skipConfigMaps}, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			phases := bcRev.GetPhases()
+
+			crdPhase := findPhase(phases, providerMixed+"-crds")
+			Expect(objectKinds(crdPhase.GetObjects())).To(ConsistOf("CustomResourceDefinition"),
+				"objects not matched by the skip transformer should be unaffected")
+
+			objectsPhase := findPhase(phases, providerMixed)
+			Expect(objectsPhase.GetObjects()).To(BeEmpty(),
+				"an object skipped by a transformer (nil return) must not appear in any phase")
+		})
+
+		It("should not invoke later transformers for an object a prior transformer already skipped", func() {
+			rev := installerRevisionFromProfiles(providerCore)
+
+			skip := &fnTransformer{fn: func(*unstructured.Unstructured) (*unstructured.Unstructured, []boxcutter.ObjectReconcileOption, error) {
+				return nil, nil, nil
+			}}
+
+			var secondCalled bool
+
+			recordCall := &fnTransformer{fn: func(obj *unstructured.Unstructured) (*unstructured.Unstructured, []boxcutter.ObjectReconcileOption, error) {
+				secondCalled = true
+				return obj, nil, nil
+			}}
+
+			_, err := toBoxcutterRevision(context.Background(), rev, []manifesttransformer.ManifestTransformer{skip, recordCall}, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(secondCalled).To(BeFalse(),
+				"a transformer must not run on an object a prior transformer already skipped")
+		})
+
+		It("should pass the output of one transformer as the input to the next", func() {
+			rev := installerRevisionFromProfiles(providerCore)
+
+			const renamedTo = "renamed-by-first-transformer"
+
+			rename := &fnTransformer{fn: func(obj *unstructured.Unstructured) (*unstructured.Unstructured, []boxcutter.ObjectReconcileOption, error) {
+				renamed := obj.DeepCopy()
+				renamed.SetName(renamedTo)
+
+				return renamed, nil, nil
+			}}
+
+			var sawName string
+
+			record := &fnTransformer{fn: func(obj *unstructured.Unstructured) (*unstructured.Unstructured, []boxcutter.ObjectReconcileOption, error) {
+				sawName = obj.GetName()
+				return obj, nil, nil
+			}}
+
+			bcRev, err := toBoxcutterRevision(context.Background(), rev, []manifesttransformer.ManifestTransformer{rename, record}, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(sawName).To(Equal(renamedTo),
+				"the second transformer should observe the first transformer's output, not the original object")
+			Expect(bcRev.GetPhases()[0].GetObjects()[0].GetName()).To(Equal(renamedTo),
+				"the final phase should contain the transformed object, not the original")
+		})
+
+		It("should apply transformers to CRDs as well as plain objects", func() {
+			rev := installerRevisionFromProfiles(providerCRD)
+
+			var sawKind string
+
+			record := &fnTransformer{fn: func(obj *unstructured.Unstructured) (*unstructured.Unstructured, []boxcutter.ObjectReconcileOption, error) {
+				sawKind = obj.GetKind()
+				return obj, nil, nil
+			}}
+
+			_, err := toBoxcutterRevision(context.Background(), rev, []manifesttransformer.ManifestTransformer{record}, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(sawKind).To(Equal("CustomResourceDefinition"), "transformers must also run against CRD objects")
+		})
+
+		It("should include the failing object's identity in the returned error", func() {
+			rev := installerRevisionFromProfiles(providerCore)
+			stub := &stubTransformer{err: errors.New("boom")}
+
+			_, err := toBoxcutterRevision(context.Background(), rev, []manifesttransformer.ManifestTransformer{stub}, nil)
+
+			Expect(err).To(MatchError(ContainSubstring(coreCMName)),
+				"the error should identify which object failed transformation")
+		})
+
+		It("should invoke transformers exactly once per object, even if GetPhases is called multiple times", func() {
+			rev := installerRevisionFromProfiles(providerCore)
+
+			var callCount int
+
+			counting := &fnTransformer{fn: func(obj *unstructured.Unstructured) (*unstructured.Unstructured, []boxcutter.ObjectReconcileOption, error) {
+				callCount++
+				return obj, nil, nil
+			}}
+
+			bcRev, err := toBoxcutterRevision(context.Background(), rev, []manifesttransformer.ManifestTransformer{counting}, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			_ = bcRev.GetPhases()
+			_ = bcRev.GetPhases()
+
+			Expect(callCount).To(Equal(1),
+				"transformation happens once during construction, not on every GetPhases call")
+		})
+	})
+
+	Describe("error aggregation", func() {
+		It("aggregates errors from multiple objects in the same phase", func() {
+			// providerManyClusterScoped has ten ClusterRoles and no CRDs, so all
+			// of them are built into a single objects phase for the component.
+			rev := installerRevisionFromProfiles(providerManyClusterScoped)
+			stub := &stubTransformer{err: errors.New("boom")}
+
+			_, err := toBoxcutterRevision(context.Background(), rev, []manifesttransformer.ManifestTransformer{stub}, nil)
+
+			Expect(err).To(MatchError(SatisfyAll(
+				ContainSubstring("/test-cr-1"),
+				ContainSubstring("/test-cr-2"),
+			)), "expected failures from multiple objects within the same phase")
+		})
+
+		It("aggregates errors from multiple transformers on the same object", func() {
+			rev := installerRevisionFromProfiles(providerCore)
+			stubA := &stubTransformer{err: errors.New("first failure")}
+			stubB := &stubTransformer{err: errors.New("second failure")}
+
+			_, err := toBoxcutterRevision(context.Background(), rev,
+				[]manifesttransformer.ManifestTransformer{stubA, stubB}, nil)
+
+			Expect(err).To(MatchError(SatisfyAll(
+				ContainSubstring("first failure"),
+				ContainSubstring("second failure"),
+			)), "expected both transformer failures for the object in a single joined error")
+		})
+
+		It("aggregates errors across the CRD and non-CRD phases of the same component", func() {
+			// providerMixed has one CRD and one ConfigMap, in the same component,
+			// but built into two separate phases (crds, objects).
+			rev := installerRevisionFromProfiles(providerMixed)
+			stub := &stubTransformer{err: errors.New("boom")}
+
+			_, err := toBoxcutterRevision(context.Background(), rev, []manifesttransformer.ManifestTransformer{stub}, nil)
+
+			Expect(err).To(MatchError(SatisfyAll(
+				ContainSubstring("/testgadgets.test.example.com"),
+				ContainSubstring("default/test-cm-mixed"),
+			)), "expected failures from both the CRD phase and the objects phase")
+		})
+
+		It("aggregates errors across multiple components rather than stopping at the first", func() {
+			rev := installerRevisionFromProfiles(providerCore, providerInfra)
+			stub := &stubTransformer{err: errors.New("boom")}
+
+			_, err := toBoxcutterRevision(context.Background(), rev, []manifesttransformer.ManifestTransformer{stub}, nil)
+
+			Expect(err).To(MatchError(SatisfyAll(
+				ContainSubstring("default/test-cm-core"),
+				ContainSubstring("default/test-cm-infra"),
+			)), "expected failures from both components, not just the first one processed")
+		})
+
+		It("does not build a Revision when any object fails transformation", func() {
+			rev := installerRevisionFromProfiles(providerCore, providerInfra)
+			stub := &stubTransformer{err: errors.New("boom")}
+
+			bcRev, err := toBoxcutterRevision(context.Background(), rev, []manifesttransformer.ManifestTransformer{stub}, nil)
+
+			Expect(err).To(HaveOccurred())
+			Expect(bcRev).To(BeNil())
+		})
 	})
 })

--- a/pkg/controllers/installer/boxcutter_test.go
+++ b/pkg/controllers/installer/boxcutter_test.go
@@ -21,12 +21,23 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"pkg.package-operator.run/boxcutter"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/cluster-capi-operator/pkg/revisiongenerator"
 	"github.com/openshift/cluster-capi-operator/pkg/util"
 )
+
+// noopCollector is a collectObjects callback that does nothing, for tests that
+// don't care about collected objects.
+func noopCollector(*unstructured.Unstructured) {}
+
+// objectRef returns a stable identifier for an object, for asserting object
+// identity without depending on object ordering.
+func objectRef(kind, name string) string {
+	return kind + "/" + name
+}
 
 // findPhase returns the phase with the given name, failing the test if none is found.
 func findPhase(phases []boxcutter.Phase, name string) boxcutter.Phase {
@@ -73,7 +84,7 @@ var _ = Describe("toBoxcutterRevision", func() {
 		It("should return a Revision with the name of the InstallerRevision", func() {
 			rev := installerRevisionFromProfiles(providerCore)
 
-			bcRev := toBoxcutterRevision(rev)
+			bcRev := toBoxcutterRevision(rev, noopCollector)
 
 			Expect(bcRev.GetName()).To(Equal(string(rev.RevisionName())),
 				"returned Revision should carry the same name as the InstallerRevision")
@@ -85,7 +96,7 @@ var _ = Describe("toBoxcutterRevision", func() {
 			func(providerName string, wantPhaseCount int) {
 				rev := installerRevisionFromProfiles(providerName)
 
-				bcRev := toBoxcutterRevision(rev)
+				bcRev := toBoxcutterRevision(rev, noopCollector)
 
 				first := bcRev.GetPhases()
 				second := bcRev.GetPhases()
@@ -111,7 +122,7 @@ var _ = Describe("toBoxcutterRevision", func() {
 		It("splits a component with CRDs and objects into a '-crds' phase and an objects phase", func() {
 			rev := installerRevisionFromProfiles(providerMixed)
 
-			phases := toBoxcutterRevision(rev).GetPhases()
+			phases := toBoxcutterRevision(rev, noopCollector).GetPhases()
 			Expect(phases).To(HaveLen(2))
 
 			crdPhase := findPhase(phases, providerMixed+"-crds")
@@ -126,7 +137,7 @@ var _ = Describe("toBoxcutterRevision", func() {
 		It("does not create a '-crds' phase for a component with no CRDs", func() {
 			rev := installerRevisionFromProfiles(providerCore)
 
-			phases := toBoxcutterRevision(rev).GetPhases()
+			phases := toBoxcutterRevision(rev, noopCollector).GetPhases()
 			Expect(phases).To(HaveLen(1))
 			Expect(phases[0].GetName()).To(Equal(providerCore))
 			Expect(objectKinds(phases[0].GetObjects())).To(ConsistOf("ConfigMap"))
@@ -135,10 +146,50 @@ var _ = Describe("toBoxcutterRevision", func() {
 		It("does not create a plain objects phase for a component with only CRDs", func() {
 			rev := installerRevisionFromProfiles(providerCRD)
 
-			phases := toBoxcutterRevision(rev).GetPhases()
+			phases := toBoxcutterRevision(rev, noopCollector).GetPhases()
 			Expect(phases).To(HaveLen(1))
 			Expect(phases[0].GetName()).To(Equal(providerCRD + "-crds"))
 			Expect(objectKinds(phases[0].GetObjects())).To(ConsistOf("CustomResourceDefinition"))
 		})
+	})
+
+	Describe("collectObjects callback", func() {
+		testWidgetCRDName := fmt.Sprintf("testwidgets.%s", testCRDGVK.Group)
+		testGadgetCRDName := fmt.Sprintf("testgadgets.%s", mixedCRDGVK.Group)
+
+		DescribeTable("is called once for every object in every component",
+			func(wantRefs []string, providerNames ...string) {
+				rev := installerRevisionFromProfiles(providerNames...)
+
+				var collectedRefs []string
+
+				toBoxcutterRevision(rev, func(obj *unstructured.Unstructured) {
+					collectedRefs = append(collectedRefs, objectRef(obj.GetKind(), obj.GetName()))
+				})
+
+				Expect(collectedRefs).To(ConsistOf(wantRefs),
+					"collectObjects should be called exactly once for every object that ends up in a phase")
+			},
+			Entry("objects only",
+				[]string{objectRef("ConfigMap", coreCMName)},
+				providerCore),
+			Entry("CRDs only",
+				[]string{objectRef("CustomResourceDefinition", testWidgetCRDName)},
+				providerCRD),
+			Entry("CRDs and objects in the same component",
+				[]string{
+					objectRef("CustomResourceDefinition", testGadgetCRDName),
+					objectRef("ConfigMap", mixedCMName),
+				},
+				providerMixed),
+			Entry("multiple components",
+				[]string{
+					objectRef("ConfigMap", coreCMName),
+					objectRef("CustomResourceDefinition", testGadgetCRDName),
+					objectRef("ConfigMap", mixedCMName),
+					objectRef("CustomResourceDefinition", testWidgetCRDName),
+				},
+				providerCore, providerMixed, providerCRD),
+		)
 	})
 })

--- a/pkg/controllers/installer/installer_controller.go
+++ b/pkg/controllers/installer/installer_controller.go
@@ -44,6 +44,7 @@ import (
 	"pkg.package-operator.run/boxcutter"
 	"pkg.package-operator.run/boxcutter/managedcache"
 
+	"github.com/openshift/cluster-capi-operator/pkg/manifesttransformer"
 	"github.com/openshift/cluster-capi-operator/pkg/operatorstatus"
 	"github.com/openshift/cluster-capi-operator/pkg/providerimages"
 	"github.com/openshift/cluster-capi-operator/pkg/revisiongenerator"
@@ -65,12 +66,13 @@ type InstallerController struct {
 	revisionEngine   *boxcutter.RevisionEngine
 	providerProfiles []providerimages.ProviderImageManifests
 	restMapper       meta.RESTMapper
+	transformers     []manifesttransformer.ManifestTransformer
 }
 
 // SetupWithManager creates the boxcutter dependencies and sets up the installer
 // controller with the Manager. Additional sources may be provided to trigger
 // reconciliation from external events (e.g. a channel source for testing).
-func SetupWithManager(mgr ctrl.Manager, providerProfiles []providerimages.ProviderImageManifests, additionalSources ...source.Source) error {
+func SetupWithManager(mgr ctrl.Manager, providerProfiles []providerimages.ProviderImageManifests, transformers []manifesttransformer.ManifestTransformer, additionalSources ...source.Source) error {
 	trackingCache, err := setupTrackingCache(mgr)
 	if err != nil {
 		return fmt.Errorf("unable to setup tracking cache: %w", err)
@@ -87,6 +89,7 @@ func SetupWithManager(mgr ctrl.Manager, providerProfiles []providerimages.Provid
 		revisionEngine:   revisionEngine,
 		providerProfiles: providerProfiles,
 		restMapper:       mgr.GetRESTMapper(),
+		transformers:     transformers,
 	}
 
 	toClusterAPI := func(_ context.Context, _ client.Object) []reconcile.Request {

--- a/pkg/controllers/installer/installer_controller_test.go
+++ b/pkg/controllers/installer/installer_controller_test.go
@@ -30,6 +30,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -191,6 +192,51 @@ var _ = Describe("InstallerController", Serial, func() {
 					HaveField("UID", Not(Equal(cm.UID))),
 					HaveField("Data", HaveKeyWithValue("version", "v1")),
 				))
+		}, defaultNodeTimeout)
+	})
+
+	Context("ManifestTransformer Drift", func() {
+		AfterEach(func() {
+			testAnnotationValue.Store(nil)
+		})
+
+		It("re-applies an updated transformer output without a new revision", func(ctx context.Context) {
+			testAnnotationValue.Store(ptr.To("v1"))
+			addRevisionAndWaitForSuccess(ctx, providerCore)
+
+			cm, err := getConfigMap(ctx, coreCMName)
+			Expect(err).NotTo(HaveOccurred(), "getting the core ConfigMap should succeed")
+			Expect(cm.Annotations).To(HaveKeyWithValue(testAnnotationKey, "v1"), "ConfigMap should carry the initial transformer annotation")
+
+			// Simulate an updated transformation -- no revision change at all.
+			testAnnotationValue.Store(ptr.To("v2"))
+			triggerReconcile()
+
+			Eventually(kWithCtx(ctx).Object(cm)).
+				WithContext(ctx).
+				WithTimeout(defaultEventuallyTimeout).
+				Should(HaveField("Annotations", HaveKeyWithValue(testAnnotationKey, "v2")), "ConfigMap should be updated with the new transformer annotation value")
+		}, defaultNodeTimeout)
+
+		It("restores a transformer-added annotation after it is manually removed", func(ctx context.Context) {
+			testAnnotationValue.Store(ptr.To("v1"))
+			addRevisionAndWaitForSuccess(ctx, providerCore)
+
+			cm, err := getConfigMap(ctx, coreCMName)
+			Expect(err).NotTo(HaveOccurred(), "getting the core ConfigMap should succeed")
+			Expect(cm.Annotations).To(HaveKeyWithValue(testAnnotationKey, "v1"), "ConfigMap should carry the initial transformer annotation")
+
+			Eventually(kWithCtx(ctx).Update(cm, func() {
+				delete(cm.Annotations, testAnnotationKey)
+			})).
+				WithContext(ctx).
+				WithTimeout(defaultEventuallyTimeout).
+				Should(Succeed(), "removing the transformer annotation should succeed")
+
+			Eventually(kWithCtx(ctx).Object(cm)).
+				WithContext(ctx).
+				WithTimeout(defaultEventuallyTimeout).
+				Should(HaveField("Annotations", HaveKeyWithValue(testAnnotationKey, "v1")), "controller should restore the removed transformer annotation")
 		}, defaultNodeTimeout)
 	})
 

--- a/pkg/controllers/installer/revision_reconciler.go
+++ b/pkg/controllers/installer/revision_reconciler.go
@@ -168,12 +168,12 @@ func (r *revisionReconciler) reconcileRevisions(ctx context.Context, apiRevision
 // * a boolean indicating if the revision was reconciled completely
 // * an error if any occurred.
 func (r *revisionReconciler) reconcileRevision(ctx context.Context, apiRevision operatorv1alpha1.ClusterAPIInstallerRevision) (bool, string, error) {
-	revision, err := revisiongenerator.NewInstallerRevisionFromAPI(apiRevision, r.providerProfiles, revisiongenerator.WithObjectCollectors(r.collectObjects))
+	revision, err := revisiongenerator.NewInstallerRevisionFromAPI(apiRevision, r.providerProfiles)
 	if err != nil {
 		return false, "", fmt.Errorf("error creating installer revision from API revision %s: %w", apiRevision.Name, reconcile.TerminalError(err))
 	}
 
-	bcRevision := toBoxcutterRevision(revision)
+	bcRevision := toBoxcutterRevision(revision, r.collectObjects)
 	phases := bcRevision.GetPhases()
 
 	totalObjects := 0
@@ -330,7 +330,7 @@ func (r *revisionReconciler) teardownRevisions(ctx context.Context, apiRevisions
 // * a boolean indicating if the revision was torn down completely
 // * an error if any occurred.
 func (r *revisionReconciler) teardownRevision(ctx context.Context, apiRevision operatorv1alpha1.ClusterAPIInstallerRevision) (bool, string, error) {
-	revision, err := revisiongenerator.NewInstallerRevisionFromAPI(apiRevision, r.providerProfiles, revisiongenerator.WithObjectCollectors(r.collectObjects))
+	revision, err := revisiongenerator.NewInstallerRevisionFromAPI(apiRevision, r.providerProfiles)
 	if err != nil {
 		// We can't teardown this revision if we can't create it, so we consider it complete.
 		return true, "", fmt.Errorf("error creating installer revision from API revision %s: %w", apiRevision.Name, reconcile.TerminalError(err))
@@ -338,7 +338,7 @@ func (r *revisionReconciler) teardownRevision(ctx context.Context, apiRevision o
 
 	revisionName := revision.RevisionName()
 
-	bcRevision := toBoxcutterRevision(revision)
+	bcRevision := toBoxcutterRevision(revision, r.collectObjects)
 	phases := bcRevision.GetPhases()
 
 	totalObjects := 0
@@ -428,7 +428,7 @@ func mergeWithTail(ctx context.Context, tailHandler revisionHandler, tailRevisio
 	}
 }
 
-func (r *revisionReconciler) collectObjects(obj unstructured.Unstructured) {
+func (r *revisionReconciler) collectObjects(obj *unstructured.Unstructured) {
 	gvk := obj.GroupVersionKind()
 	r.gvks.Insert(gvk)
 

--- a/pkg/controllers/installer/revision_reconciler.go
+++ b/pkg/controllers/installer/revision_reconciler.go
@@ -36,6 +36,7 @@ import (
 	machinerytypes "pkg.package-operator.run/boxcutter/machinery/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/openshift/cluster-capi-operator/pkg/manifesttransformer"
 	"github.com/openshift/cluster-capi-operator/pkg/revisiongenerator"
 	"github.com/openshift/cluster-capi-operator/pkg/util"
 )
@@ -173,7 +174,19 @@ func (r *revisionReconciler) reconcileRevision(ctx context.Context, apiRevision 
 		return false, "", fmt.Errorf("error creating installer revision from API revision %s: %w", apiRevision.Name, reconcile.TerminalError(err))
 	}
 
-	bcRevision := toBoxcutterRevision(revision, r.collectObjects)
+	// Defence in depth: the revision controller validates transformers before
+	// writing a new revision, but a revision read back from the API could in
+	// principle be malformed (e.g. hand-edited), so validate again here.
+	if err := manifesttransformer.ValidateTransformers(r.transformers, revision); err != nil {
+		err = fmt.Errorf("validating revision %s: %w", revision.RevisionName(), reconcile.TerminalError(err))
+		return false, err.Error(), err
+	}
+
+	bcRevision, err := toBoxcutterRevision(ctx, revision, r.transformers, r.collectObjects)
+	if err != nil {
+		return false, err.Error(), reconcile.TerminalError(fmt.Errorf("building boxcutter revision %s: %w", revision.RevisionName(), err))
+	}
+
 	phases := bcRevision.GetPhases()
 
 	totalObjects := 0
@@ -338,7 +351,12 @@ func (r *revisionReconciler) teardownRevision(ctx context.Context, apiRevision o
 
 	revisionName := revision.RevisionName()
 
-	bcRevision := toBoxcutterRevision(revision, r.collectObjects)
+	bcRevision, err := toBoxcutterRevision(ctx, revision, r.transformers, r.collectObjects)
+	if err != nil {
+		// Cannot tear down a revision that cannot be constructed — treat as complete.
+		return true, "", err
+	}
+
 	phases := bcRevision.GetPhases()
 
 	totalObjects := 0

--- a/pkg/controllers/installer/revision_reconciler.go
+++ b/pkg/controllers/installer/revision_reconciler.go
@@ -212,21 +212,19 @@ func (r *revisionReconciler) reconcileRevision(ctx context.Context, apiRevision 
 		return true, fmt.Sprintf("Revision %s: complete", revision.RevisionName()), nil
 	}
 
-	var message string
+	return false, waitingRevisionMessage(revision.RevisionName(), result), nil
+}
 
+// waitingRevisionMessage returns the message to use when a revision is still in progress.
+func waitingRevisionMessage(revisionName operatorv1alpha1.RevisionName, result machinery.RevisionResult) string {
 	for _, phase := range result.GetPhases() {
 		if !phase.IsComplete() {
-			message = fmt.Sprintf("Revision %s: waiting on phase %s", revision.RevisionName(), phase.GetName())
-			break
+			return fmt.Sprintf("Revision %s: waiting on phase %s", revisionName, phase.GetName())
 		}
 	}
 
-	if message == "" {
-		// Probably shouldn't happen?
-		message = fmt.Sprintf("Revision %s: waiting for reconciliation", revision.RevisionName())
-	}
-
-	return false, message, nil
+	// Probably shouldn't happen?
+	return fmt.Sprintf("Revision %s: waiting for reconciliation", revisionName)
 }
 
 func (r *revisionReconciler) handlePhaseResults(revisionName operatorv1alpha1.RevisionName, result machinery.RevisionResult) error {

--- a/pkg/controllers/installer/revision_reconciler.go
+++ b/pkg/controllers/installer/revision_reconciler.go
@@ -85,16 +85,6 @@ import (
 // a collision with an existing object on the cluster.
 var errCollision = errors.New("collision with existing objects")
 
-// convertedRevision holds a pre-converted InstallerRevision.
-// If conversion fails, revision is nil and conversionErr is set.
-// We need this because conversion errors are handled differently depending on
-// whether the revision is being reconciled or torn down, and we don't know
-// which in advance.
-type convertedRevision struct {
-	revision      revisiongenerator.InstallerRevision
-	conversionErr error
-}
-
 // collectedObjectRef holds intermediate object reference data collected during
 // revision rendering. The resource name is resolved later.
 type collectedObjectRef struct {
@@ -122,53 +112,43 @@ func newRevisionReconciler(installerController *InstallerController, log logr.Lo
 	}
 }
 
-func (r *revisionReconciler) reconcile(ctx context.Context, revisions []operatorv1alpha1.ClusterAPIInstallerRevision) (*operatorv1alpha1.RevisionName, []string, []error) {
+func (r *revisionReconciler) reconcile(ctx context.Context, apiRevisions []operatorv1alpha1.ClusterAPIInstallerRevision) (*operatorv1alpha1.RevisionName, []string, []error) {
 	// Sort revisions descending by revision number (newest first)
-	revisions = slices.Clone(revisions)
-	slices.SortFunc(revisions, func(a, b operatorv1alpha1.ClusterAPIInstallerRevision) int {
+	apiRevisions = slices.Clone(apiRevisions)
+	cmpRevisions := func(a, b operatorv1alpha1.ClusterAPIInstallerRevision) int {
 		return cmp.Compare(b.Revision, a.Revision)
-	})
+	}
+	slices.SortFunc(apiRevisions, cmpRevisions)
 
-	revisionNames := util.SliceMap(revisions, func(rev operatorv1alpha1.ClusterAPIInstallerRevision) string {
+	getRevisionName := func(rev operatorv1alpha1.ClusterAPIInstallerRevision) string {
 		return string(rev.Name)
-	})
+	}
+	revisionNames := util.SliceMap(apiRevisions, getRevisionName)
+
 	r.log.Info("Reconciling revisions", "revisions", strings.Join(revisionNames, ", "))
 
-	// Convert all API revisions upfront so that collectObjects (and thus
-	// relatedObjects) is fully populated before reconciliation begins.
-	converted := util.SliceMap(revisions, func(apiRev operatorv1alpha1.ClusterAPIInstallerRevision) convertedRevision {
-		rev, err := revisiongenerator.NewInstallerRevisionFromAPI(apiRev, r.providerProfiles, revisiongenerator.WithObjectCollectors(r.collectObjects))
-		if err != nil {
-			err = fmt.Errorf("error creating installer revision from API revision %s: %w", apiRev.Name, reconcile.TerminalError(err))
-		}
-
-		return convertedRevision{
-			revision:      rev,
-			conversionErr: err,
-		}
-	})
+	isComplete, messages, errs := r.reconcileRevisions(ctx, apiRevisions)
 
 	// Resolve collected objects to final ObjectReferences with correct plurals
 	if err := r.resolveCollectedObjects(); err != nil {
-		return nil, nil, []error{err}
+		errs = append(errs, err)
 	}
 
-	isComplete, messages, errs := r.reconcileRevisions(ctx, converted)
 	if isComplete {
-		name := converted[0].revision.RevisionName()
+		name := apiRevisions[0].Name
 		return &name, messages, errs
 	}
 
 	return nil, messages, errs
 }
 
-func (r *revisionReconciler) reconcileRevisions(ctx context.Context, revisions []convertedRevision) (bool, []string, []error) {
-	if len(revisions) == 0 {
+func (r *revisionReconciler) reconcileRevisions(ctx context.Context, apiRevisions []operatorv1alpha1.ClusterAPIInstallerRevision) (bool, []string, []error) {
+	if len(apiRevisions) == 0 {
 		return true, nil, nil
 	}
 
-	head := revisions[0]
-	tail := revisions[1:]
+	head := apiRevisions[0]
+	tail := apiRevisions[1:]
 
 	isComplete, messages, err := r.reconcileRevision(ctx, head)
 
@@ -187,12 +167,11 @@ func (r *revisionReconciler) reconcileRevisions(ctx context.Context, revisions [
 // * a summary message
 // * a boolean indicating if the revision was reconciled completely
 // * an error if any occurred.
-func (r *revisionReconciler) reconcileRevision(ctx context.Context, conv convertedRevision) (bool, string, error) {
-	if conv.conversionErr != nil {
-		return false, "", conv.conversionErr
+func (r *revisionReconciler) reconcileRevision(ctx context.Context, apiRevision operatorv1alpha1.ClusterAPIInstallerRevision) (bool, string, error) {
+	revision, err := revisiongenerator.NewInstallerRevisionFromAPI(apiRevision, r.providerProfiles, revisiongenerator.WithObjectCollectors(r.collectObjects))
+	if err != nil {
+		return false, "", fmt.Errorf("error creating installer revision from API revision %s: %w", apiRevision.Name, reconcile.TerminalError(err))
 	}
-
-	revision := conv.revision
 
 	bcRevision := toBoxcutterRevision(revision)
 	phases := bcRevision.GetPhases()
@@ -337,13 +316,13 @@ func handlePhaseObject(log logr.Logger, obj machinery.ObjectResult, actionCounts
 	return result
 }
 
-func (r *revisionReconciler) teardownRevisions(ctx context.Context, revisions []convertedRevision) (bool, []string, []error) {
-	if len(revisions) == 0 {
+func (r *revisionReconciler) teardownRevisions(ctx context.Context, apiRevisions []operatorv1alpha1.ClusterAPIInstallerRevision) (bool, []string, []error) {
+	if len(apiRevisions) == 0 {
 		return true, nil, nil
 	}
 
-	head := revisions[0]
-	tail := revisions[1:]
+	head := apiRevisions[0]
+	tail := apiRevisions[1:]
 
 	return mergeWithTail(ctx, r.teardownRevisions, tail)(r.teardownRevision(ctx, head))
 }
@@ -352,13 +331,13 @@ func (r *revisionReconciler) teardownRevisions(ctx context.Context, revisions []
 // * a summary message
 // * a boolean indicating if the revision was torn down completely
 // * an error if any occurred.
-func (r *revisionReconciler) teardownRevision(ctx context.Context, conv convertedRevision) (bool, string, error) {
-	if conv.conversionErr != nil {
+func (r *revisionReconciler) teardownRevision(ctx context.Context, apiRevision operatorv1alpha1.ClusterAPIInstallerRevision) (bool, string, error) {
+	revision, err := revisiongenerator.NewInstallerRevisionFromAPI(apiRevision, r.providerProfiles, revisiongenerator.WithObjectCollectors(r.collectObjects))
+	if err != nil {
 		// We can't teardown this revision if we can't create it, so we consider it complete.
-		return true, "", conv.conversionErr
+		return true, "", fmt.Errorf("error creating installer revision from API revision %s: %w", apiRevision.Name, reconcile.TerminalError(err))
 	}
 
-	revision := conv.revision
 	revisionName := revision.RevisionName()
 
 	bcRevision := toBoxcutterRevision(revision)
@@ -432,10 +411,10 @@ func (r *revisionReconciler) logTeardownPhaseResults(revisionName operatorv1alph
 	}
 }
 
-type revisionHandler func(context.Context, []convertedRevision) (bool, []string, []error)
+type revisionHandler func(context.Context, []operatorv1alpha1.ClusterAPIInstallerRevision) (bool, []string, []error)
 
 // mergeWithTail merges the results of the head revision with the results of calling the tail handler on the tail revisions.
-func mergeWithTail(ctx context.Context, tailHandler revisionHandler, tailRevisions []convertedRevision) func(bool, string, error) (bool, []string, []error) {
+func mergeWithTail(ctx context.Context, tailHandler revisionHandler, tailRevisions []operatorv1alpha1.ClusterAPIInstallerRevision) func(bool, string, error) (bool, []string, []error) {
 	return func(headComplete bool, headMessage string, headErr error) (bool, []string, []error) {
 		tailComplete, tailMessages, tailErrs := tailHandler(ctx, tailRevisions)
 

--- a/pkg/controllers/installer/revision_reconciler_test.go
+++ b/pkg/controllers/installer/revision_reconciler_test.go
@@ -17,19 +17,40 @@ limitations under the License.
 package installer
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	configv1 "github.com/openshift/api/config/v1"
+	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/openshift/cluster-capi-operator/pkg/manifesttransformer"
+	"github.com/openshift/cluster-capi-operator/pkg/revisiongenerator"
 	"github.com/openshift/cluster-capi-operator/pkg/test"
 )
+
+// apiRevisionFromProfiles renders the named provider profiles into an API
+// revision, without requiring an envtest client.
+func apiRevisionFromProfiles(names ...string) operatorv1alpha1.ClusterAPIInstallerRevision {
+	GinkgoHelper()
+
+	rendered, err := revisiongenerator.NewRenderedRevision(lookupProfiles(names...))
+	Expect(err).NotTo(HaveOccurred(), "rendering the revision from provider profiles should succeed")
+
+	installerRev, err := rendered.ForInstall("4.18.0-test", 1)
+	Expect(err).NotTo(HaveOccurred(), "converting the rendered revision for install should succeed")
+
+	apiRev, err := installerRev.ToAPIRevision()
+	Expect(err).NotTo(HaveOccurred(), "converting the installer revision to an API revision should succeed")
+
+	return apiRev
+}
 
 // errorInjectingRESTMapper wraps a real RESTMapper and injects errors for specific GVKs.
 // This allows testing error handling while using a real RESTMapper for normal cases.
@@ -174,5 +195,26 @@ var _ = Describe("revisionReconciler.resolveCollectedObjects", func() {
 			Resource: "clusterroles", // Resolved via RESTMapper
 			Name:     "test-clusterrole",
 		})).To(BeTrue())
+	})
+})
+
+var _ = Describe("revisionReconciler.reconcileRevision", func() {
+	It("should reject the revision with a terminal error when a transformer fails validation", func() {
+		apiRev := apiRevisionFromProfiles(providerCore)
+
+		validateErr := errors.New("boom")
+		failingTransformer := &stubTransformer{validateErr: validateErr}
+
+		r := newRevisionReconciler(&InstallerController{
+			providerProfiles: lookupProfiles(providerCore),
+			transformers:     []manifesttransformer.ManifestTransformer{failingTransformer},
+		}, test.NewVerboseGinkgoLogger(4))
+
+		isComplete, _, err := r.reconcileRevision(context.Background(), apiRev)
+
+		Expect(isComplete).To(BeFalse(), "revision should not be reported complete when a transformer fails validation")
+		Expect(err).To(HaveOccurred(), "reconcileRevision should return an error when a transformer fails validation")
+		Expect(errors.Is(err, validateErr)).To(BeTrue(), "expected the validation error to be wrapped")
+		Expect(errors.Is(err, reconcile.TerminalError(nil))).To(BeTrue(), "expected terminal error")
 	})
 })

--- a/pkg/controllers/installer/suite_test.go
+++ b/pkg/controllers/installer/suite_test.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/openshift/cluster-capi-operator/pkg/manifesttransformer"
 	"github.com/openshift/cluster-capi-operator/pkg/test"
 )
 
@@ -106,7 +107,10 @@ var _ = BeforeSuite(func() {
 		handler.EnqueueRequestsFromMapFunc(toClusterAPI),
 	)
 
-	Expect(SetupWithManager(mgr, allProviderProfiles, triggerSource)).To(Succeed())
+	transformers := []manifesttransformer.ManifestTransformer{
+		testValueTransformer{},
+	}
+	Expect(SetupWithManager(mgr, allProviderProfiles, transformers, triggerSource)).To(Succeed(), "set up InstallerController")
 	Expect(test.AddNamespaceFinalizerCleanup(mgr)).To(Succeed())
 
 	// Start manager in background.

--- a/pkg/controllers/installer/testvalue_transformer_test.go
+++ b/pkg/controllers/installer/testvalue_transformer_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package installer
+
+import (
+	"context"
+	"sync/atomic"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"pkg.package-operator.run/boxcutter"
+
+	"github.com/openshift/cluster-capi-operator/pkg/manifesttransformer"
+	"github.com/openshift/cluster-capi-operator/pkg/revisiongenerator"
+)
+
+// testAnnotationKey is the annotation testValueTransformer writes.
+const testAnnotationKey = "test.openshift.io/transformer-value"
+
+// testAnnotationValue is set/cleared directly by tests to control what
+// testValueTransformer stamps onto objects on the next reconcile. nil means
+// "do nothing" -- the no-op path already exercised by every other test in
+// the suite, which never touches this variable.
+var testAnnotationValue atomic.Pointer[string]
+
+// testValueTransformer stamps obj with whatever testAnnotationValue
+// currently holds. It exists purely to let tests simulate a ManifestTransformer
+// whose output changes between reconciles without a new revision, so drift
+// correction of transformer-derived state can be verified directly.
+type testValueTransformer struct{}
+
+var _ manifesttransformer.ManifestTransformer = testValueTransformer{}
+
+// TransformObject implements manifesttransformer.ManifestTransformer.
+func (testValueTransformer) TransformObject(_ context.Context, obj *unstructured.Unstructured) (*unstructured.Unstructured, []boxcutter.ObjectReconcileOption, error) {
+	val := testAnnotationValue.Load()
+	if val == nil {
+		return obj, nil, nil
+	}
+
+	obj = obj.DeepCopy()
+
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	annotations[testAnnotationKey] = *val
+	obj.SetAnnotations(annotations)
+
+	return obj, nil, nil
+}
+
+// Validate implements manifesttransformer.ManifestTransformer.
+func (testValueTransformer) Validate(_ *unstructured.Unstructured) error { return nil }
+
+// WithRevision implements manifesttransformer.ManifestTransformer. It is a
+// no-op; testValueTransformer does not need revision context.
+func (t testValueTransformer) WithRevision(_ context.Context, _ revisiongenerator.RenderedRevision) manifesttransformer.ManifestTransformer {
+	return t
+}
+
+// WithComponent implements manifesttransformer.ManifestTransformer. It is a
+// no-op; testValueTransformer does not need component context.
+func (t testValueTransformer) WithComponent(_ context.Context, _ revisiongenerator.RenderedComponent) manifesttransformer.ManifestTransformer {
+	return t
+}

--- a/pkg/controllers/revision/helpers_test.go
+++ b/pkg/controllers/revision/helpers_test.go
@@ -19,20 +19,25 @@ package revision
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"slices"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/ptr"
+	"pkg.package-operator.run/boxcutter"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
+	"github.com/openshift/cluster-capi-operator/pkg/manifesttransformer"
 	"github.com/openshift/cluster-capi-operator/pkg/providerimages"
+	"github.com/openshift/cluster-capi-operator/pkg/revisiongenerator"
 	"github.com/openshift/cluster-capi-operator/pkg/test"
 )
 
@@ -73,6 +78,7 @@ func newManagerWrapper(providerImgs []providerimages.ProviderImageManifests, tls
 		Client:           mgr.GetClient(),
 		ProviderProfiles: imgs,
 		ReleaseVersion:   "4.18.0",
+		Transformers:     []manifesttransformer.ManifestTransformer{},
 	}).SetupWithManager(mgr, tlsOptions)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -192,3 +198,41 @@ func latestRevision(revisions []operatorv1alpha1.ClusterAPIInstallerRevision) op
 
 	return latest
 }
+
+// stubTransformer is a test double for manifesttransformer.ManifestTransformer.
+type stubTransformer struct {
+	validateErr error
+}
+
+func (s *stubTransformer) TransformObject(_ context.Context, obj *unstructured.Unstructured) (*unstructured.Unstructured, []boxcutter.ObjectReconcileOption, error) {
+	return obj, nil, nil
+}
+
+func (s *stubTransformer) Validate(_ *unstructured.Unstructured) error {
+	return s.validateErr
+}
+
+func (s *stubTransformer) WithRevision(_ context.Context, _ revisiongenerator.RenderedRevision) manifesttransformer.ManifestTransformer {
+	return s
+}
+
+func (s *stubTransformer) WithComponent(_ context.Context, _ revisiongenerator.RenderedComponent) manifesttransformer.ManifestTransformer {
+	return s
+}
+
+var _ manifesttransformer.ManifestTransformer = &stubTransformer{}
+
+// fakeRevision implements revisiongenerator.RenderedRevision for unit tests.
+type fakeRevision struct {
+	components []revisiongenerator.RenderedComponent
+}
+
+func (f *fakeRevision) ContentID() (string, error) { return "fake-content-id", nil }
+func (f *fakeRevision) Components() []revisiongenerator.RenderedComponent {
+	return f.components
+}
+func (f *fakeRevision) ForInstall(string, int64) (revisiongenerator.InstallerRevision, error) {
+	return nil, errors.New("not implemented")
+}
+
+var _ revisiongenerator.RenderedRevision = &fakeRevision{}

--- a/pkg/controllers/revision/revision_controller.go
+++ b/pkg/controllers/revision/revision_controller.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/openshift/cluster-capi-operator/pkg/manifesttransformer"
 	"github.com/openshift/cluster-capi-operator/pkg/operatorstatus"
 	"github.com/openshift/cluster-capi-operator/pkg/providerimages"
 	"github.com/openshift/cluster-capi-operator/pkg/revisiongenerator"
@@ -65,6 +66,7 @@ type RevisionController struct {
 	client.Client
 	ProviderProfiles []providerimages.ProviderImageManifests
 	ReleaseVersion   string
+	Transformers     []manifesttransformer.ManifestTransformer
 
 	// manifestSubstitutions is derived from TLSProfileSpec during SetupWithManager.
 	manifestSubstitutions map[string]string
@@ -150,6 +152,10 @@ func (r *RevisionController) generateDesiredRevision(ctx context.Context) (revis
 	revision, err := revisiongenerator.NewRenderedRevision(providerComponents, revisiongenerator.WithManifestSubstitutions(r.manifestSubstitutions))
 	if err != nil {
 		return nil, opresult.ErrorP(fmt.Errorf("error creating rendered revision: %w", err))
+	}
+
+	if err := manifesttransformer.ValidateTransformers(r.Transformers, revision); err != nil {
+		return nil, opresult.NonRetryableErrorP(fmt.Errorf("transformer validation failed: %w", err))
 	}
 
 	return revision, nil

--- a/pkg/controllers/revision/revision_controller_test.go
+++ b/pkg/controllers/revision/revision_controller_test.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/openshift/cluster-capi-operator/pkg/manifesttransformer"
 	"github.com/openshift/cluster-capi-operator/pkg/operatorstatus"
 	"github.com/openshift/cluster-capi-operator/pkg/providerimages"
 	"github.com/openshift/cluster-capi-operator/pkg/test"
@@ -573,5 +574,31 @@ var _ = Describe("RevisionController error handling", Serial, func() {
 			WithStatus(configv1.ConditionTrue).
 			WithReason(operatorstatus.ReasonEphemeralError).
 			WithMessage(ContainSubstring(testErr.Error())))
+	}, defaultNodeTimeout)
+
+	It("sets NonRetryableError when a transformer Validate fails", func(ctx context.Context) {
+		stub := &stubTransformer{validateErr: errors.New("invalid manifest")}
+		r := &RevisionController{
+			Client:           cl,
+			ProviderProfiles: defaultProviderImgs,
+			ReleaseVersion:   "4.18.0",
+			Transformers:     []manifesttransformer.ManifestTransformer{stub},
+		}
+
+		_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKey{Name: "cluster"}})
+		Expect(err).To(HaveOccurred(), "reconcile should surface the transformer validation failure")
+		Expect(errors.Is(err, reconcile.TerminalError(nil))).To(BeTrue(), "transformer validation failure should be a terminal error")
+
+		co := &configv1.ClusterOperator{}
+		Expect(cl.Get(ctx, client.ObjectKey{Name: "cluster-api"}, co)).To(Succeed())
+		Expect(co.Status.Conditions).To(SatisfyAll(
+			test.HaveCondition(conditionTypeProgressing).
+				WithStatus(configv1.ConditionFalse).
+				WithReason(operatorstatus.ReasonNonRetryableError),
+			test.HaveCondition(conditionTypeAvailable).
+				WithStatus(configv1.ConditionFalse).
+				WithReason(operatorstatus.ReasonNonRetryableError).
+				WithMessage(ContainSubstring("invalid manifest")),
+		))
 	}, defaultNodeTimeout)
 })

--- a/pkg/manifesttransformer/manifest_transformer.go
+++ b/pkg/manifesttransformer/manifest_transformer.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manifesttransformer
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"pkg.package-operator.run/boxcutter"
+
+	"github.com/openshift/cluster-capi-operator/pkg/revisiongenerator"
+)
+
+// ManifestTransformer transforms objects at install time while objects are being
+// collected into boxcutter phases.
+type ManifestTransformer interface {
+	// TransformObject returns a transformed copy of the object and any
+	// boxcutter options that should apply to the object. If TransformObject
+	// returns a nil object, it means the object should be skipped.
+	TransformObject(ctx context.Context, obj *unstructured.Unstructured) (*unstructured.Unstructured, []boxcutter.ObjectReconcileOption, error)
+
+	// Validate checks that the object is valid for this transformer. An error
+	// prevents revision creation and is treated as non-retryable.
+	Validate(obj *unstructured.Unstructured) error
+
+	// WithRevision returns a new transformer that will be used for the given revision.
+	WithRevision(ctx context.Context, revision revisiongenerator.RenderedRevision) ManifestTransformer
+
+	// WithComponent returns a new transformer that will be used for the given component.
+	WithComponent(ctx context.Context, component revisiongenerator.RenderedComponent) ManifestTransformer
+}

--- a/pkg/manifesttransformer/validate.go
+++ b/pkg/manifesttransformer/validate.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manifesttransformer
+
+import (
+	"errors"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/cluster-capi-operator/pkg/revisiongenerator"
+)
+
+// ValidateTransformers calls Validate on each transformer for every object in the revision.
+// All errors are collected and returned together via errors.Join.
+func ValidateTransformers(transformers []ManifestTransformer, rev revisiongenerator.RenderedRevision) error {
+	var allErrs []error
+
+	for _, component := range rev.Components() {
+		for _, obj := range component.Objects() {
+			for _, t := range transformers {
+				if err := t.Validate(obj); err != nil {
+					allErrs = append(allErrs, fmt.Errorf("%s %s: %w", component.Name(), client.ObjectKeyFromObject(obj), err))
+				}
+			}
+		}
+	}
+
+	return errors.Join(allErrs...)
+}

--- a/pkg/manifesttransformer/validate_test.go
+++ b/pkg/manifesttransformer/validate_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manifesttransformer
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"pkg.package-operator.run/boxcutter"
+
+	"github.com/openshift/cluster-capi-operator/pkg/revisiongenerator"
+)
+
+func TestValidateTransformers(t *testing.T) {
+	const componentName = "my-component"
+
+	testObj := unstructured.Unstructured{}
+	testObj.SetName("my-obj")
+
+	testObj2 := unstructured.Unstructured{}
+	testObj2.SetName("my-obj2")
+
+	t.Run("nil transformers returns no error", func(t *testing.T) {
+		g := NewWithT(t)
+		rev := &fakeRevision{
+			components: []revisiongenerator.RenderedComponent{
+				&fakeComponent{name: componentName, objects: []*unstructured.Unstructured{&testObj}},
+			},
+		}
+		g.Expect(ValidateTransformers(nil, rev)).To(Succeed())
+	})
+
+	t.Run("empty transformers returns no error", func(t *testing.T) {
+		g := NewWithT(t)
+		rev := &fakeRevision{
+			components: []revisiongenerator.RenderedComponent{
+				&fakeComponent{name: componentName, objects: []*unstructured.Unstructured{&testObj}},
+			},
+		}
+		g.Expect(ValidateTransformers([]ManifestTransformer{}, rev)).To(Succeed())
+	})
+
+	t.Run("validates Objects and includes component name in error", func(t *testing.T) {
+		g := NewWithT(t)
+		rev := &fakeRevision{
+			components: []revisiongenerator.RenderedComponent{
+				&fakeComponent{name: componentName, objects: []*unstructured.Unstructured{&testObj}},
+			},
+		}
+		stub := &stubTransformer{validateErr: errors.New("obj invalid")}
+		g.Expect(ValidateTransformers([]ManifestTransformer{stub}, rev)).
+			To(MatchError(SatisfyAll(
+				ContainSubstring(componentName),
+				ContainSubstring("my-obj"),
+				ContainSubstring("obj invalid"),
+			)))
+	})
+
+	t.Run("collects errors from multiple objects", func(t *testing.T) {
+		g := NewWithT(t)
+		rev := &fakeRevision{
+			components: []revisiongenerator.RenderedComponent{
+				&fakeComponent{name: componentName, objects: []*unstructured.Unstructured{&testObj, &testObj2}},
+			},
+		}
+		stub := &stubTransformer{validateErr: errors.New("invalid")}
+		g.Expect(ValidateTransformers([]ManifestTransformer{stub}, rev)).
+			To(MatchError(SatisfyAll(
+				ContainSubstring("my-obj"),
+				ContainSubstring("my-obj2"),
+			)))
+	})
+
+	t.Run("aggregates errors across multiple components rather than stopping at the first", func(t *testing.T) {
+		g := NewWithT(t)
+
+		objA := &unstructured.Unstructured{}
+		objA.SetName("obj-a")
+
+		objB := &unstructured.Unstructured{}
+		objB.SetName("obj-b")
+
+		rev := &fakeRevision{
+			components: []revisiongenerator.RenderedComponent{
+				&fakeComponent{name: "comp-1", objects: []*unstructured.Unstructured{objA}},
+				&fakeComponent{name: "comp-2", objects: []*unstructured.Unstructured{objB}},
+			},
+		}
+		stub := &stubTransformer{validateErr: errors.New("invalid")}
+
+		err := ValidateTransformers([]ManifestTransformer{stub}, rev)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("comp-1"))
+		g.Expect(err.Error()).To(ContainSubstring("obj-a"))
+		g.Expect(err.Error()).To(ContainSubstring("comp-2"))
+		g.Expect(err.Error()).To(ContainSubstring("obj-b"))
+	})
+
+	t.Run("aggregates errors from multiple transformers on the same object", func(t *testing.T) {
+		g := NewWithT(t)
+
+		rev := &fakeRevision{
+			components: []revisiongenerator.RenderedComponent{
+				&fakeComponent{name: componentName, objects: []*unstructured.Unstructured{&testObj}},
+			},
+		}
+		stubA := &stubTransformer{validateErr: errors.New("error-a")}
+		stubB := &stubTransformer{validateErr: errors.New("error-b")}
+
+		err := ValidateTransformers([]ManifestTransformer{stubA, stubB}, rev)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("error-a"))
+		g.Expect(err.Error()).To(ContainSubstring("error-b"))
+	})
+}
+
+// stubTransformer is a test double for ManifestTransformer.
+type stubTransformer struct {
+	validateErr error
+}
+
+func (s *stubTransformer) TransformObject(_ context.Context, obj *unstructured.Unstructured) (*unstructured.Unstructured, []boxcutter.ObjectReconcileOption, error) {
+	return obj, nil, nil
+}
+
+func (s *stubTransformer) Validate(_ *unstructured.Unstructured) error {
+	return s.validateErr
+}
+
+func (s *stubTransformer) WithRevision(_ context.Context, _ revisiongenerator.RenderedRevision) ManifestTransformer {
+	return s
+}
+
+func (s *stubTransformer) WithComponent(_ context.Context, _ revisiongenerator.RenderedComponent) ManifestTransformer {
+	return s
+}
+
+var _ ManifestTransformer = &stubTransformer{}
+
+// fakeComponent implements revisiongenerator.RenderedComponent for unit tests
+// that need a revision without running the full revision generator.
+type fakeComponent struct {
+	name    string
+	objects []*unstructured.Unstructured
+}
+
+func (f *fakeComponent) Name() string                          { return f.name }
+func (f *fakeComponent) Objects() []*unstructured.Unstructured { return f.objects }
+
+// fakeRevision implements revisiongenerator.RenderedRevision for unit tests.
+type fakeRevision struct {
+	components []revisiongenerator.RenderedComponent
+}
+
+func (f *fakeRevision) ContentID() (string, error) { return "fake-content-id", nil }
+func (f *fakeRevision) Components() []revisiongenerator.RenderedComponent {
+	return f.components
+}
+func (f *fakeRevision) ForInstall(string, int64) (revisiongenerator.InstallerRevision, error) {
+	return nil, errors.New("not implemented")
+}
+
+var _ revisiongenerator.RenderedRevision = &fakeRevision{}

--- a/pkg/revisiongenerator/revision.go
+++ b/pkg/revisiongenerator/revision.go
@@ -283,22 +283,10 @@ func buildRevisionName(releaseVersion, contentID string, index int64) operatorv1
 }
 
 type revisionRenderConfig struct {
-	objectCollectors []RevisionObjectCollector
-	substitutions    map[string]string
+	substitutions map[string]string
 }
 
 type revisionRenderOption func(*revisionRenderConfig)
-
-// RevisionObjectCollector is a function that will be called for each object in
-// the rendered revision.
-type RevisionObjectCollector func(obj unstructured.Unstructured)
-
-// WithObjectCollectors adds object collectors to the revision render config.
-func WithObjectCollectors(collectors ...RevisionObjectCollector) revisionRenderOption {
-	return func(opts *revisionRenderConfig) {
-		opts.objectCollectors = append(opts.objectCollectors, collectors...)
-	}
-}
 
 // WithManifestSubstitutions adds envsubst-style substitutions that will be
 // applied to manifests during rendering and recorded on the revision. When
@@ -409,10 +397,6 @@ func newRenderedComponent(providerProfile *providerimages.ProviderImageManifests
 		}
 
 		unstructured = transformObject(unstructured, component.name)
-
-		for _, collector := range cfg.objectCollectors {
-			collector(unstructured)
-		}
 
 		component.objects = append(component.objects, &unstructured)
 	}

--- a/pkg/revisiongenerator/revision.go
+++ b/pkg/revisiongenerator/revision.go
@@ -29,8 +29,6 @@ import (
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	operatorv1alpha1ac "github.com/openshift/client-go/operator/applyconfigurations/operator/v1alpha1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	k8syaml "sigs.k8s.io/yaml"
 
 	"github.com/openshift/cluster-capi-operator/pkg/providerimages"
@@ -78,15 +76,13 @@ type InstallerRevision interface {
 	ToAPIRevision() (operatorv1alpha1.ClusterAPIInstallerRevision, error)
 }
 
-// RenderedComponent represents a single provider component with manifests
-// separated into CRDs and other objects.
+// RenderedComponent represents a single provider component with its manifests
+// parsed.
 type RenderedComponent interface {
 	// Name returns the component name.
 	Name() string
-	// CRDs returns the CRD objects for this component.
-	CRDs() []client.Object
-	// Objects returns the non-CRD objects for this component.
-	Objects() []client.Object
+	// Objects returns all objects for this component.
+	Objects() []*unstructured.Unstructured
 }
 
 type renderedRevision struct {
@@ -387,8 +383,7 @@ type renderedComponent struct {
 	imageRef string
 	profile  string
 
-	crds    []unstructured.Unstructured
-	objects []unstructured.Unstructured
+	objects []*unstructured.Unstructured
 }
 
 func newRenderedComponent(providerProfile *providerimages.ProviderImageManifests, cfg *revisionRenderConfig) (*renderedComponent, error) {
@@ -419,14 +414,7 @@ func newRenderedComponent(providerProfile *providerimages.ProviderImageManifests
 			collector(unstructured)
 		}
 
-		gvk := unstructured.GroupVersionKind()
-
-		switch gvk.GroupKind() {
-		case schema.GroupKind{Group: "apiextensions.k8s.io", Kind: "CustomResourceDefinition"}:
-			component.crds = append(component.crds, unstructured)
-		default:
-			component.objects = append(component.objects, unstructured)
-		}
+		component.objects = append(component.objects, &unstructured)
 	}
 
 	return component, nil
@@ -439,24 +427,15 @@ func (c *renderedComponent) Name() string {
 	return c.name
 }
 
-// CRDs returns the CRD objects for this component.
-func (c *renderedComponent) CRDs() []client.Object {
-	return util.SliceMap(c.crds, func(crd unstructured.Unstructured) client.Object {
-		return &crd
-	})
-}
-
-// Objects returns the non-CRD objects for this component.
-func (c *renderedComponent) Objects() []client.Object {
-	return util.SliceMap(c.objects, func(obj unstructured.Unstructured) client.Object {
-		return &obj
-	})
+// Objects returns all objects for this component, including CRDs.
+func (c *renderedComponent) Objects() []*unstructured.Unstructured {
+	return c.objects
 }
 
 func (c *renderedComponent) contentID() (string, error) {
 	h := sha256.New()
 
-	for _, obj := range slices.Concat(c.crds, c.objects) {
+	for _, obj := range c.objects {
 		data, err := json.Marshal(obj.Object)
 		if err != nil {
 			return "", fmt.Errorf("error marshalling object: %w", err)

--- a/pkg/revisiongenerator/revision_test.go
+++ b/pkg/revisiongenerator/revision_test.go
@@ -310,8 +310,7 @@ func TestForInstall(t *testing.T) {
 
 		components := installer.Components()
 		g.Expect(components).To(HaveLen(1))
-		g.Expect(components[0].CRDs()).To(HaveLen(1))
-		g.Expect(components[0].Objects()).To(HaveLen(1))
+		g.Expect(components[0].Objects()).To(HaveLen(2))
 	})
 
 	t.Run("name truncation with long version", func(t *testing.T) {
@@ -548,26 +547,17 @@ func TestComponents(t *testing.T) {
 	for _, tc := range []struct {
 		name        string
 		manifests   string
-		wantCRDs    int
 		wantObjects int
 	}{
 		{
-			name:        "separates CRDs from other objects",
+			name:        "returns all objects",
 			manifests:   multiDoc(crdA, configMapA, crdB, configMapB),
-			wantCRDs:    2,
-			wantObjects: 2,
+			wantObjects: 4,
 		},
 		{
-			name:        "component with only CRDs has empty Objects",
-			manifests:   crdA,
-			wantCRDs:    1,
+			name:        "returns no objects",
+			manifests:   "",
 			wantObjects: 0,
-		},
-		{
-			name:        "component with only objects has empty CRDs",
-			manifests:   configMapA,
-			wantCRDs:    0,
-			wantObjects: 1,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -578,26 +568,11 @@ func TestComponents(t *testing.T) {
 			}))(g)
 
 			c := rev.Components()[0]
-			g.Expect(c.CRDs()).To(HaveLen(tc.wantCRDs))
 			g.Expect(c.Objects()).To(HaveLen(tc.wantObjects))
 		})
 	}
 
-	t.Run("CRDs returns client.Object slices matching underlying objects", func(t *testing.T) {
-		g := NewWithT(t)
-
-		rev := must(NewRenderedRevision([]providerimages.ProviderImageManifests{
-			profile(t, "core", "img1", "default", crdA),
-		}))(g)
-
-		crds := rev.Components()[0].CRDs()
-		g.Expect(crds).To(HaveLen(1))
-		g.Expect(crds[0].GetName()).To(Equal("widgets.example.com"))
-		g.Expect(crds[0].GetObjectKind().GroupVersionKind().Kind).To(Equal("CustomResourceDefinition"))
-		g.Expect(crds[0].GetLabels()).To(HaveKeyWithValue(ManagedLabelKey, "core"))
-	})
-
-	t.Run("Objects returns client.Object slices matching underlying objects", func(t *testing.T) {
+	t.Run("Objects returns unstructured.Unstructured slices matching underlying objects", func(t *testing.T) {
 		g := NewWithT(t)
 
 		rev := must(NewRenderedRevision([]providerimages.ProviderImageManifests{
@@ -710,7 +685,7 @@ func TestNewInstallerRevisionFromAPI(t *testing.T) {
 		g.Expect(components[1].Name()).To(Equal("core"))
 	})
 
-	t.Run("renders CRDs and objects from matched profiles", func(t *testing.T) {
+	t.Run("renders objects from matched profiles", func(t *testing.T) {
 		g := NewWithT(t)
 
 		profiles := makeProfiles(t)
@@ -728,8 +703,7 @@ func TestNewInstallerRevisionFromAPI(t *testing.T) {
 		rev := must(NewInstallerRevisionFromAPI(apiRev, profiles))(g)
 
 		c := rev.Components()[0]
-		g.Expect(c.CRDs()).To(HaveLen(1))
-		g.Expect(c.Objects()).To(HaveLen(1))
+		g.Expect(c.Objects()).To(HaveLen(2))
 	})
 
 	t.Run("returns error for missing component", func(t *testing.T) {

--- a/pkg/revisiongenerator/validate.go
+++ b/pkg/revisiongenerator/validate.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/openshift/cluster-capi-operator/pkg/operatorstatus"
@@ -53,7 +53,7 @@ var ErrInvalidAdoptExistingAnnotation = errors.New("invalid " + AdoptExistingAnn
 
 // ValidateAdoptExistingAnnotation returns an error if the object has an
 // adopt-existing annotation with an unrecognised value.
-func ValidateAdoptExistingAnnotation(obj client.Object) error {
+func ValidateAdoptExistingAnnotation(obj *unstructured.Unstructured) error {
 	annotations := obj.GetAnnotations()
 	if annotations == nil {
 		return nil
@@ -82,12 +82,6 @@ func ValidateAdoptExistingAnnotation(obj client.Object) error {
 // validateRenderedRevision validates all objects in a rendered revision.
 func validateRenderedRevision(rev *renderedRevision) error {
 	for _, component := range rev.components {
-		for _, obj := range component.CRDs() {
-			if err := ValidateAdoptExistingAnnotation(obj); err != nil {
-				return err
-			}
-		}
-
 		for _, obj := range component.Objects() {
 			if err := ValidateAdoptExistingAnnotation(obj); err != nil {
 				return err

--- a/pkg/revisiongenerator/validate_test.go
+++ b/pkg/revisiongenerator/validate_test.go
@@ -87,7 +87,7 @@ func TestValidateRenderedRevision(t *testing.T) {
 		rev := &renderedRevision{
 			components: []*renderedComponent{
 				{
-					objects: []unstructured.Unstructured{
+					objects: []*unstructured.Unstructured{
 						makeUnstructuredWithAnnotations(nil),
 						makeUnstructuredWithAnnotations(map[string]string{AdoptExistingAnnotation: AdoptExistingAlways}),
 					},
@@ -104,28 +104,7 @@ func TestValidateRenderedRevision(t *testing.T) {
 		rev := &renderedRevision{
 			components: []*renderedComponent{
 				{
-					objects: []unstructured.Unstructured{
-						makeUnstructuredWithAnnotations(map[string]string{AdoptExistingAnnotation: "bad"}),
-					},
-				},
-			},
-		}
-
-		err := validateRenderedRevision(rev)
-		if err == nil {
-			t.Fatal("expected error, got nil")
-		}
-
-		if !errors.Is(err, ErrInvalidAdoptExistingAnnotation) {
-			t.Errorf("expected error to wrap ErrInvalidAdoptExistingAnnotation, got %v", err)
-		}
-	})
-
-	t.Run("invalid annotation in CRDs", func(t *testing.T) {
-		rev := &renderedRevision{
-			components: []*renderedComponent{
-				{
-					crds: []unstructured.Unstructured{
+					objects: []*unstructured.Unstructured{
 						makeUnstructuredWithAnnotations(map[string]string{AdoptExistingAnnotation: "bad"}),
 					},
 				},
@@ -143,8 +122,8 @@ func TestValidateRenderedRevision(t *testing.T) {
 	})
 }
 
-func makeUnstructuredWithAnnotations(annotations map[string]string) unstructured.Unstructured {
-	obj := unstructured.Unstructured{}
+func makeUnstructuredWithAnnotations(annotations map[string]string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
 	obj.SetAnnotations(annotations)
 
 	return obj


### PR DESCRIPTION
Adds the ManifestTransformers interface and integrates it into the installer and revision controllers. This change does not yet add any ManifestTransformers. It is purely preparatory work.

Builds on https://github.com/openshift/cluster-capi-operator/pull/633

TODO:
- [x] Merge https://github.com/openshift/cluster-capi-operator/pull/633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added configurable install-time manifest transformers that can update resources, skip specific objects, and influence per-object reconciliation behavior.
  * Added transformer validation that blocks non-retryable revision creation when manifests fail validation.
* **Bug Fixes**
  * Improved reconciliation to build and resolve revisions on demand, reducing upfront conversion work.
  * Updated adopt-existing annotation handling to respect transformed resources and collision-protection behavior.
* **Tests**
  * Expanded coverage for transformer validation, chaining, error aggregation, object skipping, CRD vs non-CRD phase behavior, and transformer-driven drift.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->