### PR TITLE
OCPCLOUD-3513: Generate the manifests summary

### DIFF
--- a/manifests-gen/generate.go
+++ b/manifests-gen/generate.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"sort"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-capi-operator/manifests-gen/providermetadata"
@@ -57,6 +58,10 @@ func generateManifests(opts cmdlineOptions) error {
 	// Write the metadata file
 	if err := writeMetadata(opts); err != nil {
 		return fmt.Errorf("error writing metadata: %w", err)
+	}
+
+	if err := writeManifestsSummary(opts, resources); err != nil {
+		return fmt.Errorf("error writing manifests summary: %w", err)
 	}
 
 	return nil
@@ -136,6 +141,77 @@ func writeManifests(opts cmdlineOptions, resources []client.Object) (err error) 
 		if _, err := writer.Write(data); err != nil {
 			return fmt.Errorf("error writing object to manifests file: %w", err)
 		}
+	}
+
+	return nil
+}
+
+type ManifestMetadata struct {
+	Kind       string `json:"kind,omitempty"`
+	APIVersion string `json:"apiVersion,omitempty"`
+	Name       string `json:"name,omitempty"`
+	Namespace  string `json:"namespace,omitempty"`
+}
+
+type ManifestsSummary map[string][]ManifestMetadata
+
+func writeManifestsSummary(opts cmdlineOptions, resources []client.Object) (err error) {
+	if opts.manifestsSummaryFile == "" {
+		return nil
+	}
+
+	var manifests []ManifestMetadata
+	for _, resource := range resources {
+		manifests = append(manifests, ManifestMetadata{
+			Kind:       resource.GetObjectKind().GroupVersionKind().Kind,
+			APIVersion: resource.GetObjectKind().GroupVersionKind().GroupVersion().String(),
+			Name:       resource.GetName(),
+			Namespace:  resource.GetNamespace(),
+		})
+	}
+
+	sort.Slice(manifests, func(i, j int) bool {
+		if manifests[i].Kind != manifests[j].Kind {
+			return manifests[i].Kind < manifests[j].Kind
+		}
+		if manifests[i].APIVersion != manifests[j].APIVersion {
+			return manifests[i].APIVersion < manifests[j].APIVersion
+		}
+		if manifests[i].Namespace != manifests[j].Namespace {
+			return manifests[i].Namespace < manifests[j].Namespace
+		}
+
+		return manifests[i].Name < manifests[j].Name
+	})
+
+	var summary ManifestsSummary
+	if data, err := os.ReadFile(opts.manifestsSummaryFile); err == nil {
+		if err := yaml.Unmarshal(data, &summary); err != nil {
+			return fmt.Errorf("failed to unmarshal existing summary: %w", err)
+		}
+	} else if errors.Is(err, os.ErrNotExist) {
+		summary = make(ManifestsSummary)
+	} else {
+		return fmt.Errorf("error reading manifests summary file %s: %w", opts.manifestsSummaryFile, err)
+	}
+
+	summary[opts.profileName] = manifests
+
+	data, err := yaml.Marshal(summary)
+	if err != nil {
+		return fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	manifestsSummaryFile, err := os.OpenFile(opts.manifestsSummaryFile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY|os.O_APPEND, 0600)
+	if err != nil {
+		return fmt.Errorf("error opening metadata file %s: %w", opts.manifestsSummaryFile, err)
+	}
+	defer func() {
+		err = errors.Join(err, manifestsSummaryFile.Close())
+	}()
+
+	if _, err := manifestsSummaryFile.Write(data); err != nil {
+		return fmt.Errorf("error writing manifests summary to file: %w", err)
 	}
 
 	return nil

--- a/manifests-gen/generate.go
+++ b/manifests-gen/generate.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"sort"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -202,16 +203,25 @@ func writeManifestsSummary(opts cmdlineOptions, resources []client.Object) (err 
 		return fmt.Errorf("failed to marshal: %w", err)
 	}
 
-	manifestsSummaryFile, err := os.OpenFile(opts.manifestsSummaryFile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY|os.O_APPEND, 0600)
+	tmpFile, err := os.CreateTemp(filepath.Dir(opts.manifestsSummaryFile), ".manifests-summary-*.yaml")
 	if err != nil {
-		return fmt.Errorf("error opening metadata file %s: %w", opts.manifestsSummaryFile, err)
+		return fmt.Errorf("error creating temp file for manifests summary: %w", err)
 	}
-	defer func() {
-		err = errors.Join(err, manifestsSummaryFile.Close())
-	}()
 
-	if _, err := manifestsSummaryFile.Write(data); err != nil {
-		return fmt.Errorf("error writing manifests summary to file: %w", err)
+	if _, err := tmpFile.Write(data); err != nil {
+		tmpFile.Close()
+		os.Remove(tmpFile.Name())
+		return fmt.Errorf("error writing manifests summary to temp file: %w", err)
+	}
+
+	if err := tmpFile.Close(); err != nil {
+		os.Remove(tmpFile.Name())
+		return fmt.Errorf("error closing temp file: %w", err)
+	}
+
+	if err := os.Rename(tmpFile.Name(), opts.manifestsSummaryFile); err != nil {
+		os.Remove(tmpFile.Name())
+		return fmt.Errorf("error renaming temp file to %s: %w", opts.manifestsSummaryFile, err)
 	}
 
 	return nil

--- a/manifests-gen/generate.go
+++ b/manifests-gen/generate.go
@@ -156,7 +156,7 @@ type ManifestMetadata struct {
 
 type ManifestsSummary map[string][]ManifestMetadata
 
-func writeManifestsSummary(opts cmdlineOptions, resources []client.Object) (err error) {
+func writeManifestsSummary(opts cmdlineOptions, resources []client.Object) error {
 	if opts.manifestsSummaryFile == "" {
 		return nil
 	}
@@ -209,19 +209,25 @@ func writeManifestsSummary(opts cmdlineOptions, resources []client.Object) (err 
 	}
 
 	if _, err := tmpFile.Write(data); err != nil {
-		tmpFile.Close()
-		os.Remove(tmpFile.Name())
-		return fmt.Errorf("error writing manifests summary to temp file: %w", err)
+		return errors.Join(
+			fmt.Errorf("error writing manifests summary to temp file: %w", err),
+			tmpFile.Close(),
+			os.Remove(tmpFile.Name()),
+		)
 	}
 
 	if err := tmpFile.Close(); err != nil {
-		os.Remove(tmpFile.Name())
-		return fmt.Errorf("error closing temp file: %w", err)
+		return errors.Join(
+			fmt.Errorf("error closing temp file: %w", err),
+			os.Remove(tmpFile.Name()),
+		)
 	}
 
 	if err := os.Rename(tmpFile.Name(), opts.manifestsSummaryFile); err != nil {
-		os.Remove(tmpFile.Name())
-		return fmt.Errorf("error renaming temp file to %s: %w", opts.manifestsSummaryFile, err)
+		return errors.Join(
+			fmt.Errorf("error renaming temp file to %s: %w", opts.manifestsSummaryFile, err),
+			os.Remove(tmpFile.Name()),
+		)
 	}
 
 	return nil

--- a/manifests-gen/generate.go
+++ b/manifests-gen/generate.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"path/filepath"
 	"sort"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -26,6 +25,8 @@ const (
 
 	// metadataFilename is the name of the file containing provider metadata.
 	metadataFilename = "metadata.yaml"
+
+	manifestsSummaryFilename = "manifests-summary.yaml"
 
 	// capiNamespace is the namespace where capi components are created.
 	capiNamespace = "openshift-cluster-api"
@@ -154,16 +155,18 @@ type ManifestMetadata struct {
 	Namespace  string `json:"namespace,omitempty"`
 }
 
-type ManifestsSummary map[string][]ManifestMetadata
+type ManifestsSummary []ManifestMetadata
 
 func writeManifestsSummary(opts cmdlineOptions, resources []client.Object) error {
-	if opts.manifestsSummaryFile == "" {
+	if !opts.manifestsSummary {
 		return nil
 	}
 
-	var manifests []ManifestMetadata
+	manifestsSummaryPathname := path.Join(opts.manifestsPath, opts.profileName, manifestsSummaryFilename)
+
+	var summary ManifestsSummary
 	for _, resource := range resources {
-		manifests = append(manifests, ManifestMetadata{
+		summary = append(summary, ManifestMetadata{
 			Kind:       resource.GetObjectKind().GroupVersionKind().Kind,
 			APIVersion: resource.GetObjectKind().GroupVersionKind().GroupVersion().String(),
 			Name:       resource.GetName(),
@@ -171,63 +174,27 @@ func writeManifestsSummary(opts cmdlineOptions, resources []client.Object) error
 		})
 	}
 
-	sort.Slice(manifests, func(i, j int) bool {
-		if manifests[i].Kind != manifests[j].Kind {
-			return manifests[i].Kind < manifests[j].Kind
+	sort.Slice(summary, func(i, j int) bool {
+		if summary[i].Kind != summary[j].Kind {
+			return summary[i].Kind < summary[j].Kind
 		}
-		if manifests[i].APIVersion != manifests[j].APIVersion {
-			return manifests[i].APIVersion < manifests[j].APIVersion
+		if summary[i].APIVersion != summary[j].APIVersion {
+			return summary[i].APIVersion < summary[j].APIVersion
 		}
-		if manifests[i].Namespace != manifests[j].Namespace {
-			return manifests[i].Namespace < manifests[j].Namespace
+		if summary[i].Namespace != summary[j].Namespace {
+			return summary[i].Namespace < summary[j].Namespace
 		}
 
-		return manifests[i].Name < manifests[j].Name
+		return summary[i].Name < summary[j].Name
 	})
-
-	var summary ManifestsSummary
-	if data, err := os.ReadFile(opts.manifestsSummaryFile); err == nil {
-		if err := yaml.Unmarshal(data, &summary); err != nil {
-			return fmt.Errorf("failed to unmarshal existing summary: %w", err)
-		}
-	} else if errors.Is(err, os.ErrNotExist) {
-		summary = make(ManifestsSummary)
-	} else {
-		return fmt.Errorf("error reading manifests summary file %s: %w", opts.manifestsSummaryFile, err)
-	}
-
-	summary[opts.profileName] = manifests
 
 	data, err := yaml.Marshal(summary)
 	if err != nil {
 		return fmt.Errorf("failed to marshal: %w", err)
 	}
 
-	tmpFile, err := os.CreateTemp(filepath.Dir(opts.manifestsSummaryFile), ".manifests-summary-*.yaml")
-	if err != nil {
-		return fmt.Errorf("error creating temp file for manifests summary: %w", err)
-	}
-
-	if _, err := tmpFile.Write(data); err != nil {
-		return errors.Join(
-			fmt.Errorf("error writing manifests summary to temp file: %w", err),
-			tmpFile.Close(),
-			os.Remove(tmpFile.Name()),
-		)
-	}
-
-	if err := tmpFile.Close(); err != nil {
-		return errors.Join(
-			fmt.Errorf("error closing temp file: %w", err),
-			os.Remove(tmpFile.Name()),
-		)
-	}
-
-	if err := os.Rename(tmpFile.Name(), opts.manifestsSummaryFile); err != nil {
-		return errors.Join(
-			fmt.Errorf("error renaming temp file to %s: %w", opts.manifestsSummaryFile, err),
-			os.Remove(tmpFile.Name()),
-		)
+	if err := os.WriteFile(manifestsSummaryPathname, data, 0600); err != nil {
+		return fmt.Errorf("failed to write manifests summary: %w", err)
 	}
 
 	return nil

--- a/manifests-gen/main.go
+++ b/manifests-gen/main.go
@@ -48,6 +48,7 @@ func init() {
 
 type cmdlineOptions struct {
 	manifestsPath          string
+	manifestsSummaryFile   string
 	profileName            string
 	kustomizeDir           string
 	name                   string
@@ -78,9 +79,10 @@ func (a attributeFlags) Set(value string) error {
 
 func main() {
 	var (
-		manifestsPath = flag.String("manifests-path", "", "Path to the desired directory where to output the generated manifests. Required.")
-		profileName   = flag.String("profile-name", "default", "Name of the profile, e.g 'featuregate-foo' (default: 'default'.'")
-		kustomizeDir  = flag.String("kustomize-dir", "", "Directory containing kustomization.yaml file used to generate the base resources, relative to the current working directory. Required.")
+		manifestsPath        = flag.String("manifests-path", "", "Path to the desired directory where to output the generated manifests. Required.")
+		profileName          = flag.String("profile-name", "default", "Name of the profile, e.g 'featuregate-foo' (default: 'default'.'")
+		kustomizeDir         = flag.String("kustomize-dir", "", "Directory containing kustomization.yaml file used to generate the base resources, relative to the current working directory. Required.")
+		manifestsSummaryFile = flag.String("manifests-summary-file", "", "Path to output the summary YAML file")
 
 		name = flag.String("name", "", "Name of the provider, e.g. 'cluster-api-provider-aws'. Required.")
 
@@ -97,6 +99,7 @@ func main() {
 
 	opts := cmdlineOptions{
 		manifestsPath:          *manifestsPath,
+		manifestsSummaryFile:   *manifestsSummaryFile,
 		profileName:            *profileName,
 		kustomizeDir:           *kustomizeDir,
 		name:                   *name,

--- a/manifests-gen/main.go
+++ b/manifests-gen/main.go
@@ -48,7 +48,7 @@ func init() {
 
 type cmdlineOptions struct {
 	manifestsPath          string
-	manifestsSummaryFile   string
+	manifestsSummary       bool
 	profileName            string
 	kustomizeDir           string
 	name                   string
@@ -79,10 +79,10 @@ func (a attributeFlags) Set(value string) error {
 
 func main() {
 	var (
-		manifestsPath        = flag.String("manifests-path", "", "Path to the desired directory where to output the generated manifests. Required.")
-		profileName          = flag.String("profile-name", "default", "Name of the profile, e.g 'featuregate-foo' (default: 'default'.'")
-		kustomizeDir         = flag.String("kustomize-dir", "", "Directory containing kustomization.yaml file used to generate the base resources, relative to the current working directory. Required.")
-		manifestsSummaryFile = flag.String("manifests-summary-file", "", "Path to output the summary YAML file")
+		manifestsPath    = flag.String("manifests-path", "", "Path to the desired directory where to output the generated manifests. Required.")
+		profileName      = flag.String("profile-name", "default", "Name of the profile, e.g 'featuregate-foo' (default: 'default'.'")
+		kustomizeDir     = flag.String("kustomize-dir", "", "Directory containing kustomization.yaml file used to generate the base resources, relative to the current working directory. Required.")
+		manifestsSummary = flag.Bool("manifests-summary", false, "If set, output the manifests summary YAML file")
 
 		name = flag.String("name", "", "Name of the provider, e.g. 'cluster-api-provider-aws'. Required.")
 
@@ -99,7 +99,7 @@ func main() {
 
 	opts := cmdlineOptions{
 		manifestsPath:          *manifestsPath,
-		manifestsSummaryFile:   *manifestsSummaryFile,
+		manifestsSummary:       *manifestsSummary,
 		profileName:            *profileName,
 		kustomizeDir:           *kustomizeDir,
 		name:                   *name,


### PR DESCRIPTION
Required by https://github.com/openshift/cluster-api-provider-aws/pull/616

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional manifest summary generation during manifest creation.
  - Summaries include each resource’s kind, API version, name, and namespace.
  - Added a command-line option to specify the summary output file.
  - Existing summaries are preserved and updated by profile.

- **Improvements**
  - Summary entries are sorted deterministically for consistent output.
  - Improved handling of missing, invalid, or unavailable summary files.
  - Summary updates are applied safely to prevent incomplete output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->