### PR TITLE
OCPBUGS-105850: skip Cluster API Machine Management tests on External topology

### DIFF
--- a/e2e/cluster_api_machine_management.go
+++ b/e2e/cluster_api_machine_management.go
@@ -31,8 +31,11 @@ import (
 	"github.com/openshift/cluster-capi-operator/pkg/test"
 )
 
-var _ = Describe("[sig-cluster-lifecycle][OCPFeatureGate:ClusterAPIMachineManagement] Cluster API Machine Management", func() {
+var _ = Describe("[sig-cluster-lifecycle][OCPFeatureGate:ClusterAPIMachineManagement] Cluster API Machine Management", Label("skip-topology:External"), func() {
 	BeforeEach(func() {
+		if infra.Status.ControlPlaneTopology == configv1.ExternalTopologyMode {
+			Skip("Cluster API Machine Management tests are not supported on External topology clusters.")
+		}
 		if !framework.IsFeatureGateEnabled(ctx, cl, features.FeatureGateClusterAPIMachineManagement) {
 			Skip("Feature gate ClusterAPIMachineManagement is not enabled.")
 		}

--- a/e2e/cluster_api_machine_management_aws.go
+++ b/e2e/cluster_api_machine_management_aws.go
@@ -31,8 +31,12 @@ import (
 
 var _ = Describe("[sig-cluster-lifecycle][OCPFeatureGate:ClusterAPIMachineManagementAWS] Cluster API Machine Management AWS",
 	Label("platform:aws"),
+	Label("skip-topology:External"),
 	func() {
 		BeforeEach(func() {
+			if infra.Status.ControlPlaneTopology == configv1.ExternalTopologyMode {
+				Skip("Cluster API Machine Management AWS tests are not supported on External topology clusters.")
+			}
 			if platform != configv1.AWSPlatformType {
 				Skip("Skipping AWS-specific tests on non-AWS platform.")
 			}


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-105850

Add `skip-topology:External` label and runtime checks to prevent `ClusterAPIMachineManagement` and `ClusterAPIMachineManagementAWS` e2e tests from running on HyperShift (External topology) clusters.

CAPI components are not deployed on HyperShift hosted clusters by design — they run on the management cluster — so these tests time out waiting for resources that will never appear.

The fix uses two mechanisms:
- `Label("skip-topology:External")` — processed by OTE to generate CEL exclude rule, preventing test selection via openshift-tests
- Runtime `Skip()` in `BeforeEach` — catches direct ginkgo/make e2e runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated machine-management end-to-end tests to identify external control-plane topologies.
  * Tests now skip unsupported external-topology environments before evaluating platform and feature prerequisites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->