### PR TITLE
OCPBUGS-100143: e2e: skip CRD Compatibility Checker tests on External topology clusters

### DIFF
--- a/e2e/crd_compatibility.go
+++ b/e2e/crd_compatibility.go
@@ -91,10 +91,14 @@ func testCRDGVK(crd *apiextensionsv1.CustomResourceDefinition) schema.GroupVersi
 	}
 }
 
-var _ = Describe("[sig-cluster-lifecycle][OCPFeatureGate:CRDCompatibilityRequirementOperator] CRD Compatibility Checker", Ordered, func() {
+var _ = Describe("[sig-cluster-lifecycle][OCPFeatureGate:CRDCompatibilityRequirementOperator] CRD Compatibility Checker", Label("skip-topology:External"), Ordered, func() {
 	BeforeAll(func() {
 		if !framework.IsFeatureGateEnabled(ctx, cl, features.FeatureGateCRDCompatibilityRequirementOperator) {
 			Skip("Feature gate CRDCompatibilityRequirementOperator is not enabled.")
+		}
+
+		if infra.Status.ControlPlaneTopology == configv1.ExternalTopologyMode {
+			Skip("CRD Compatibility Checker tests are not supported on External topology clusters.")
 		}
 	})
 

--- a/openshift-tests-extension/README.md
+++ b/openshift-tests-extension/README.md
@@ -64,6 +64,32 @@ var _ = Describe("[sig-cluster-lifecycle][OCPFeatureGate:ClusterAPIMachineManage
 })
 ```
 
+## Environment labels
+
+Ginkgo labels with specific prefixes are automatically translated into OTE
+environment selectors in `openshift-tests-extension/cmd/main.go`:
+
+| Ginkgo label | OTE effect | Example |
+|---|---|---|
+| `Label("platform:<name>")` | Include only on matching platform | `Label("platform:AWS")` |
+| `Label("skip-topology:<mode>")` | Exclude on matching topology | `Label("skip-topology:External")` |
+
+These labels have no effect when running via `make e2e` — use a runtime
+`Skip()` in `BeforeAll` as a fallback for that path.
+
+Example — skip a test on External topology clusters (both OTE and `make e2e`):
+
+```go
+var _ = Describe("My test", Label("skip-topology:External"), func() {
+    BeforeAll(func() {
+        if infra.Status.ControlPlaneTopology == configv1.ExternalTopologyMode {
+            Skip("Not supported on External topology clusters.")
+        }
+    })
+    // ...
+})
+```
+
 ## Feature gate labeling
 
 Every e2e test must carry the appropriate `[OCPFeatureGate:FeatureName]` tag in

--- a/openshift-tests-extension/cmd/main.go
+++ b/openshift-tests-extension/cmd/main.go
@@ -72,11 +72,14 @@ func main() {
 		e2e.InitCommonVariables()
 	})
 
-	// Auto-apply platform environment selectors from Ginkgo Label("platform:<name>") annotations.
+	// Auto-apply environment selectors from Ginkgo labels.
 	specs.Walk(func(spec *et.ExtensionTestSpec) {
 		for label := range spec.Labels {
 			if platform, ok := strings.CutPrefix(label, "platform:"); ok {
 				spec.Include(et.PlatformEquals(platform))
+			}
+			if topology, ok := strings.CutPrefix(label, "skip-topology:"); ok {
+				spec.Exclude(et.TopologyEquals(topology))
 			}
 		}
 	})


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-100143

The compatibility-requirements-controllers Deployment is not deployed on HyperShift (External topology) clusters because the control plane runs externally, causing all CRD Compatibility Checker tests to fail.

Two skip mechanisms cover both execution paths:
- OTE: a generic `Label("skip-topology:<mode>")` convention is introduced. `specs.Walk()` translates it into an exclude selector so the harness drops matching tests before selecting them for execution. The test `Describe` block carries `Label("skip-topology:External")`.
- make e2e (standard Ginkgo): a runtime `BeforeAll Skip()` guards the suite since OTE selectors are not evaluated by the Ginkgo runner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented CRD compatibility checks from running in external-topology clusters.
  * Improved test selection so topology-incompatible scenarios are automatically excluded based on Ginkgo label hints.
* **Documentation**
  * Added guidance for using environment labels (e.g., `platform:<name>` and `skip-topology:<mode>`) to control which tests run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->