### PR TITLE
OCPBUGS-100316: Change failurePolicy to Ignore on MAPI-guarding VAPs …

### DIFF
--- a/admission-policies/default/authoritative-api-transition-requires-capi-infrastructure-ready.yaml
+++ b/admission-policies/default/authoritative-api-transition-requires-capi-infrastructure-ready.yaml
@@ -25,7 +25,7 @@ kind: ValidatingAdmissionPolicy
 metadata:
   name: openshift-mapi-authoritative-api-transition-requires-capi-infrastructure-ready-and-not-deleting
 spec:
-  failurePolicy: Fail
+  failurePolicy: Ignore
 
   paramKind:
     apiVersion: cluster.x-k8s.io/v1beta2

--- a/admission-policies/default/machine-api-machine-set-vap.yaml
+++ b/admission-policies/default/machine-api-machine-set-vap.yaml
@@ -25,7 +25,7 @@ kind: ValidatingAdmissionPolicy
 metadata:
   name: machine-api-machine-set-vap
 spec:
-  failurePolicy: Fail
+  failurePolicy: Ignore
 
   paramKind:
     apiVersion: cluster.x-k8s.io/v1beta2

--- a/admission-policies/default/machine-api-machine-vap.yaml
+++ b/admission-policies/default/machine-api-machine-vap.yaml
@@ -25,7 +25,7 @@ kind: ValidatingAdmissionPolicy
 metadata:
   name: machine-api-machine-vap
 spec:
-  failurePolicy: Fail
+  failurePolicy: Ignore
 
   paramKind:
     apiVersion: cluster.x-k8s.io/v1beta2

--- a/admission-policies/default/only-create-mapi-machine-if-authoritative-api-capi.yaml
+++ b/admission-policies/default/only-create-mapi-machine-if-authoritative-api-capi.yaml
@@ -3,7 +3,7 @@ kind: ValidatingAdmissionPolicy
 metadata:
   name: openshift-only-create-mapi-machine-if-authoritative-api-capi
 spec:
-  failurePolicy: Fail
+  failurePolicy: Ignore
   
   paramKind:
     apiVersion: cluster.x-k8s.io/v1beta2

--- a/admission-policies/default/prevent-authoritative-mapi-machineset-create-when-capi-exists.yaml
+++ b/admission-policies/default/prevent-authoritative-mapi-machineset-create-when-capi-exists.yaml
@@ -3,7 +3,7 @@ kind: ValidatingAdmissionPolicy
 metadata:
   name: openshift-prevent-authoritative-mapi-machineset-create-when-capi-exists 
 spec:
-  failurePolicy: Fail
+  failurePolicy: Ignore
   paramKind:
     apiVersion: cluster.x-k8s.io/v1beta2
     kind: MachineSet

--- a/capi-operator-manifests/default/manifests.yaml
+++ b/capi-operator-manifests/default/manifests.yaml
@@ -22,7 +22,7 @@ kind: ValidatingAdmissionPolicy
 metadata:
   name: machine-api-machine-vap
 spec:
-  failurePolicy: Fail
+  failurePolicy: Ignore
   matchConditions:
   - expression: |-
       !(request.userInfo.username in [
@@ -149,7 +149,7 @@ kind: ValidatingAdmissionPolicy
 metadata:
   name: machine-api-machine-set-vap
 spec:
-  failurePolicy: Fail
+  failurePolicy: Ignore
   matchConditions:
   - expression: |-
       !(request.userInfo.username in [
@@ -525,7 +525,7 @@ kind: ValidatingAdmissionPolicy
 metadata:
   name: openshift-only-create-mapi-machine-if-authoritative-api-capi
 spec:
-  failurePolicy: Fail
+  failurePolicy: Ignore
   matchConditions:
   - expression: object.metadata.name == params.metadata.name
     name: check-param-match
@@ -576,7 +576,7 @@ kind: ValidatingAdmissionPolicy
 metadata:
   name: openshift-prevent-authoritative-mapi-machineset-create-when-capi-exists
 spec:
-  failurePolicy: Fail
+  failurePolicy: Ignore
   matchConditions:
   - expression: object.metadata.name == params.metadata.name
     name: check-param-match
@@ -901,7 +901,7 @@ kind: ValidatingAdmissionPolicy
 metadata:
   name: openshift-mapi-authoritative-api-transition-requires-capi-infrastructure-ready-and-not-deleting
 spec:
-  failurePolicy: Fail
+  failurePolicy: Ignore
   matchConditions:
   - expression: |-
       !(request.userInfo.username in [


### PR DESCRIPTION
…with CAPI paramKind.

 looks good to me as immediate fix for unblocking tp installs on vsphere 
  When the CAPI CRDs (cluster.x-k8s.io/v1beta2) are not yet established during install, the apiserver cannot resolve the paramKind and the VAP is "misconfigured". With `failurePolicy: Fail`, this denies every MAPI machine update — including status patches from machine-api-controllers, which are normally exempted via matchConditions but never reach that
evaluation. Workers clone successfully in vCenter but the machinecontroller can never persist the provider task ID, leaving all workers stuck in Provisioning and failing the install.


  Affected files:
  - authoritative-api-transition-requires-capi-infrastructure-ready.yaml
  - machine-api-machine-vap.yaml
  - machine-api-machine-set-vap.yaml
  - only-create-mapi-machine-if-authoritative-api-capi.yaml
  - prevent-authoritative-mapi-machineset-create-when-capi-exists.yaml
  
  generated by *claude*
  
  I understand there might be a reason we set them as `Fail` earlier , so we may have to dig more for a way to establish that CRDs are established and then we change it to fail ( that might need more in depth analysis ) 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * Updated several admission policies to continue processing requests when policy evaluation cannot be completed.
  * Applies to machine and machine set validation, MAPI creation safeguards, and authoritative API transition checks.
  * These checks now fail open instead of blocking requests when an evaluation error occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->