### PR TITLE
NO-JIRA: Fix flaky CI unit tests: reduce parallelism

### DIFF
--- a/hack/test.sh
+++ b/hack/test.sh
@@ -20,7 +20,13 @@ ARTIFACT_DIR=${ARTIFACT_DIR:-""}
 GINKGO=${GINKGO:-"go run -mod=vendor ${REPO_ROOT}/vendor/github.com/onsi/ginkgo/v2/ginkgo"}
 PARALLEL_FLAG="-p"
 if [ "${OPENSHIFT_CI:-}" == "true" ]; then
-  PARALLEL_FLAG="--procs=4"
+  if [[ "${TEST_DIRS}" == *"e2e"* ]]; then
+    PARALLEL_FLAG="--procs=4"
+  else
+    # Limit parallelism: each Ginkgo process starts its own envtest
+    # control plane, and higher values cause timeout failures in CI.
+    PARALLEL_FLAG="--procs=2"
+  fi
 fi
 GINKGO_ARGS=${GINKGO_ARGS:-"-r -v ${PARALLEL_FLAG} --randomize-all --randomize-suites --keep-going --race --trace --timeout=${TIMEOUT}"}
 GINKGO_EXTRA_ARGS=${GINKGO_EXTRA_ARGS:-""}

--- a/pkg/controllers/machinesetsync/suite_test.go
+++ b/pkg/controllers/machinesetsync/suite_test.go
@@ -43,7 +43,7 @@ import (
 )
 
 const (
-	timeout              = 2 * time.Second
+	timeout              = 5 * time.Second
 	longerTimeout        = 10 * time.Second
 	setupTimeout         = 1 * time.Minute
 	consecutiveFailLimit = 8


### PR DESCRIPTION
## Summary

Unit tests have been frequently failing in CI due to envtest resource contention. Analysis of 19 recent failed builds (across PRs #577, #591, #622, #627, #634, #635, #636, #637, #638, #640, #642) shows the root cause: `--procs=4` runs 4 test suites simultaneously, each starting its own etcd + kube-apiserver (8 heavy processes total), causing widespread timeouts on resource-constrained CI nodes.

This PR:
- Reduces CI parallelism from `--procs=4` to `--procs=2`, halving resource contention
- Increases the machinesetsync `Eventually` timeout from 2s to 5s (the most frequently failing suite: 22 of 57 failures)

### Why not just increase timeouts?

We tested both approaches on CI:

| Approach | Runs | Pass rate | Test step time |
|----------|------|-----------|----------------|
| `procs=2` + machinesetsync 5s | 2 | 2/2 | 11.9-15.3m |
| `procs=4` + all timeout increases | 3 | 3/3 | 9.1-11.9m |
| Baseline `procs=4` (no changes) | 28 | ~64% | 9.5-20.6m |

We chose `procs=2` because it addresses the root cause (resource contention) rather than masking symptoms with larger timeouts, and is more robust against future test additions. The wall-clock cost (~3-5 min) is small compared to the cost of frequent CI retries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Increased the default test wait timeout from 2 to 5 seconds.
  * Updated OpenShift CI test execution to use four parallel processes for end-to-end tests and two for other test suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->