### PR TITLE
OCPCLOUD-3318: Integrate CompatibilityRequirements into the CCAPIO Insaller

### DIFF
--- a/.claude/skills/test-standards/SKILL.md
+++ b/.claude/skills/test-standards/SKILL.md
@@ -115,7 +115,62 @@ time.Sleep(5 * time.Second)
 Expect(machine.Status.Phase).To(Equal("Running"))
 ```
 
+## Ginkgo/Gomega patterns
+
+Use built-in features over custom implementations:
+- Use `DescribeTable` with `Entry` for table-driven tests instead of manual loops
+- Use `HaveField`, `HaveValue`, `HaveKey` for struct/map assertions instead of manual field checks
+- Use `ConsistOf` for unordered slice matching instead of sorting + `Equal`
+- Use `BeNumerically` for numeric comparisons instead of manual range checks
+
+### Async assertions with Komega
+
+Use Komega for Kubernetes object assertions:
+```go
+Eventually(k.Object(myResource)).Should(HaveField("ObjectMeta.ResourceVersion", Equal(expectedRV)))
+
+Eventually(k.UpdateStatus(myResource, func() {
+    myResource.Status.SomeField = "value"
+})).Should(Succeed())
+```
+
+### Resource management
+
+Use testutils resource builders for creating test objects:
+```go
+mapiMachine = mapiMachineBuilder.
+    WithNamespace(namespace).
+    WithName("foo").
+    WithAuthoritativeAPI(machinev1beta1.MachineAuthorityMachineAPI).
+    Build()
+```
+
+Standard cleanup in AfterEach:
+```go
+testutils.CleanupResources(Default, ctx, cfg, k8sClient, namespace,
+    &machinev1beta1.Machine{},
+    &clusterv1.Machine{},
+)
+```
+
+### Complex assertions
+
+Combine matchers with `SatisfyAll`:
+```go
+Eventually(komega.Object(resource)).Should(SatisfyAll(
+    HaveField("Status.AuthoritativeAPI", Equal(expected)),
+    HaveField("Status.SynchronizedGeneration", BeZero()),
+))
+```
+
+Nested field checks:
+```go
+HaveField("Status.Conditions", ContainElement(SatisfyAll(
+    HaveField("Type", Equal("Paused")),
+    HaveField("Status", Equal(corev1.ConditionTrue)),
+)))
+```
+
 ## General
 
-- Follow patterns from CLAUDE.md (Komega, DescribeTable, resource builders, testutils cleanup).
 - Remove `FIt`/`FContext` before committing.

--- a/manifests/0000_30_cluster-api-operator_03_capi-installer-clusterrole.yaml
+++ b/manifests/0000_30_cluster-api-operator_03_capi-installer-clusterrole.yaml
@@ -72,6 +72,19 @@ rules:
   - update
   - patch
   - delete
+# boxcutter: manages CompatibilityRequirements for unmanaged CRDs
+- apiGroups:
+  - apiextensions.openshift.io
+  resources:
+  - compatibilityrequirements
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
 # boxcutter: manages admission resources from provider manifests
 - apiGroups:
   - admissionregistration.k8s.io

--- a/pkg/controllers/installer/boxcutter.go
+++ b/pkg/controllers/installer/boxcutter.go
@@ -17,8 +17,11 @@ limitations under the License.
 package installer
 
 import (
+	"fmt"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"pkg.package-operator.run/boxcutter"
 	"pkg.package-operator.run/boxcutter/probing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -38,7 +41,11 @@ import (
 // all processing required only at installation time. Ideally InstallerRevision
 // will contain only parsed versions of exactly what was in provider manifests
 // without any further processing. That processing should be done here.
-func toBoxcutterRevision(installerRevision revisiongenerator.InstallerRevision, collectObjects func(obj *unstructured.Unstructured)) boxcutter.Revision {
+func toBoxcutterRevision(
+	installerRevision revisiongenerator.InstallerRevision,
+	collectObjects func(obj *unstructured.Unstructured),
+	unmanagedCRDs []string,
+) (boxcutter.Revision, error) {
 	probeOpts := util.SliceMap(allProbes(), func(p *probing.GroupKindSelector) boxcutter.PhaseReconcileOption {
 		return boxcutter.WithProbe(boxcutter.ProgressProbeType, p)
 	})
@@ -57,14 +64,47 @@ func toBoxcutterRevision(installerRevision revisiongenerator.InstallerRevision, 
 		phases = append(phases, bcPhase)
 	}
 
+	unmanagedSet := sets.New(unmanagedCRDs...)
+	var compatObjects []*unstructured.Unstructured
+
 	for _, component := range installerRevision.Components() {
-		var crds, objects []*unstructured.Unstructured
+		// Step 1: Transform — replace unmanaged CRDs with CompatibilityRequirements.
+		// Future transformations (proxy env vars, etc.) chain here before the split.
+		var transformed []*unstructured.Unstructured
 
 		for _, obj := range component.Objects() {
 			collectObjects(obj)
 
-			gvk := obj.GetObjectKind().GroupVersionKind()
-			if gvk.GroupKind() == (schema.GroupKind{Group: "apiextensions.k8s.io", Kind: "CustomResourceDefinition"}) {
+			if isCRD(obj) && unmanagedSet.Has(obj.GetName()) {
+				unmanagedSet.Delete(obj.GetName())
+
+				cr, err := buildCompatibilityRequirement(obj)
+				if err != nil {
+					return nil, fmt.Errorf("building CompatibilityRequirement for CRD %s: %w", obj.GetName(), err)
+				}
+
+				labels := cr.GetLabels()
+				if labels == nil {
+					labels = make(map[string]string)
+				}
+
+				labels[revisiongenerator.ManagedLabelKey] = "compatibility-requirements"
+				cr.SetLabels(labels)
+
+				collectObjects(cr)
+				compatObjects = append(compatObjects, cr)
+
+				// Unmanaged CRD intentionally dropped — not installed, only checked for compatibility.
+				continue
+			}
+
+			transformed = append(transformed, obj)
+		}
+
+		// Step 2: Split transformed objects into CRDs and non-CRDs, build phases.
+		var crds, objects []*unstructured.Unstructured
+		for _, obj := range transformed {
+			if isCRD(obj) {
 				crds = append(crds, obj)
 			} else {
 				objects = append(objects, obj)
@@ -75,11 +115,26 @@ func toBoxcutterRevision(installerRevision revisiongenerator.InstallerRevision, 
 		addPhase(component.Name(), objects)
 	}
 
+	if unmanagedSet.Len() > 0 {
+		return nil, fmt.Errorf("unmanaged CRDs not found in any component: %v", sets.List(unmanagedSet))
+	}
+
+	// Prepend compatibility phase before all component phases.
+	if len(compatObjects) > 0 {
+		compatPhase := boxcutter.NewPhase("compatibility-requirements", util.SliceMap(compatObjects, toClientObject)).
+			WithReconcileOptions(probeOpts...)
+		phases = append([]boxcutter.Phase{compatPhase}, phases...)
+	}
+
 	return boxcutter.NewRevision(
 		string(installerRevision.RevisionName()),
 		installerRevision.RevisionIndex(),
 		phases,
-	)
+	), nil
+}
+
+func isCRD(obj *unstructured.Unstructured) bool {
+	return obj.GetObjectKind().GroupVersionKind().GroupKind() == schema.GroupKind{Group: "apiextensions.k8s.io", Kind: "CustomResourceDefinition"}
 }
 
 // processAdoptExistingAnnotations processes the adopt-existing annotation on

--- a/pkg/controllers/installer/boxcutter_test.go
+++ b/pkg/controllers/installer/boxcutter_test.go
@@ -33,6 +33,16 @@ import (
 // don't care about collected objects.
 func noopCollector(*unstructured.Unstructured) {}
 
+// mustBoxcutterRevision calls toBoxcutterRevision and fails the test on error.
+func mustBoxcutterRevision(rev revisiongenerator.InstallerRevision, collect func(*unstructured.Unstructured), unmanagedCRDs []string) boxcutter.Revision {
+	GinkgoHelper()
+
+	bcRev, err := toBoxcutterRevision(rev, collect, unmanagedCRDs)
+	Expect(err).NotTo(HaveOccurred())
+
+	return bcRev
+}
+
 // objectRef returns a stable identifier for an object, for asserting object
 // identity without depending on object ordering.
 func objectRef(kind, name string) string {
@@ -84,7 +94,7 @@ var _ = Describe("toBoxcutterRevision", func() {
 		It("should return a Revision with the name of the InstallerRevision", func() {
 			rev := installerRevisionFromProfiles(providerCore)
 
-			bcRev := toBoxcutterRevision(rev, noopCollector)
+			bcRev := mustBoxcutterRevision(rev, noopCollector, nil)
 
 			Expect(bcRev.GetName()).To(Equal(string(rev.RevisionName())),
 				"returned Revision should carry the same name as the InstallerRevision")
@@ -96,7 +106,7 @@ var _ = Describe("toBoxcutterRevision", func() {
 			func(providerName string, wantPhaseCount int) {
 				rev := installerRevisionFromProfiles(providerName)
 
-				bcRev := toBoxcutterRevision(rev, noopCollector)
+				bcRev := mustBoxcutterRevision(rev, noopCollector, nil)
 
 				first := bcRev.GetPhases()
 				second := bcRev.GetPhases()
@@ -122,7 +132,7 @@ var _ = Describe("toBoxcutterRevision", func() {
 		It("splits a component with CRDs and objects into a '-crds' phase and an objects phase", func() {
 			rev := installerRevisionFromProfiles(providerMixed)
 
-			phases := toBoxcutterRevision(rev, noopCollector).GetPhases()
+			phases := mustBoxcutterRevision(rev, noopCollector, nil).GetPhases()
 			Expect(phases).To(HaveLen(2))
 
 			crdPhase := findPhase(phases, providerMixed+"-crds")
@@ -137,7 +147,7 @@ var _ = Describe("toBoxcutterRevision", func() {
 		It("does not create a '-crds' phase for a component with no CRDs", func() {
 			rev := installerRevisionFromProfiles(providerCore)
 
-			phases := toBoxcutterRevision(rev, noopCollector).GetPhases()
+			phases := mustBoxcutterRevision(rev, noopCollector, nil).GetPhases()
 			Expect(phases).To(HaveLen(1))
 			Expect(phases[0].GetName()).To(Equal(providerCore))
 			Expect(objectKinds(phases[0].GetObjects())).To(ConsistOf("ConfigMap"))
@@ -146,7 +156,7 @@ var _ = Describe("toBoxcutterRevision", func() {
 		It("does not create a plain objects phase for a component with only CRDs", func() {
 			rev := installerRevisionFromProfiles(providerCRD)
 
-			phases := toBoxcutterRevision(rev, noopCollector).GetPhases()
+			phases := mustBoxcutterRevision(rev, noopCollector, nil).GetPhases()
 			Expect(phases).To(HaveLen(1))
 			Expect(phases[0].GetName()).To(Equal(providerCRD + "-crds"))
 			Expect(objectKinds(phases[0].GetObjects())).To(ConsistOf("CustomResourceDefinition"))
@@ -163,9 +173,10 @@ var _ = Describe("toBoxcutterRevision", func() {
 
 				var collectedRefs []string
 
-				toBoxcutterRevision(rev, func(obj *unstructured.Unstructured) {
+				_, err := toBoxcutterRevision(rev, func(obj *unstructured.Unstructured) {
 					collectedRefs = append(collectedRefs, objectRef(obj.GetKind(), obj.GetName()))
-				})
+				}, nil)
+				Expect(err).NotTo(HaveOccurred())
 
 				Expect(collectedRefs).To(ConsistOf(wantRefs),
 					"collectObjects should be called exactly once for every object that ends up in a phase")
@@ -191,5 +202,68 @@ var _ = Describe("toBoxcutterRevision", func() {
 				},
 				providerCore, providerMixed, providerCRD),
 		)
+	})
+
+	Describe("unmanaged CRDs", func() {
+		testWidgetCRDName := fmt.Sprintf("testwidgets.%s", testCRDGVK.Group)
+		testGadgetCRDName := fmt.Sprintf("testgadgets.%s", mixedCRDGVK.Group)
+
+		It("should produce a compatibility phase as the first phase", func() {
+			rev := installerRevisionFromProfiles(providerCRD)
+			bcRev := mustBoxcutterRevision(rev, noopCollector, []string{testWidgetCRDName})
+
+			phases := bcRev.GetPhases()
+			Expect(phases).To(HaveLen(1))
+			Expect(phases[0].GetName()).To(Equal("compatibility-requirements"))
+			Expect(phases[0].GetObjects()).To(HaveLen(1))
+			Expect(phases[0].GetObjects()[0].GetName()).To(Equal("ccapio-" + testWidgetCRDName))
+		})
+
+		It("should filter the unmanaged CRD from the component CRD phase", func() {
+			rev := installerRevisionFromProfiles(providerMixed)
+			bcRev := mustBoxcutterRevision(rev, noopCollector, []string{testGadgetCRDName})
+
+			phases := bcRev.GetPhases()
+			// compatibility-requirements + mixed (ConfigMap only, no CRD phase since CRD was unmanaged)
+			Expect(phases).To(HaveLen(2))
+			Expect(phases[0].GetName()).To(Equal("compatibility-requirements"))
+			Expect(phases[1].GetName()).To(Equal(providerMixed))
+			Expect(objectKinds(phases[1].GetObjects())).To(ConsistOf("ConfigMap"))
+		})
+
+		It("should collect multiple unmanaged CRDs from different components into a single compatibility phase", func() {
+			rev := installerRevisionFromProfiles(providerCRD, providerMixed)
+			bcRev := mustBoxcutterRevision(rev, noopCollector, []string{testWidgetCRDName, testGadgetCRDName})
+
+			phases := bcRev.GetPhases()
+			compatPhase := findPhase(phases, "compatibility-requirements")
+			Expect(compatPhase.GetObjects()).To(HaveLen(2))
+		})
+
+		It("should return an error when an unmanaged CRD is not found in any component", func() {
+			rev := installerRevisionFromProfiles(providerCore)
+			_, err := toBoxcutterRevision(rev, noopCollector, []string{"nonexistent.example.com"})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not found"))
+		})
+
+		It("should set the managed label on CompatibilityRequirement objects", func() {
+			rev := installerRevisionFromProfiles(providerCRD)
+			bcRev := mustBoxcutterRevision(rev, noopCollector, []string{testWidgetCRDName})
+
+			crObj := bcRev.GetPhases()[0].GetObjects()[0]
+			Expect(crObj.GetLabels()).To(HaveKeyWithValue(revisiongenerator.ManagedLabelKey, "compatibility-requirements"))
+		})
+
+		It("should call collectObjects for CompatibilityRequirement objects", func() {
+			rev := installerRevisionFromProfiles(providerCRD)
+
+			var collectedRefs []string
+			mustBoxcutterRevision(rev, func(obj *unstructured.Unstructured) {
+				collectedRefs = append(collectedRefs, objectRef(obj.GetKind(), obj.GetName()))
+			}, []string{testWidgetCRDName})
+
+			Expect(collectedRefs).To(ContainElement(objectRef("CompatibilityRequirement", "ccapio-"+testWidgetCRDName)))
+		})
 	})
 })

--- a/pkg/controllers/installer/compatibility.go
+++ b/pkg/controllers/installer/compatibility.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package installer
+
+import (
+	"fmt"
+
+	apiextensionsv1alpha1 "github.com/openshift/api/apiextensions/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8syaml "sigs.k8s.io/yaml"
+)
+
+const (
+	compatibilityRequirementNamePrefix = "ccapio-"
+	capiNamespace                      = "openshift-cluster-api"
+)
+
+// buildCompatibilityRequirement constructs a CompatibilityRequirement for the
+// given CRD and returns it as an unstructured object for inclusion in the
+// compatibility phase.
+func buildCompatibilityRequirement(crd *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	crdYAML, err := k8syaml.Marshal(crd.Object)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling CRD %s to YAML: %w", crd.GetName(), err)
+	}
+
+	cr := &apiextensionsv1alpha1.CompatibilityRequirement{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: apiextensionsv1alpha1.GroupVersion.String(),
+			Kind:       "CompatibilityRequirement",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: compatibilityRequirementNamePrefix + crd.GetName(),
+		},
+		Spec: apiextensionsv1alpha1.CompatibilityRequirementSpec{
+			CompatibilitySchema: apiextensionsv1alpha1.CompatibilitySchema{
+				CustomResourceDefinition: apiextensionsv1alpha1.CRDData{
+					Type: apiextensionsv1alpha1.CRDDataTypeYAML,
+					Data: string(crdYAML),
+				},
+				RequiredVersions: apiextensionsv1alpha1.APIVersions{
+					// additionalVersions deferred to a separate PR.
+					// See https://github.com/openshift/cluster-capi-operator/pull/604#discussion_r3657934049
+					DefaultSelection: apiextensionsv1alpha1.APIVersionSetTypeStorageOnly,
+				},
+			},
+			CustomResourceDefinitionSchemaValidation: apiextensionsv1alpha1.CustomResourceDefinitionSchemaValidation{
+				Action: apiextensionsv1alpha1.CRDAdmitActionDeny,
+			},
+			ObjectSchemaValidation: apiextensionsv1alpha1.ObjectSchemaValidation{
+				Action: apiextensionsv1alpha1.CRDAdmitActionDeny,
+				NamespaceSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"kubernetes.io/metadata.name": capiNamespace,
+					},
+				},
+			},
+		},
+	}
+
+	data, err := runtime.DefaultUnstructuredConverter.ToUnstructured(cr)
+	if err != nil {
+		return nil, fmt.Errorf("converting CompatibilityRequirement to unstructured: %w", err)
+	}
+
+	return &unstructured.Unstructured{Object: data}, nil
+}

--- a/pkg/controllers/installer/compatibility_test.go
+++ b/pkg/controllers/installer/compatibility_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package installer
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/openshift/cluster-capi-operator/pkg/test"
+)
+
+func toUnstructuredCRD(crd *apiextensionsv1.CustomResourceDefinition) (*unstructured.Unstructured, error) {
+	crd.SetGroupVersionKind(schema.GroupVersionKind{Group: "apiextensions.k8s.io", Version: "v1", Kind: "CustomResourceDefinition"})
+	data, err := runtime.DefaultUnstructuredConverter.ToUnstructured(crd)
+	if err != nil {
+		return nil, err
+	}
+	return &unstructured.Unstructured{Object: data}, nil
+}
+
+var _ = Describe("buildCompatibilityRequirement", func() {
+	var crd *unstructured.Unstructured
+
+	BeforeEach(func() {
+		typed := test.GenerateSchemalessSpecStatusCRD(testCRDGVK)
+		u, err := toUnstructuredCRD(typed)
+		Expect(err).NotTo(HaveOccurred())
+		crd = u
+	})
+
+	It("should set the name with ccapio- prefix", func() {
+		cr, err := buildCompatibilityRequirement(crd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cr.GetName()).To(Equal("ccapio-" + crd.GetName()))
+	})
+
+	It("should set the correct GVK", func() {
+		cr, err := buildCompatibilityRequirement(crd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cr.GroupVersionKind()).To(Equal(schema.GroupVersionKind{
+			Group:   "apiextensions.openshift.io",
+			Version: "v1alpha1",
+			Kind:    "CompatibilityRequirement",
+		}))
+	})
+
+	It("should embed the CRD YAML in the spec", func() {
+		cr, err := buildCompatibilityRequirement(crd)
+		Expect(err).NotTo(HaveOccurred())
+
+		data, found, err := unstructured.NestedString(cr.Object, "spec", "compatibilitySchema", "customResourceDefinition", "data")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(data).To(ContainSubstring(crd.GetName()))
+	})
+
+	It("should set defaultSelection to StorageOnly", func() {
+		cr, err := buildCompatibilityRequirement(crd)
+		Expect(err).NotTo(HaveOccurred())
+
+		selection, found, err := unstructured.NestedString(cr.Object, "spec", "compatibilitySchema", "requiredVersions", "defaultSelection")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(selection).To(Equal("StorageOnly"))
+	})
+
+	It("should set action to Deny on both validation fields", func() {
+		cr, err := buildCompatibilityRequirement(crd)
+		Expect(err).NotTo(HaveOccurred())
+
+		crdAction, _, _ := unstructured.NestedString(cr.Object, "spec", "customResourceDefinitionSchemaValidation", "action")
+		Expect(crdAction).To(Equal("Deny"))
+
+		objAction, _, _ := unstructured.NestedString(cr.Object, "spec", "objectSchemaValidation", "action")
+		Expect(objAction).To(Equal("Deny"))
+	})
+
+	It("should set the namespace selector to openshift-cluster-api", func() {
+		cr, err := buildCompatibilityRequirement(crd)
+		Expect(err).NotTo(HaveOccurred())
+
+		labels, found, err := unstructured.NestedStringMap(cr.Object, "spec", "objectSchemaValidation", "namespaceSelector", "matchLabels")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(labels).To(HaveKeyWithValue("kubernetes.io/metadata.name", "openshift-cluster-api"))
+	})
+})

--- a/pkg/controllers/installer/helpers_test.go
+++ b/pkg/controllers/installer/helpers_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
+	apiextensionsv1alpha1 "github.com/openshift/api/apiextensions/v1alpha1"
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -442,4 +443,55 @@ func waitForRevision(ctx context.Context, revision operatorv1alpha1.RevisionName
 			test.HaveCondition(conditionTypeProgressing).WithStatus(configv1.ConditionFalse),
 		)
 	})
+}
+
+// setUnmanagedCRDs updates the ClusterAPI spec to set the unmanaged CRD list.
+func setUnmanagedCRDs(ctx context.Context, unmanagedCRDs []string) {
+	GinkgoHelper()
+
+	clusterAPI := &operatorv1alpha1.ClusterAPI{}
+	Expect(cl.Get(ctx, client.ObjectKey{Name: clusterAPIName}, clusterAPI)).To(Succeed())
+
+	if clusterAPI.Spec == nil {
+		clusterAPI.Spec = &operatorv1alpha1.ClusterAPISpec{}
+	}
+
+	clusterAPI.Spec.UnmanagedCustomResourceDefinitions = unmanagedCRDs
+	Expect(cl.Update(ctx, clusterAPI)).To(Succeed())
+}
+
+// setCompatibilityRequirementConditions sets Admitted and Compatible conditions on a CompatibilityRequirement.
+func setCompatibilityRequirementConditions(ctx context.Context, name string, admitted, compatible bool) {
+	GinkgoHelper()
+
+	toStatus := func(b bool) metav1.ConditionStatus {
+		if b {
+			return metav1.ConditionTrue
+		}
+
+		return metav1.ConditionFalse
+	}
+
+	cr := &apiextensionsv1alpha1.CompatibilityRequirement{}
+	cr.SetName(name)
+
+	Eventually(kWithCtx(ctx).UpdateStatus(cr, func() {
+		cr.Status.Conditions = []metav1.Condition{
+			{
+				Type:               apiextensionsv1alpha1.CompatibilityRequirementAdmitted,
+				Status:             toStatus(admitted),
+				LastTransitionTime: metav1.Now(),
+				Reason:             "Test",
+			},
+			{
+				Type:               apiextensionsv1alpha1.CompatibilityRequirementCompatible,
+				Status:             toStatus(compatible),
+				LastTransitionTime: metav1.Now(),
+				Reason:             "Test",
+			},
+		}
+	})).
+		WithContext(ctx).
+		WithTimeout(defaultEventuallyTimeout).
+		Should(Succeed())
 }

--- a/pkg/controllers/installer/installer_controller.go
+++ b/pkg/controllers/installer/installer_controller.go
@@ -222,6 +222,11 @@ func (c *InstallerController) reconcile(ctx context.Context, log logr.Logger) op
 	}
 
 	revisionReconciler := newRevisionReconciler(c, log)
+
+	if clusterAPI.Spec != nil {
+		revisionReconciler.unmanagedCRDs = clusterAPI.Spec.UnmanagedCustomResourceDefinitions
+	}
+
 	reconciledRevision, messages, errs := revisionReconciler.reconcile(ctx, clusterAPI.Status.Revisions)
 
 	// Write relatedObjects via non-SSA merge patch so the SSA conditions

--- a/pkg/controllers/installer/installer_controller_test.go
+++ b/pkg/controllers/installer/installer_controller_test.go
@@ -21,15 +21,18 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	apiextensionsv1alpha1 "github.com/openshift/api/apiextensions/v1alpha1"
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -655,6 +658,140 @@ var _ = Describe("InstallerController", Serial, func() {
 			)
 		}, defaultNodeTimeout)
 	})
+})
+
+var _ = Describe("InstallerController CompatibilityRequirements", Serial, func() {
+	testWidgetCRDName := fmt.Sprintf("testwidgets.%s", testCRDGVK.Group)
+	testGadgetCRDName := fmt.Sprintf("testgadgets.%s", mixedCRDGVK.Group)
+	testWidgetCRName := "ccapio-" + testWidgetCRDName
+	testGadgetCRName := "ccapio-" + testGadgetCRDName
+
+	// Each test uses createFixturesWithUnmanagedCRDs, which deletes and
+	// recreates the ClusterAPI object as needed, because
+	// unmanagedCustomResourceDefinitions cannot be unset once set.
+	createFixturesWithUnmanagedCRDs := func(ctx context.Context, unmanagedCRDs []string) {
+		GinkgoHelper()
+
+		var cleanupObjs []client.Object //nolint:prealloc
+
+		DeferCleanup(func(ctx context.Context) {
+			deleteAndWait(ctx, cleanupObjs...)
+		})
+
+		clusterAPIObj := &operatorv1alpha1.ClusterAPI{
+			ObjectMeta: metav1.ObjectMeta{Name: clusterAPIName},
+			Spec: &operatorv1alpha1.ClusterAPISpec{
+				UnmanagedCustomResourceDefinitions: unmanagedCRDs,
+			},
+		}
+		Expect(cl.Create(ctx, clusterAPIObj)).To(Succeed())
+		cleanupObjs = append(cleanupObjs, clusterAPIObj)
+
+		clusterOperatorObj := &configv1.ClusterOperator{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster-api"},
+		}
+		Expect(cl.Create(ctx, clusterOperatorObj)).To(Succeed())
+		cleanupObjs = append(cleanupObjs, clusterOperatorObj)
+	}
+
+	It("should gate on Admitted and Compatible conditions", func(ctx context.Context) {
+		createFixturesWithUnmanagedCRDs(ctx, []string{testWidgetCRDName})
+		addRevision(ctx, providerCRD)
+
+		By("verifying the controller is waiting on the compatibility phase")
+		waitForConditions(ctx,
+			test.HaveCondition(conditionTypeProgressing).
+				WithStatus(configv1.ConditionTrue).
+				WithReason(operatorstatus.ReasonProgressing).
+				WithMessage(ContainSubstring("waiting on phase compatibility-requirements")),
+		)
+
+		By("verifying the CompatibilityRequirement was created")
+		cr := &apiextensionsv1alpha1.CompatibilityRequirement{}
+		cr.SetName(testWidgetCRName)
+		Eventually(kWithCtx(ctx).Get(cr)).
+			WithContext(ctx).
+			WithTimeout(defaultEventuallyTimeout).
+			Should(Succeed())
+
+		By("setting Admitted and Compatible to True")
+		setCompatibilityRequirementConditions(ctx, testWidgetCRName, true, true)
+
+		By("verifying the revision completes")
+		clusterAPI := &operatorv1alpha1.ClusterAPI{}
+		Expect(cl.Get(ctx, client.ObjectKey{Name: clusterAPIName}, clusterAPI)).To(Succeed())
+		latest := latestRevision(clusterAPI.Status.Revisions)
+		waitForRevision(ctx, latest.Name)
+	}, defaultNodeTimeout)
+
+	It("should stay progressing when conditions are not set", func(ctx context.Context) {
+		createFixturesWithUnmanagedCRDs(ctx, []string{testWidgetCRDName})
+		addRevision(ctx, providerCRD)
+
+		waitForConditions(ctx,
+			test.HaveCondition(conditionTypeProgressing).
+				WithStatus(configv1.ConditionTrue).
+				WithReason(operatorstatus.ReasonProgressing).
+				WithMessage(ContainSubstring("waiting on phase compatibility-requirements")),
+		)
+
+		co := &configv1.ClusterOperator{}
+		co.SetName("cluster-api")
+
+		Consistently(kWithCtx(ctx).Object(co)).
+			WithContext(ctx).
+			WithTimeout(2 * time.Second).
+			Should(HaveField("Status.Conditions",
+				test.HaveCondition(conditionTypeProgressing).WithStatus(configv1.ConditionTrue)))
+	}, defaultNodeTimeout)
+
+	It("should block when one of multiple unmanaged CRDs is incompatible", func(ctx context.Context) {
+		createFixturesWithUnmanagedCRDs(ctx, []string{testWidgetCRDName, testGadgetCRDName})
+		addRevision(ctx, providerCRD, providerMixed)
+
+		waitForConditions(ctx,
+			test.HaveCondition(conditionTypeProgressing).
+				WithStatus(configv1.ConditionTrue).
+				WithMessage(ContainSubstring("compatibility-requirements")),
+		)
+
+		By("setting one Compatible=True and one Compatible=False")
+		setCompatibilityRequirementConditions(ctx, testWidgetCRName, true, true)
+		setCompatibilityRequirementConditions(ctx, testGadgetCRName, true, false)
+
+		co := &configv1.ClusterOperator{}
+		co.SetName("cluster-api")
+
+		Consistently(kWithCtx(ctx).Object(co)).
+			WithContext(ctx).
+			WithTimeout(2 * time.Second).
+			Should(HaveField("Status.Conditions",
+				test.HaveCondition(conditionTypeProgressing).WithStatus(configv1.ConditionTrue)))
+	}, defaultNodeTimeout)
+
+	It("should leave previous revision running while blocked", func(ctx context.Context) {
+		createFixturesWithUnmanagedCRDs(ctx, nil)
+
+		By("installing rev1 normally")
+		addRevisionAndWaitForSuccess(ctx, providerCore)
+		Expect(checkConfigMap(ctx, coreCMName)).To(Succeed())
+
+		By("setting unmanagedCRDs and adding rev2")
+		setUnmanagedCRDs(ctx, []string{testWidgetCRDName})
+		addRevision(ctx, providerCore, providerCRD)
+
+		waitForConditions(ctx,
+			test.HaveCondition(conditionTypeProgressing).
+				WithStatus(configv1.ConditionTrue).
+				WithMessage(ContainSubstring("compatibility-requirements")),
+		)
+
+		By("verifying rev1 objects still exist")
+		cm, err := getConfigMap(ctx, coreCMName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cm.Data).To(HaveKeyWithValue("version", "v1"))
+	}, defaultNodeTimeout)
+
 })
 
 var _ = Describe("InstallerController without ClusterAPI", Serial, func() {

--- a/pkg/controllers/installer/probes.go
+++ b/pkg/controllers/installer/probes.go
@@ -31,6 +31,8 @@ func allProbes() []*probing.GroupKindSelector {
 	return []*probing.GroupKindSelector{
 		crdEstablishedProbe(),
 		deploymentAvailableProbe(),
+		compatibilityRequirementAdmittedProbe(),
+		compatibilityRequirementCompatibleProbe(),
 	}
 }
 
@@ -49,6 +51,22 @@ func deploymentAvailableProbe() *probing.GroupKindSelector {
 	return &probing.GroupKindSelector{
 		GroupKind: schema.GroupKind{Group: "apps", Kind: "Deployment"},
 		Prober:    &probing.ConditionProbe{Type: "Available", Status: "True"},
+	}
+}
+
+// compatibilityRequirementAdmittedProbe checks that a CompatibilityRequirement has the Admitted condition set to True.
+func compatibilityRequirementAdmittedProbe() *probing.GroupKindSelector {
+	return &probing.GroupKindSelector{
+		GroupKind: schema.GroupKind{Group: "apiextensions.openshift.io", Kind: "CompatibilityRequirement"},
+		Prober:    &probing.ConditionProbe{Type: "Admitted", Status: "True"},
+	}
+}
+
+// compatibilityRequirementCompatibleProbe checks that a CompatibilityRequirement has the Compatible condition set to True.
+func compatibilityRequirementCompatibleProbe() *probing.GroupKindSelector {
+	return &probing.GroupKindSelector{
+		GroupKind: schema.GroupKind{Group: "apiextensions.openshift.io", Kind: "CompatibilityRequirement"},
+		Prober:    &probing.ConditionProbe{Type: "Compatible", Status: "True"},
 	}
 }
 

--- a/pkg/controllers/installer/revision_reconciler.go
+++ b/pkg/controllers/installer/revision_reconciler.go
@@ -95,6 +95,7 @@ type collectedObjectRef struct {
 type revisionReconciler struct {
 	*InstallerController
 	log                   logr.Logger
+	unmanagedCRDs         []string
 	gvks                  sets.Set[schema.GroupVersionKind]
 	collectedNonNSObjects sets.Set[collectedObjectRef]       // intermediate storage
 	crdGKResourceMapping  map[schema.GroupKind]string        // CRD GK → resource
@@ -175,7 +176,11 @@ func (r *revisionReconciler) reconcileRevision(ctx context.Context, apiRevision 
 		return false, "", fmt.Errorf("error creating installer revision from API revision %s: %w", apiRevision.Name, reconcile.TerminalError(err))
 	}
 
-	bcRevision := toBoxcutterRevision(revision, r.collectObjects)
+	bcRevision, err := toBoxcutterRevision(revision, r.collectObjects, r.unmanagedCRDs)
+	if err != nil {
+		return false, "", fmt.Errorf("error building boxcutter revision from API revision %s: %w", apiRevision.Name, reconcile.TerminalError(err))
+	}
+
 	phases := bcRevision.GetPhases()
 
 	totalObjects := 0
@@ -340,7 +345,12 @@ func (r *revisionReconciler) teardownRevision(ctx context.Context, apiRevision o
 
 	revisionName := revision.RevisionName()
 
-	bcRevision := toBoxcutterRevision(revision, r.collectObjects)
+	bcRevision, err := toBoxcutterRevision(revision, r.collectObjects, r.unmanagedCRDs)
+	if err != nil {
+		// We can't teardown this revision if we can't build it, so we consider it complete.
+		return true, "", fmt.Errorf("error building boxcutter revision from API revision %s: %w", apiRevision.Name, reconcile.TerminalError(err))
+	}
+
 	phases := bcRevision.GetPhases()
 
 	totalObjects := 0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compatibility checks for selected unmanaged custom resources before installing or updating revisions.
  * Installation now waits for required resources to be admitted and confirmed compatible.
  * Added permissions and lifecycle handling for compatibility requirements.

* **Bug Fixes**
  * Prevents incompatible revisions from replacing the currently active revision.
  * Reports errors when configured unmanaged resources are missing or cannot be converted.

* **Tests**
  * Added coverage for compatibility gating, filtering, failure handling, and successful installation scenarios.

* **Documentation**
  * Added guidance for writing synchronous and asynchronous Kubernetes tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->