### PR TITLE
OCPBUGS-114018: fix(machinesetsync): ensure spec.template.spec.authoritativeAPI matches spec.authoritativeAPI

### DIFF
--- a/pkg/controllers/machinesetsync/machineset_sync_controller.go
+++ b/pkg/controllers/machinesetsync/machineset_sync_controller.go
@@ -1422,8 +1422,10 @@ func restoreMAPIFields(existingMAPIMachineSet, convertedMAPIMachineSet *mapiv1be
 	convertedMAPIMachineSet.Spec.Template.Labels = util.MergeMaps(existingMAPIMachineSet.Spec.Template.Labels, convertedMAPIMachineSet.Spec.Template.Labels)
 	convertedMAPIMachineSet.Spec.Template.Spec.Labels = util.MergeMaps(existingMAPIMachineSet.Spec.Template.Spec.Labels, convertedMAPIMachineSet.Spec.Template.Spec.Labels)
 	// Restore API authoritativeness, as it gets lost in MAPI->CAPI->MAPI translation.
+	// The template machine authority must match the machineset authority so that any machines
+	// created from the template have the correct authority, consistent with the machineset.
 	convertedMAPIMachineSet.Spec.AuthoritativeAPI = existingMAPIMachineSet.Spec.AuthoritativeAPI
-	convertedMAPIMachineSet.Spec.Template.Spec.AuthoritativeAPI = existingMAPIMachineSet.Spec.Template.Spec.AuthoritativeAPI
+	convertedMAPIMachineSet.Spec.Template.Spec.AuthoritativeAPI = existingMAPIMachineSet.Spec.AuthoritativeAPI
 	// Restore the original MAPI selector as it is immutable.
 	convertedMAPIMachineSet.Spec.Selector = existingMAPIMachineSet.Spec.Selector
 	convertedMAPIMachineSet.OwnerReferences = nil // No CAPI machine set owner references are converted to MAPI machine set.

--- a/pkg/controllers/machinesetsync/machineset_sync_controller_test.go
+++ b/pkg/controllers/machinesetsync/machineset_sync_controller_test.go
@@ -663,6 +663,50 @@ var _ = Describe("With a running MachineSetSync controller", func() {
 			})
 		})
 
+		Context("when spec.authoritativeAPI is ClusterAPI but spec.template.spec.authoritativeAPI defaulted to MachineAPI", func() {
+			// This tests the bug where a stub MAPI MachineSet is created with spec.authoritativeAPI: ClusterAPI
+			// but spec.template.spec.authoritativeAPI is left unset and defaults to MachineAPI.
+			// The CAPI->MAPI sync should correct spec.template.spec.authoritativeAPI to ClusterAPI.
+			BeforeEach(func() {
+				By("Updating spec.authoritativeAPI to ClusterAPI while leaving spec.template.spec.authoritativeAPI as MachineAPI")
+				Eventually(k.Update(mapiMachineSet, func() {
+					mapiMachineSet.Spec.AuthoritativeAPI = mapiv1beta1.MachineAuthorityClusterAPI
+					// spec.template.spec.authoritativeAPI stays as MachineAPI (the API server default),
+					// simulating a stub created with only spec.authoritativeAPI: ClusterAPI set.
+					mapiMachineSet.Spec.Template.Spec.AuthoritativeAPI = mapiv1beta1.MachineAuthorityMachineAPI
+				})).Should(Succeed())
+
+				By("Creating the CAPI infra machine template")
+				Eventually(kCreate(ctx, capaMachineTemplate)).Should(Succeed(), "capa machine template should be able to be created")
+
+				By("Creating the CAPI machine set")
+
+				capiMachineSet = capiMachineSetBuilder.Build()
+				Eventually(kCreate(ctx, capiMachineSet)).Should(Succeed())
+
+				By("Setting the CAPI machine set observed generation to its metadata generation")
+				Eventually(k.UpdateStatus(capiMachineSet, func() {
+					capiMachineSet.Status.ObservedGeneration = capiMachineSet.Generation
+				})).Should(Succeed())
+
+				By("Waiting for the manager's informer cache to observe the CAPI machine set")
+				eventuallyManagerInformerCache(capiMachineSet).Should(
+					HaveField("Status.ObservedGeneration", Equal(capiMachineSet.Generation)),
+				)
+			})
+
+			It("should correct spec.template.spec.authoritativeAPI to ClusterAPI to match spec.authoritativeAPI", func() {
+				Eventually(k.Object(mapiMachineSet), timeout).Should(
+					SatisfyAll(
+						HaveField("Spec.AuthoritativeAPI", Equal(mapiv1beta1.MachineAuthorityClusterAPI)),
+						HaveField("Spec.Template.Spec.AuthoritativeAPI", Equal(mapiv1beta1.MachineAuthorityClusterAPI)),
+					),
+					"MachineSet %s: expected both spec.authoritativeAPI and spec.template.spec.authoritativeAPI to be ClusterAPI after CAPI->MAPI sync",
+					mapiMachineSet.Name,
+				)
+			})
+		})
+
 		Context("when the CAPI machine set exists and the object meta differs", func() {
 			BeforeEach(func() {
 				// We expect a sync, so we require the infra template


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-114018

When a stub MAPI MachineSet is created with `spec.authoritativeAPI: ClusterAPI` but `spec.template.spec.authoritativeAPI` is left unset, the Kubernetes API server defaults the template field to MachineAPI. The CAPI->MAPI sync then preserved this inconsistent MachineAPI value via `restoreMAPIFields`, leaving the machineset in a state where the machineset-level authority (ClusterAPI) contradicted the machine template authority (MachineAPI).

Fixed by deriving `spec.template.spec.authoritativeAPI` from the machineset's own `spec.authoritativeAPI` rather than blindly restoring the existing template value. This is consistent with how the machine sync controller handles individual MAPI machines created from CAPI: it always sets `spec.authoritativeAPI: ClusterAPI` on new MAPI machine mirrors regardless of the template field.

Also added an integration test that explicitly creates the inconsistent initial state (`spec.authoritativeAPI: ClusterAPI`, `spec.template.spec.authoritativeAPI: MachineAPI`) and verifies the sync corrects the template field to ClusterAPI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed synchronization of authority settings so MachineSet templates correctly reflect the MachineSet’s configured API authority.
  * Improved Cluster API to Machine API synchronization when authority values differ between top-level and nested settings.

* **Tests**
  * Added coverage validating authority synchronization for MachineSet templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->