### PR TITLE
NO-JIRA: go.mod: pin k8s.io/cri-streaming to v0.36.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ replace (
 	k8s.io/controller-manager => k8s.io/controller-manager v0.36.2
 	k8s.io/cri-api => k8s.io/cri-api v0.36.2
 	k8s.io/cri-client => k8s.io/cri-client v0.36.2
+	k8s.io/cri-streaming => k8s.io/cri-streaming v0.36.2
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.36.2
 	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.36.2
 	k8s.io/endpointslice => k8s.io/endpointslice v0.36.2

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -3375,6 +3375,7 @@ sigs.k8s.io/yaml/goyaml.v2
 # k8s.io/controller-manager => k8s.io/controller-manager v0.36.2
 # k8s.io/cri-api => k8s.io/cri-api v0.36.2
 # k8s.io/cri-client => k8s.io/cri-client v0.36.2
+# k8s.io/cri-streaming => k8s.io/cri-streaming v0.36.2
 # k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.36.2
 # k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.36.2
 # k8s.io/endpointslice => k8s.io/endpointslice v0.36.2


### PR DESCRIPTION
`k8s.io/kubernetes@v1.36.2` depends on `k8s.io/cri-streaming@v0.0.0`, a placeholder version that cannot be resolved. 
```
cluster-capi-operator$ go list -m -json -mod=readonly all
go: k8s.io/cri-streaming@v0.0.0: invalid version: unknown revision v0.0.0
```

Add a replace directive to pin it to the actual `v0.36.2` release, consistent with all other `k8s.io/*` replacements.

CI will be updated to find these issues in https://github.com/openshift/release/pull/82669

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Kubernetes container runtime streaming component to version 0.36.2 for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->