### PR TITLE
OCPBUGS-114670: fix(capi2mapi): normalize empty SSHKeyName to nil for MAPI AWS conversion

### DIFF
--- a/pkg/conversion/capi2mapi/aws.go
+++ b/pkg/conversion/capi2mapi/aws.go
@@ -167,7 +167,7 @@ func (m machineAndAWSMachineAndAWSCluster) toProviderSpec() (*mapiv1beta1.AWSMac
 		},
 		// UserDataSecret - Populated below.
 		// CredentialsSecret - Handled below.
-		KeyName: m.awsMachine.Spec.SSHKeyName,
+		KeyName: convertAWSSSHKeyNameToMAPI(m.awsMachine.Spec.SSHKeyName),
 		// DeviceIndex - OCPCLOUD-2707: Value must always be zero. No other values are valid in MAPA even though the value is configurable.
 		PublicIP:             m.awsMachine.Spec.PublicIP,
 		SecurityGroups:       convertAWSSecurityGroupstoMAPI(m.awsMachine.Spec.AdditionalSecurityGroups), // This is the way we want to convert security groups, as the AdditionalSecurity Groups are what gets added to MAPI SGs.
@@ -891,6 +891,18 @@ func ConvertAWSLoadBalancerToMAPI(loadBalancer *awsv1.AWSLoadBalancerSpec) (mapi
 	default:
 		return mapiv1beta1.LoadBalancerReference{}, errUnsupportedLoadBalancerType
 	}
+}
+
+// convertAWSSSHKeyNameToMAPI normalizes CAPI's tri-state SSHKeyName for MAPI.
+// CAPI: nil=cluster default, ptr("")=no key, ptr("name")=named key.
+// MAPI has no tri-state: any non-nil KeyName including "" is passed to AWS RunInstances and rejected.
+// ptr("") is normalized to nil so MAPI omits the field, matching the "no SSH key" intent.
+func convertAWSSSHKeyNameToMAPI(sshKeyName *string) *string {
+	if sshKeyName != nil && *sshKeyName == "" {
+		return nil
+	}
+
+	return sshKeyName
 }
 
 // ConvertAWSCPUOptionsToMAPI converts CAPI CPUOptions to MAPI CPUOptions.

--- a/pkg/conversion/capi2mapi/machine_test.go
+++ b/pkg/conversion/capi2mapi/machine_test.go
@@ -171,3 +171,12 @@ var _ = Describe("capi2mapi Machine Status Conversion", func() {
 		})
 	})
 })
+
+var _ = DescribeTable("convertAWSSSHKeyNameToMAPI",
+	func(input *string, expected *string) {
+		Expect(convertAWSSSHKeyNameToMAPI(input)).To(Equal(expected), "input: %v", input)
+	},
+	Entry("should return nil when input is nil", nil, nil),
+	Entry("should return nil when input is empty string", ptr.To(""), nil),
+	Entry("should return the key name when input is non-empty", ptr.To("my-key"), ptr.To("my-key")),
+)

--- a/pkg/conversion/mapi2capi/aws_fuzz_test.go
+++ b/pkg/conversion/mapi2capi/aws_fuzz_test.go
@@ -167,6 +167,13 @@ func (f *awsProviderFuzzer) fuzzProviderConfig(ps *mapiv1beta1.AWSMachineProvide
 		ps.PlacementGroupPartition = nil
 	}
 
+	// ptr("") is normalized to nil during CAPI→MAPI conversion because MAPI passes
+	// KeyName directly to AWS RunInstances, which rejects an empty string.
+	// Avoid fuzzing KeyName to ptr("") to preserve roundtrip fidelity.
+	if ps.KeyName != nil && *ps.KeyName == "" {
+		ps.KeyName = nil
+	}
+
 	// Copy instance-type, region and zone to the struct so they can be set at the machine labels too.
 	f.InstanceType = ps.InstanceType
 	f.Region = ps.Placement.Region


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-114670

CAPI's AWSMachine.Spec.SSHKeyName is tri-state: nil means "use cluster default", `ptr("")` means "no SSH key", and a non-empty pointer means a named key. IPI clusters installed with CAPA default to `ptr("")`.

MAPI's AWS actuator has no such tri-state handling — any non-nil KeyName, including an empty string, is passed straight to AWS RunInstances and rejected with "Invalid value '' for keyPairNames".

Normalize `ptr("")` to nil in the conversion so MAPI omits the field, matching the "no SSH key" intent.

It is equivalent of test helper in https://github.com/openshift/cluster-api-actuator-pkg/pull/491/changes/63074080db99e16eceb85ccb601310aac3ba3d29#diff-77afc90f80bdb30e5eb1d917d9def6557a9aca2994b361936df2f7f49a41ee39R175

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved AWS SSH key configuration handling during conversion.
  - Empty SSH key names are now treated as unset, while valid key names and omitted values remain unchanged.
  - This keeps provider configuration consistent across conversion paths and prevents invalid empty values from being carried forward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->