### PR TITLE
NO-JIRA: embed transformer YAML so go mod vendor copies it

### DIFF
--- a/manifests-gen/main.go
+++ b/manifests-gen/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"embed"
 	"errors"
 	"flag"
 	"fmt"
@@ -16,6 +17,12 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 )
+
+// Transformer YAML is loaded from disk by provider kustomization overlays.
+// Embedding it makes `go mod vendor` copy those files into consumer repos.
+//
+//go:embed transformers/*.yaml
+var _ embed.FS
 
 var (
 	allowedPlatformTypes = []string{


### PR DESCRIPTION
Provider kustomize overlays load `transformers/*.yaml` from vendored `manifests-gen`. `go mod vendor` omitted that directory because it had no Go files, so rebasebot's `make ocp-manifests` failed looking them up under `tools/vendor`.

`//go:embed transformers/*.yaml` on `package main` makes `go mod vendor` copy the YAML. 