### PR TITLE
OCPBUGS-104496: aws: use capa-controller-manager as service account

### DIFF
--- a/manifests/0000_30_cluster-api_01_credentials-request.yaml
+++ b/manifests/0000_30_cluster-api_01_credentials-request.yaml
@@ -10,7 +10,7 @@ metadata:
     release.openshift.io/feature-gate: "ClusterAPIMachineManagement,ClusterAPIMachineManagementAWS"
 spec:
   serviceAccountNames:
-    - capi-controllers
+    - capa-controller-manager
   secretRef:
     name: capa-manager-bootstrap-credentials
     namespace: openshift-cluster-api


### PR DESCRIPTION
## Description

The service account for cluster-api-provider-aws (CAPA) is `capa-controller-manager` instead of `capi-controllers`.

The service account is used to construct the condition for IAM role trust policy. A mismatch will reject the pod's request to assume IAM role via AssumeRoleWithWebIdentity.

For reference, see CAPA openshift manifest: https://github.com/openshift/cluster-api-provider-aws/blob/1f5b17cc6969d6013a1abc5c6c62f00add809ceb/openshift/capi-operator-manifests/default/manifests.yaml#L201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated AWS credential access to use the correct controller, improving cluster provisioning reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->